### PR TITLE
Add Portal node type

### DIFF
--- a/components/nodes/PortalNode.tsx
+++ b/components/nodes/PortalNode.tsx
@@ -1,0 +1,45 @@
+"use client";
+
+import { fetchUser } from "@/lib/actions/user.actions";
+import { useAuth } from "@/lib/AuthContext";
+import { AuthorOrAuthorId } from "@/lib/reactflow/types";
+import BaseNode from "./BaseNode";
+import { NodeProps } from "@xyflow/react";
+import { useEffect, useState } from "react";
+
+interface PortalNodeData {
+  targetRoomId: string;
+  author: AuthorOrAuthorId;
+  locked: boolean;
+}
+
+function PortalNode({ id, data }: NodeProps<PortalNodeData>) {
+  const currentUser = useAuth().user;
+  const [author, setAuthor] = useState(data.author);
+
+  useEffect(() => {
+    if ("username" in author) return;
+    fetchUser(data.author.id).then((user) => user && setAuthor(user));
+  }, [data]);
+
+  const isOwned = currentUser
+    ? Number(currentUser.userId) === Number(data.author.id)
+    : false;
+
+  return (
+    <BaseNode
+      modalContent={null}
+      id={id}
+      author={author}
+      isOwned={isOwned}
+      type={"PORTAL"}
+      isLocked={data.locked}
+    >
+      <div className="p-4 text-center">
+        <p>Portal to room {data.targetRoomId}</p>
+      </div>
+    </BaseNode>
+  );
+}
+
+export default PortalNode;

--- a/components/reactflow/Room.tsx
+++ b/components/reactflow/Room.tsx
@@ -34,6 +34,7 @@ import LiveStreamNode from "../nodes/LiveStreamNode";
 import TextInputNode from "../nodes/TextInputNode";
 import YoutubeNode from "../nodes/YoutubeNode";
 import CollageNode from "../nodes/CollageNode";
+import PortalNode from "../nodes/PortalNode";
 import HamburgerMenu from "../shared/HamburgerMenu";
 import NodeSidebar from "../shared/NodeSidebar";
 import { createRealtimeEdge } from "@/lib/actions/realtimeedge.actions";
@@ -207,6 +208,7 @@ function Room({ roomId, initialNodes, initialEdges }: Props) {
     LIVESTREAM: LiveStreamNode,
     IMAGE_COMPUTE: ImageComputeNode,
     COLLAGE: CollageNode,
+    PORTAL: PortalNode,
   };
   const edgeTypes = {
     DEFAULT: DefaultEdge,

--- a/lib/reactflow/types.ts
+++ b/lib/reactflow/types.ts
@@ -72,6 +72,15 @@ export type CollageNodeData = Node<
   "COLLAGE"
 >;
 
+export type PortalNode = Node<
+  {
+    targetRoomId: string;
+    author: AuthorOrAuthorId;
+    locked: boolean;
+  },
+  "PORTAL"
+>;
+
 
 
 export type DefaultEdge = Edge<{}, "DEFAULT">;
@@ -83,6 +92,7 @@ export const NodeTypeMap = {
   LIVESTREAM: {} as WebcamNode,
   IMAGE_COMPUTE: {} as ImageComputeNodeProps,
   COLLAGE: {} as CollageNodeData,
+  PORTAL: {} as PortalNode,
 };
 
 export interface AppEdgeMapping {
@@ -105,7 +115,8 @@ export type AppNode =
   | ImageUNode
   | WebcamNode
   | ImageComputeNodeProps
-  | CollageNodeData;
+  | CollageNodeData
+  | PortalNode;
 
 export type AppEdgeType = keyof AppEdgeMapping;
 
@@ -119,6 +130,7 @@ export const DEFAULT_NODE_VALUES: Record<AppNodeType, string> = {
   ["IMAGE_COMPUTE"]:
     "https://live.staticflickr.com/5702/23230527751_b14f3cd11d_b.jpg",
   ["COLLAGE"]:"",
+  ["PORTAL"]: "",
 };
 
 export type AppState = {


### PR DESCRIPTION
## Summary
- introduce `PortalNode` component
- add `PORTAL` to nodeTypes in `Room`
- support new type in `DEFAULT_NODE_VALUES`
- extend type definitions with `PORTAL`

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_685b3d7a40548329b55b9d29bec62d06