### PR TITLE
Add portal node conversion

### DIFF
--- a/lib/reactflow/reactflowutils.ts
+++ b/lib/reactflow/reactflowutils.ts
@@ -7,6 +7,7 @@ import {
   WebcamNode,
   ImageComputeNodeProps,
   CollageNodeData,
+  PortalNode,
   AppEdge,
 } from "./types";
 
@@ -116,7 +117,7 @@ export function convertPostToNode(
           y: realtimePost.y_coordinate,
         },
       } as ImageComputeNodeProps;
-      case "COLLAGE": 
+      case "COLLAGE":
         return{
           id: realtimePost.id.toString(),
           type: realtimePost.type, // literal string
@@ -130,7 +131,20 @@ export function convertPostToNode(
             y: realtimePost.y_coordinate,
           },
         }  as CollageNodeData;
-      
+    case "PORTAL":
+      return {
+        id: realtimePost.id.toString(),
+        type: realtimePost.type,
+        data: {
+          author: authorToSet,
+          locked: realtimePost.locked,
+        },
+        position: {
+          x: realtimePost.x_coordinate,
+          y: realtimePost.y_coordinate,
+        },
+      } as PortalNode;
+
     default:
       throw new Error("Unsupported real-time post type");
       

--- a/lib/reactflow/types.ts
+++ b/lib/reactflow/types.ts
@@ -72,6 +72,14 @@ export type CollageNodeData = Node<
   "COLLAGE"
 >;
 
+export type PortalNode = Node<
+  {
+    author: AuthorOrAuthorId;
+    locked: boolean;
+  },
+  "PORTAL"
+>;
+
 
 
 export type DefaultEdge = Edge<{}, "DEFAULT">;
@@ -83,6 +91,7 @@ export const NodeTypeMap = {
   LIVESTREAM: {} as WebcamNode,
   IMAGE_COMPUTE: {} as ImageComputeNodeProps,
   COLLAGE: {} as CollageNodeData,
+  PORTAL: {} as PortalNode,
 };
 
 export interface AppEdgeMapping {
@@ -105,7 +114,8 @@ export type AppNode =
   | ImageUNode
   | WebcamNode
   | ImageComputeNodeProps
-  | CollageNodeData;
+  | CollageNodeData
+  | PortalNode;
 
 export type AppEdgeType = keyof AppEdgeMapping;
 
@@ -119,6 +129,7 @@ export const DEFAULT_NODE_VALUES: Record<AppNodeType, string> = {
   ["IMAGE_COMPUTE"]:
     "https://live.staticflickr.com/5702/23230527751_b14f3cd11d_b.jpg",
   ["COLLAGE"]:"",
+  ["PORTAL"]: "",
 };
 
 export type AppState = {


### PR DESCRIPTION
## Summary
- support `PORTAL` node type in reactflow utils
- define `PortalNode` type and register it in the node mappings

## Testing
- `npm run lint` *(shows warnings but finishes)*

------
https://chatgpt.com/codex/tasks/task_e_685b3d76bc8c832996efb17547da0814