### PR TITLE
Add default profile icon

### DIFF
--- a/components/cards/PostCard.tsx
+++ b/components/cards/PostCard.tsx
@@ -43,11 +43,11 @@ const PostCard = async ({
               className="relative h-[2rem] w-[2rem] left-[.5rem]"
             >
               <Image
-                src={author.image || ""}
+                src={author.image || "/assets/profile.svg"}
                 alt="Profile Image"
                 fill
                 objectFit="cover"
-                className="cursor-pointer rounded-full border-[.05rem] border-indigo-300 profile-shadow hover:shadow-none 
+                className="cursor-pointer rounded-full border-[.05rem] border-indigo-300 profile-shadow hover:shadow-none
 
                 "
               />

--- a/components/cards/ThreadCard.tsx
+++ b/components/cards/ThreadCard.tsx
@@ -61,7 +61,7 @@ const ThreadCard = async ({
           <div className="flex flex-col items-center">
             <Link href={`/profile/${author.id}`} className="relative h-11 w-11">
               <Image
-                src={author.image || ""}
+                src={author.image || "/assets/profile.svg"}
                 alt="Profile Image"
                 fill
                 className="cursor-pointer rounded-lg"

--- a/components/cards/UserCard.tsx
+++ b/components/cards/UserCard.tsx
@@ -39,7 +39,7 @@ const UserCard = ({ userId, name, username, imgUrl, personType }: Props) => {
       <article className="user-card">
         <div className="user-card_avatar">
           <Image
-            src={imgUrl || ""}
+            src={imgUrl || "/assets/profile.svg"}
             alt="logo"
             width={48}
             height={48}

--- a/components/reactflow/NodeAuthorDisplay.tsx
+++ b/components/reactflow/NodeAuthorDisplay.tsx
@@ -15,7 +15,7 @@ const NodeAuthorDisplay = ({ author }: Props) => {
         {/* This link wraps both the image and the username, so you have one unified hover area */}
         <Link href={`/profile/${author.id}`} className="node-author-wrapper ">
           <Image
-            src={"image" in author ? author.image || "" : ""}
+            src={"image" in author ? author.image || "/assets/profile.svg" : "/assets/profile.svg"}
             alt="Profile Image"
             width={24}
             height={24}

--- a/components/shared/ProfileHeader.tsx
+++ b/components/shared/ProfileHeader.tsx
@@ -28,7 +28,7 @@ const ProfileHeader = ({
         <div className="flex items-center gap-3">
           <div className="relative h-20 w-20 objects-cover">
             <Image
-              src={imgUrl || ""}
+              src={imgUrl || "/assets/profile.svg"}
               alt="Profile Image"
               fill
               className="rounded-none object-cover shadow-2xl"


### PR DESCRIPTION
## Summary
- show `public/assets/profile.svg` whenever profile image is missing
- update profile header and user display components to use the default icon

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_685dc75c2644832984dcc79b8d19765a