### PR TITLE
Fix undefined nodeInternals in Room

### DIFF
--- a/components/reactflow/Room.tsx
+++ b/components/reactflow/Room.tsx
@@ -90,8 +90,8 @@ function Room({ roomId, initialNodes, initialEdges }: Props) {
 
   const getClosestEdge = useCallback(
     (node: AppNode) => {
-      const { nodeInternals } = storeApi.getState();
-      const storeNodes = Array.from(nodeInternals.values());
+      const { nodeLookup } = storeApi.getState();
+      const storeNodes = Array.from(nodeLookup.values());
 
       const closestNode = storeNodes.reduce(
         (res, n) => {


### PR DESCRIPTION
## Summary
- use `nodeLookup` from XYFlow store instead of deprecated `nodeInternals`

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_685ccf963db48329b5cd9d36188bafa0