### PR TITLE
Add PortalNode component

### DIFF
--- a/components/nodes/PortalNode.tsx
+++ b/components/nodes/PortalNode.tsx
@@ -1,0 +1,52 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { NodeProps, useReactFlow } from "@xyflow/react";
+import { useAuth } from "@/lib/AuthContext";
+import { fetchUser } from "@/lib/actions/user.actions";
+import BaseNode from "./BaseNode";
+import { PortalNodeData, AuthorOrAuthorId } from "@/lib/reactflow/types";
+
+function PortalNode({ id, data }: NodeProps<PortalNodeData>) {
+  const reactFlow = useReactFlow();
+  const currentActiveUser = useAuth().user;
+  const [author, setAuthor] = useState<AuthorOrAuthorId>(data.author);
+
+  useEffect(() => {
+    if ("username" in author) {
+      return;
+    }
+    fetchUser(data.author.id).then((user) => {
+      if (user) setAuthor(user);
+    });
+  }, [data]);
+
+  const isOwned = currentActiveUser
+    ? Number(currentActiveUser.userId) === Number(data.author.id)
+    : false;
+
+  const goToTarget = () => {
+    reactFlow.setViewport({ x: data.targetX, y: data.targetY, zoom: 1 }, {
+      duration: 800,
+    });
+  };
+
+  return (
+    <BaseNode
+      modalContent={null}
+      id={id}
+      author={author}
+      isOwned={isOwned}
+      type={"PORTAL"}
+      isLocked={data.locked}
+    >
+      <div className="p-2">
+        <button className="button" onClick={goToTarget}>
+          Go To Target
+        </button>
+      </div>
+    </BaseNode>
+  );
+}
+
+export default PortalNode;

--- a/lib/reactflow/types.ts
+++ b/lib/reactflow/types.ts
@@ -72,6 +72,16 @@ export type CollageNodeData = Node<
   "COLLAGE"
 >;
 
+export type PortalNodeData = Node<
+  {
+    targetX: number;
+    targetY: number;
+    author: AuthorOrAuthorId;
+    locked: boolean;
+  },
+  "PORTAL"
+>;
+
 
 
 export type DefaultEdge = Edge<{}, "DEFAULT">;
@@ -83,6 +93,7 @@ export const NodeTypeMap = {
   LIVESTREAM: {} as WebcamNode,
   IMAGE_COMPUTE: {} as ImageComputeNodeProps,
   COLLAGE: {} as CollageNodeData,
+  PORTAL: {} as PortalNodeData,
 };
 
 export interface AppEdgeMapping {
@@ -105,7 +116,8 @@ export type AppNode =
   | ImageUNode
   | WebcamNode
   | ImageComputeNodeProps
-  | CollageNodeData;
+  | CollageNodeData
+  | PortalNodeData;
 
 export type AppEdgeType = keyof AppEdgeMapping;
 
@@ -119,6 +131,7 @@ export const DEFAULT_NODE_VALUES: Record<AppNodeType, string> = {
   ["IMAGE_COMPUTE"]:
     "https://live.staticflickr.com/5702/23230527751_b14f3cd11d_b.jpg",
   ["COLLAGE"]:"",
+  ["PORTAL"]:"",
 };
 
 export type AppState = {


### PR DESCRIPTION
## Summary
- define `PortalNodeData` type and extend node mappings
- implement `PortalNode` using `BaseNode` and ReactFlow viewport control

## Testing
- `npm run lint` *(fails: warnings present)*

------
https://chatgpt.com/codex/tasks/task_e_685b3d771bd88329939160cb05f6faaa