### PR TITLE
Add create post modal

### DIFF
--- a/components/forms/CreateFeedPost.tsx
+++ b/components/forms/CreateFeedPost.tsx
@@ -1,0 +1,50 @@
+"use client";
+
+import { useState } from "react";
+import { Dialog, DialogTrigger, DialogContent } from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import Image from "next/image";
+import TextNodeModal from "@/components/modals/TextNodeModal";
+import { createRealtimePost } from "@/lib/actions/realtimepost.actions";
+import { useRouter } from "next/navigation";
+import { z } from "zod";
+import { TextPostValidation } from "@/lib/validations/thread";
+
+const CreateFeedPost = () => {
+  const [open, setOpen] = useState(false);
+  const router = useRouter();
+
+  async function onSubmit(values: z.infer<typeof TextPostValidation>) {
+    await createRealtimePost({
+      text: values.postContent,
+      path: "/",
+      coordinates: { x: 0, y: 0 },
+      type: "TEXT",
+      realtimeRoomId: "global",
+    });
+    setOpen(false);
+    router.refresh();
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger asChild>
+        <Button className="h-full w-full rounded-md leftsidebar-item border-none">
+          <Image
+            src="/assets/plus-circle.svg"
+            alt="create post"
+            className="mr-2"
+            width={24}
+            height={24}
+          />
+          <p className="text-black max-lg:hidden">Create Post</p>
+        </Button>
+      </DialogTrigger>
+      <DialogContent className="max-w-[57rem]">
+        <TextNodeModal isOwned={true} currentText="" onSubmit={onSubmit} />
+      </DialogContent>
+    </Dialog>
+  );
+};
+
+export default CreateFeedPost;

--- a/components/shared/LeftSidebar.tsx
+++ b/components/shared/LeftSidebar.tsx
@@ -9,6 +9,7 @@ import Image from "next/image";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import localFont from 'next/font/local'
+import CreateFeedPost from "@/components/forms/CreateFeedPost";
 const parabole = localFont({ src: '/Parabole-DisplayRegular.woff2' })
 
 interface Props {
@@ -64,6 +65,9 @@ function LeftSidebar({ userRooms }: Props) {
           />
           <p className="text-black max-lg:hidden">{"Create Room"}</p>
         </Link>
+      </div>
+      <div className="mb-6 px-6 ">
+        {isUserSignedIn && <CreateFeedPost />}
       </div>
       <div className="mb-6 px-6 ">
         {isUserSignedIn && (


### PR DESCRIPTION
## Summary
- add `CreateFeedPost` form for adding text posts to the global feed
- expose create post button in `LeftSidebar`

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_685c55180db0832993c9bb613af2ec31