### PR TITLE
Improve onboarding style

### DIFF
--- a/app/(auth)/onboarding/layout.tsx
+++ b/app/(auth)/onboarding/layout.tsx
@@ -1,0 +1,22 @@
+import localFont from "next/font/local";
+import "../../globals.css";
+
+const founderslight = localFont({ src: "/NewEdgeTest-LightRounded.otf" });
+
+export default function OnboardingLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <html>
+      <body className={`${founderslight.className}`}>
+        <main className="flex min-h-screen items-center justify-center bg-gradient-to-r from-zinc-200 via-indigo-300 to-rose-200">
+          <section className="w-full max-w-4xl px-6 py-10">
+            {children}
+          </section>
+        </main>
+      </body>
+    </html>
+  );
+}

--- a/app/(auth)/onboarding/page.tsx
+++ b/app/(auth)/onboarding/page.tsx
@@ -1,9 +1,5 @@
 import AccountProfile from "@/components/forms/AccountProfile";
-import { fetchUser } from "@/lib/actions/user.actions";
-import { serverConfig } from "@/lib/firebase/config";
 import { getUserFromCookies } from "@/lib/serverutils";
-import { getTokens } from "next-firebase-auth-edge";
-import { cookies } from "next/headers";
 
 async function Page() {
   const user = await getUserFromCookies();
@@ -18,13 +14,13 @@ async function Page() {
     image: user?.photoURL || "",
   };
   return (
-    <main className="mx-auto flex max-w-3xl flex-col justify-start px-10 py-20">
+    <main className="mx-auto flex max-w-3xl flex-col justify-start px-10 py-20 text-black">
       <h1 className="head-text">Onboarding</h1>
       <p className="mt-3 text-base-regular text-light-2">
         Complete your profile now to use mesh
       </p>
-      <section className="mt-9 bg-dark-2 p-10">
-        <AccountProfile user={userData} btnTitle="Continue"></AccountProfile>
+      <section className="postcard mt-9 bg-white bg-opacity-70 p-10">
+        <AccountProfile user={userData} btnTitle="Continue" />
       </section>
     </main>
   );


### PR DESCRIPTION
## Summary
- restyle onboarding page with new layout
- use gradient background and local fonts
- tweak onboarding form container

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_685b286997388329a1433ad893d055e6