### PR TITLE
Implement portal teleport node

### DIFF
--- a/components/nodes/PortalNode.tsx
+++ b/components/nodes/PortalNode.tsx
@@ -4,11 +4,12 @@ import { fetchUser } from "@/lib/actions/user.actions";
 import { useAuth } from "@/lib/AuthContext";
 import { AuthorOrAuthorId } from "@/lib/reactflow/types";
 import BaseNode from "./BaseNode";
-import { NodeProps } from "@xyflow/react";
-import { useEffect, useState } from "react";
+import { NodeProps, useReactFlow } from "@xyflow/react";
+import { useEffect, useState, useCallback } from "react";
 
 interface PortalNodeData {
-  roomId: string;
+  x: number;
+  y: number;
   author: AuthorOrAuthorId;
   locked: boolean;
 }
@@ -16,6 +17,7 @@ interface PortalNodeData {
 function PortalNode({ id, data }: NodeProps<PortalNodeData>) {
   const currentUser = useAuth().user;
   const [author, setAuthor] = useState(data.author);
+  const { setViewport } = useReactFlow();
 
   useEffect(() => {
     if ("username" in author) return;
@@ -25,6 +27,10 @@ function PortalNode({ id, data }: NodeProps<PortalNodeData>) {
   const isOwned = currentUser
     ? Number(currentUser.userId) === Number(data.author.id)
     : false;
+
+  const handleTeleport = useCallback(() => {
+    setViewport({ x: data.x, y: data.y, zoom: 0.75 }, { duration: 800 });
+  }, [data.x, data.y, setViewport]);
 
   return (
     <BaseNode
@@ -36,11 +42,15 @@ function PortalNode({ id, data }: NodeProps<PortalNodeData>) {
       isLocked={data.locked}
     >
       <div className="p-25 text-center portal-node">
-        <div className="portal-block">        <p>Portal to room {data.roomId}</p>
-</div>
+        <div className="portal-block">
+          <button onClick={handleTeleport} className="button">
+            Go to ({data.x}, {data.y})
+          </button>
+        </div>
       </div>
     </BaseNode>
   );
 }
 
 export default PortalNode;
+

--- a/components/shared/NodeSidebar.tsx
+++ b/components/shared/NodeSidebar.tsx
@@ -203,8 +203,9 @@ export default function NodeSidebar({
         store.openModal(
           <PortalNodeModal
             isOwned={true}
-            onSubmit={() => {
+            onSubmit={(values) => {
               createPostAndAddToCanvas({
+                text: JSON.stringify(values),
                 path: pathname,
                 coordinates: centerPosition,
                 type: "PORTAL",

--- a/lib/reactflow/reactflowutils.ts
+++ b/lib/reactflow/reactflowutils.ts
@@ -133,10 +133,20 @@ export function convertPostToNode(
           },
         }  as CollageNodeData;
         case "PORTAL":
+          let portalCoords = { x: 0, y: 0 };
+          if (realtimePost.content) {
+            try {
+              portalCoords = JSON.parse(realtimePost.content);
+            } catch (e) {
+              portalCoords = { x: 0, y: 0 };
+            }
+          }
           return {
             id: realtimePost.id.toString(),
             type: realtimePost.type,
             data: {
+              x: portalCoords.x,
+              y: portalCoords.y,
               author: authorToSet,
               locked: realtimePost.locked,
             },

--- a/lib/reactflow/types.ts
+++ b/lib/reactflow/types.ts
@@ -76,7 +76,8 @@ export type CollageNodeData = Node<
 
 export type PortalNode = Node<
   {
-    roomId: string;
+    x: number;
+    y: number;
     author: AuthorOrAuthorId;
     locked: boolean;
   },


### PR DESCRIPTION
## Summary
- enable portal nodes to teleport users within the same room
- pass destination coordinates when creating portal nodes
- parse stored coordinates when loading portal nodes
- adjust node type definitions accordingly

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_685c5faa96b08329b53e1b4244dbdee5