### PR TITLE
Fix unmatched braces in reactflow utils

### DIFF
--- a/lib/reactflow/reactflowutils.ts
+++ b/lib/reactflow/reactflowutils.ts
@@ -146,16 +146,7 @@ export function convertPostToNode(
             },
           } as PortalNode;
     
-        default:
-          throw new Error("Unsupported real-time post type");
-          
-      }
-      
+          default:
+            throw new Error("Unsupported real-time post type");
+        }
     }
-      
-    default:
-      throw new Error("Unsupported real-time post type");
-      
-  }
-  
-}


### PR DESCRIPTION
## Summary
- resolve syntax error in `convertPostToNode` by removing stray braces

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b4a6e7f988329920a8cc15e6031c5