### PR TITLE
Add gallery node type

### DIFF
--- a/components/nodes/GalleryNode.tsx
+++ b/components/nodes/GalleryNode.tsx
@@ -1,0 +1,105 @@
+"use client";
+
+import { NodeProps, useReactFlow } from "@xyflow/react";
+import { useEffect, useMemo, useState, CSSProperties } from "react";
+import { usePathname } from "next/navigation";
+import Image from "next/image";
+
+import { useAuth } from "@/lib/AuthContext";
+import useStore from "@/lib/reactflow/store";
+import { GalleryNodeData, AppState } from "@/lib/reactflow/types";
+import { updateRealtimePost } from "@/lib/actions/realtimepost.actions";
+import BaseNode from "./BaseNode";
+import { useShallow } from "zustand/react/shallow";
+
+interface GalleryConfigType {
+  layoutStyle: string;
+  columns: number;
+  gap: number;
+}
+
+function GalleryNode({ id, data }: NodeProps<GalleryNodeData>) {
+  const path = usePathname();
+  const currentActiveUser = useAuth().user;
+  const store = useStore(
+    useShallow((state: AppState) => ({
+      closeModal: state.closeModal,
+    }))
+  );
+  const reactFlowInstance = useReactFlow();
+
+  const [layoutStyle, setLayoutStyle] = useState(data.layoutStyle || "grid");
+  const [columns, setColumns] = useState(data.columns ?? 3);
+  const [gap, setGap] = useState(data.gap ?? 8);
+
+  useEffect(() => {
+    setLayoutStyle(data.layoutStyle || "grid");
+    setColumns(data.columns ?? 3);
+    setGap(data.gap ?? 8);
+  }, [data.layoutStyle, data.columns, data.gap]);
+
+  const isOwned = currentActiveUser
+    ? Number(currentActiveUser.userId) === Number(data.author.id)
+    : false;
+
+  const edgesToThisNode = useMemo(() => {
+    return reactFlowInstance.getEdges().filter((e) => e.target === id);
+  }, [reactFlowInstance, id]);
+
+  const imageURLs = useMemo(() => {
+    const urls: string[] = [];
+    edgesToThisNode.forEach((edge) => {
+      const sourceNode = reactFlowInstance.getNode(edge.source);
+      if (sourceNode?.type === "IMAGE") {
+        const url = (sourceNode.data as any).imageurl;
+        if (typeof url === "string") {
+          urls.push(url);
+        }
+      }
+    });
+    return urls;
+  }, [edgesToThisNode, reactFlowInstance]);
+
+  async function onGallerySubmit(values: GalleryConfigType) {
+    setLayoutStyle(values.layoutStyle);
+    setColumns(values.columns);
+    setGap(values.gap);
+
+    await updateRealtimePost({
+      id,
+      path,
+      collageLayoutStyle: values.layoutStyle,
+      collageColumns: values.columns,
+      collageGap: values.gap,
+    });
+
+    store.closeModal();
+  }
+
+  const containerStyle: CSSProperties = {
+    display: "grid",
+    gap: `${gap}px`,
+    gridTemplateColumns: `repeat(${columns}, 1fr)`,
+    padding: "12px",
+  };
+
+  return (
+    <BaseNode
+      id={id}
+      author={data.author}
+      isOwned={isOwned}
+      type="GALLERY"
+      isLocked={data.locked}
+    >
+      <div style={containerStyle}>
+        {imageURLs.map((url, idx) => (
+          <div key={idx} style={{ position: "relative", minWidth: 150, minHeight: 150 }}>
+            <Image src={url} alt={`img-${idx}`} fill style={{ objectFit: "cover" }} />
+          </div>
+        ))}
+      </div>
+    </BaseNode>
+  );
+}
+
+export default GalleryNode;

--- a/components/reactflow/Room.tsx
+++ b/components/reactflow/Room.tsx
@@ -35,6 +35,7 @@ import TextInputNode from "../nodes/TextInputNode";
 import PortalNode from "../nodes/PortalNode";
 import YoutubeNode from "../nodes/YoutubeNode";
 import CollageNode from "../nodes/CollageNode";
+import GalleryNode from "../nodes/GalleryNode";
 import DrawNode from "../nodes/DrawNode";
 import HamburgerMenu from "../shared/HamburgerMenu";
 import NodeSidebar from "../shared/NodeSidebar";
@@ -186,9 +187,6 @@ function Room({ roomId, initialNodes, initialEdges }: Props) {
         id: nodePositionChange.id,
         path: pathname,
         coordinates: nodePositionChange.position,
-        collageLayoutStyle: "grid",
-        collageColumns: 3,
-        collageGap: 10,
       });
     }
     onNodesChangeStore(changes);
@@ -209,6 +207,7 @@ function Room({ roomId, initialNodes, initialEdges }: Props) {
     LIVESTREAM: LiveStreamNode,
     IMAGE_COMPUTE: ImageComputeNode,
     COLLAGE: CollageNode,
+    GALLERY: GalleryNode,
     PORTAL: PortalNode,
     DRAW: DrawNode,
   };

--- a/components/shared/NodeSidebar.tsx
+++ b/components/shared/NodeSidebar.tsx
@@ -37,6 +37,7 @@ const nodeTypes: { label: string; nodeType: AppNodeType }[] = [
   { label: "LIVESTREAM", nodeType: "LIVESTREAM" },
   { label: "IMAGE_COMPUTE", nodeType: "IMAGE_COMPUTE" },
   { label: "COLLAGE", nodeType: "COLLAGE" },
+  { label: "GALLERY", nodeType: "GALLERY" },
   { label: "PORTAL", nodeType: "PORTAL" },
   { label: "DRAW", nodeType: "DRAW" },
 ];
@@ -190,6 +191,25 @@ export default function NodeSidebar({
                 path: pathname,
                 coordinates: centerPosition,
                 type: "COLLAGE",
+                realtimeRoomId: roomId,
+                collageLayoutStyle: vals.layoutStyle,
+                collageColumns: vals.columns,
+                collageGap: vals.gap,
+              });
+            }}
+          />
+        );
+        break;
+
+      case "GALLERY":
+        store.openModal(
+          <CollageCreationModal
+            isOwned={true}
+            onSubmit={(vals) => {
+              createPostAndAddToCanvas({
+                path: pathname,
+                coordinates: centerPosition,
+                type: "GALLERY",
                 realtimeRoomId: roomId,
                 collageLayoutStyle: vals.layoutStyle,
                 collageColumns: vals.columns,

--- a/lib/models/schema.prisma
+++ b/lib/models/schema.prisma
@@ -144,6 +144,7 @@ enum realtime_post_type {
   LIVESTREAM
   IMAGE_COMPUTE
   COLLAGE
+  GALLERY
   PORTAL
   AUDIO
   DRAW

--- a/lib/reactflow/reactflowutils.ts
+++ b/lib/reactflow/reactflowutils.ts
@@ -7,6 +7,7 @@ import {
   WebcamNode,
   ImageComputeNodeProps,
   CollageNodeData,
+  GalleryNodeData,
   PortalNode,
   DrawNode,
   
@@ -105,22 +106,22 @@ export function convertPostToNode(
           y: realtimePost.y_coordinate,
         },
       } as WebcamNode;
-    case "IMAGE_COMPUTE":
-      return {
-        id: realtimePost.id.toString(),
-        type: realtimePost.type,
-        data: {
-          imageurl: realtimePost.image_url,
-          author: authorToSet,
-          locked: realtimePost.locked,
-        },
-        position: {
-          x: realtimePost.x_coordinate,
-          y: realtimePost.y_coordinate,
-        },
-      } as ImageComputeNodeProps;
+      case "IMAGE_COMPUTE":
+        return {
+          id: realtimePost.id.toString(),
+          type: realtimePost.type,
+          data: {
+            imageurl: realtimePost.image_url,
+            author: authorToSet,
+            locked: realtimePost.locked,
+          },
+          position: {
+            x: realtimePost.x_coordinate,
+            y: realtimePost.y_coordinate,
+          },
+        } as ImageComputeNodeProps;
       case "COLLAGE":
-        return{
+        return {
           id: realtimePost.id.toString(),
           type: realtimePost.type, // literal string
           data: {
@@ -133,6 +134,23 @@ export function convertPostToNode(
             y: realtimePost.y_coordinate,
           },
         }  as CollageNodeData;
+      case "GALLERY":
+        return {
+          id: realtimePost.id.toString(),
+          type: realtimePost.type,
+          data: {
+            images: [],
+            author: authorToSet,
+            locked: realtimePost.locked,
+            layoutStyle: realtimePost.collageLayoutStyle || undefined,
+            columns: realtimePost.collageColumns || undefined,
+            gap: realtimePost.collageGap || undefined,
+          },
+          position: {
+            x: realtimePost.x_coordinate,
+            y: realtimePost.y_coordinate,
+          },
+        } as GalleryNodeData;
         case "PORTAL":
           let portalCoords = { x: 0, y: 0 };
           if (realtimePost.content) {

--- a/lib/reactflow/store.ts
+++ b/lib/reactflow/store.ts
@@ -8,6 +8,7 @@ import {
   YoutubeVidNode,
   WebcamNode,
   CollageNodeData,
+  GalleryNodeData,
   AppEdge,
 } from "./types";
 
@@ -25,6 +26,9 @@ function isWebcamNode(node: AppNode): node is WebcamNode {
 }
 function isCollageNode(node: AppNode): node is CollageNodeData {
   return node.type === "COLLAGE";
+}
+function isGalleryNode(node: AppNode): node is GalleryNodeData {
+  return node.type === "GALLERY";
 }
 
 function isDefaultEdge(edge: AppEdge): edge is AppEdge {

--- a/lib/reactflow/types.ts
+++ b/lib/reactflow/types.ts
@@ -74,6 +74,18 @@ export type CollageNodeData = Node<
   "COLLAGE"
 >;
 
+export type GalleryNodeData = Node<
+  {
+    images: string[];
+    author: AuthorOrAuthorId;
+    locked: boolean;
+    layoutStyle?: string;
+    columns?: number;
+    gap?: number;
+  },
+  "GALLERY"
+>;
+
 export type PortalNode = Node<
   {
     x: number;
@@ -139,6 +151,7 @@ export const NodeTypeMap = {
   LIVESTREAM: {} as WebcamNode,
   IMAGE_COMPUTE: {} as ImageComputeNodeProps,
   COLLAGE: {} as CollageNodeData,
+  GALLERY: {} as GalleryNodeData,
   PORTAL: {} as PortalNode,
   DRAW: {} as DrawNode,
   AUDIO: {} as AudioNode,
@@ -159,6 +172,7 @@ export const NodeTypeToModalMap = {
   IMAGE: ImageNodeModal,
   VIDEO: YoutubeNodeModal,
   COLLAGE: CollageCreationModal,
+  GALLERY: CollageCreationModal,
   PORTAL: ShareRoomModal,
 };
 
@@ -169,6 +183,7 @@ export type AppNode =
   | WebcamNode
   | ImageComputeNodeProps
   | CollageNodeData
+  | GalleryNodeData
   | PortalNode
   | DrawNode
   | AudioNode
@@ -188,6 +203,7 @@ export const DEFAULT_NODE_VALUES: Record<AppNodeType, string> = {
   ["IMAGE_COMPUTE"]:
     "https://live.staticflickr.com/5702/23230527751_b14f3cd11d_b.jpg",
   ["COLLAGE"]:"",
+  ["GALLERY"]: "",
   ["PORTAL"]: "",
   ["DRAW"]: "",
   ["AUDIO"]: "",


### PR DESCRIPTION
## Summary
- add `GALLERY` enum value in Prisma schema
- implement `GalleryNode` to display connected images in a grid
- register gallery type in React Flow mapping and sidebar
- support gallery node conversion from realtime posts
- update default node values and modal map

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_685c6a461a4883298f40475ee59be20c