### PR TITLE
Fix room join when room missing

### DIFF
--- a/lib/actions/realtimeroom.actions.ts
+++ b/lib/actions/realtimeroom.actions.ts
@@ -57,6 +57,15 @@ export async function joinRoom({ roomId }: { roomId: string }) {
       throw new Error("User not authenticated");
     }
 
+    const existingRoom = await prisma.realtimeRoom.findUnique({
+      where: { id: roomId },
+    });
+    if (!existingRoom) {
+      await prisma.realtimeRoom.create({
+        data: { id: roomId, room_icon: "/assets/logo-white.svg" },
+      });
+    }
+
     await prisma.userRealtimeRoom.upsert({
       where: {
         user_id_realtime_room_id: {


### PR DESCRIPTION
## Summary
- ensure `joinRoom` creates the room if it doesn't exist

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_685d9e6acf9c83298c60af6c8b3d7fd4