### PR TITLE
Add portal node modal and form

### DIFF
--- a/components/forms/PortalNodeForm.tsx
+++ b/components/forms/PortalNodeForm.tsx
@@ -1,0 +1,43 @@
+import { PortalNodeValidation } from "@/lib/validations/thread";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useForm } from "react-hook-form";
+import { z } from "zod";
+import { Button } from "../ui/button";
+import { Input } from "../ui/input";
+
+interface Props {
+  onSubmit: (values: z.infer<typeof PortalNodeValidation>) => void;
+  currentX: number;
+  currentY: number;
+}
+
+const PortalNodeForm = ({ onSubmit, currentX, currentY }: Props) => {
+  const form = useForm({
+    resolver: zodResolver(PortalNodeValidation),
+    defaultValues: { x: currentX, y: currentY },
+  });
+
+  return (
+    <form method="post" className="ml-3 mr-3" onSubmit={form.handleSubmit(onSubmit)}>
+      <hr />
+      <div className="py-4 grid gap-2">
+        <label className="flex flex-col text-sm text-white">
+          X:
+          <Input type="number" {...form.register("x", { valueAsNumber: true })} />
+        </label>
+        <label className="flex flex-col text-sm text-white">
+          Y:
+          <Input type="number" {...form.register("y", { valueAsNumber: true })} />
+        </label>
+      </div>
+      <hr />
+      <div className="py-4 mb-4">
+        <Button type="submit" className="form-submit-button" size={"lg"}>
+          Save Changes
+        </Button>
+      </div>
+    </form>
+  );
+};
+
+export default PortalNodeForm;

--- a/components/modals/PortalNodeModal.tsx
+++ b/components/modals/PortalNodeModal.tsx
@@ -1,0 +1,95 @@
+import { PortalNodeValidation } from "@/lib/validations/thread";
+import { z } from "zod";
+import PortalNodeForm from "@/components/forms/PortalNodeForm";
+import {
+  DialogClose,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+
+interface Props {
+  id?: string;
+  isOwned: boolean;
+  onSubmit?: (values: z.infer<typeof PortalNodeValidation>) => void;
+  currentX: number;
+  currentY: number;
+}
+
+const renderCreate = ({
+  onSubmit,
+}: {
+  onSubmit?: (values: z.infer<typeof PortalNodeValidation>) => void;
+}) => {
+  return (
+    <div>
+      <DialogHeader className="dialog-header text-white text-lg py-4 mt-[-4rem]">
+        <b> Create Portal</b>
+      </DialogHeader>
+      <hr />
+      <PortalNodeForm onSubmit={onSubmit!} currentX={0} currentY={0} />
+    </div>
+  );
+};
+
+const renderEdit = ({
+  onSubmit,
+  currentX,
+  currentY,
+}: {
+  onSubmit?: (values: z.infer<typeof PortalNodeValidation>) => void;
+  currentX: number;
+  currentY: number;
+}) => {
+  return (
+    <div>
+      <DialogHeader className="dialog-header text-white text-lg py-4 mt-[-4rem]">
+        <b> Edit Portal</b>
+      </DialogHeader>
+      <hr />
+      <PortalNodeForm onSubmit={onSubmit!} currentX={currentX} currentY={currentY} />
+    </div>
+  );
+};
+
+const renderView = (currentX: number, currentY: number) => {
+  return (
+    <div>
+      <DialogHeader className="dialog-header text-white text-lg py-4 mt-[-3rem]">
+        <b> View Portal</b>
+      </DialogHeader>
+      <hr />
+      <div className="py-4 grid gap-2 text-white">
+        <div>X: {currentX}</div>
+        <div>Y: {currentY}</div>
+      </div>
+      <hr />
+      <div className="py-4">
+        <DialogClose id="animateButton" className={`form-submit-button pl-2 py-2 pr-[1rem]`}>
+          <div className="w-2"></div>
+          <> Close </>
+        </DialogClose>
+      </div>
+    </div>
+  );
+};
+
+const PortalNodeModal = ({ id, isOwned, onSubmit, currentX, currentY }: Props) => {
+  const isCreate = !id && isOwned;
+  const isEdit = id && isOwned;
+  const isView = id && !isOwned;
+  return (
+    <div>
+      <DialogContent className="max-w-[57rem]">
+        <DialogTitle>PortalNodeModal</DialogTitle>
+        <div className="grid rounded-md px-4 py-2">
+          {isCreate && renderCreate({ onSubmit })}
+          {isEdit && renderEdit({ onSubmit, currentX, currentY })}
+          {isView && renderView(currentX, currentY)}
+        </div>
+      </DialogContent>
+    </div>
+  );
+};
+
+export default PortalNodeModal;

--- a/lib/validations/thread.ts
+++ b/lib/validations/thread.ts
@@ -45,3 +45,8 @@ export const ImagePostValidation = z.object({
 export const CommentValidation = z.object({
   thread: z.string().min(3, { message: "Minimum of 3 characters" }),
 });
+
+export const PortalNodeValidation = z.object({
+  x: z.number(),
+  y: z.number(),
+});


### PR DESCRIPTION
## Summary
- create `PortalNodeForm` with numeric x/y fields
- add `PortalNodeModal` using same pattern as other node modals
- validate portal coordinates in `PortalNodeValidation`

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_685b3d785210832999abc7b4ccee30fb