### PR TITLE
Fix seed script Prisma import

### DIFF
--- a/scripts/seed.ts
+++ b/scripts/seed.ts
@@ -1,4 +1,5 @@
-import { Prisma, prisma } from "../lib/prismaclient";
+import { Prisma } from "@prisma/client";
+import { prisma } from "../lib/prismaclient";
 import { cert, initializeApp } from "firebase-admin/app";
 import { getAuth } from "firebase-admin/auth";
 import { serverConfig } from "../lib/firebase/config";


### PR DESCRIPTION
## Summary
- fix Prisma import in `scripts/seed.ts` so Decimal is defined

## Testing
- `npm run lint`
- `yarn seed` *(fails: can't reach Supabase database)*

------
https://chatgpt.com/codex/tasks/task_e_685da8749e8c8329ba5c6dcf88d5f516