### PR TITLE
Add user realtime posts tab

### DIFF
--- a/app/(root)/(standard)/profile/[id]/page.tsx
+++ b/app/(root)/(standard)/profile/[id]/page.tsx
@@ -1,5 +1,6 @@
 import ProfileHeader from "@/components/shared/ProfileHeader";
 import ThreadsTab from "@/components/shared/ThreadsTab";
+import RealtimePostsTab from "@/components/shared/RealtimePostsTab";
 import AboutTab from "@/components/shared/AboutTab";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { profileTabs } from "@/constants";
@@ -61,8 +62,8 @@ async function Page({ params }: { params: { id: string } }) {
               value={tab.value}
               className="w-full text-light-1"
             >
-              {tab.label === "Posts" ? ( // Render ThreadsTab only if the tab's value is 'threads'
-                <ThreadsTab
+              {tab.label === "Posts" ? (
+                <RealtimePostsTab
                   currentUserId={activeUser.userId!}
                   accountId={profilePageUser.id}
                 />

--- a/components/shared/RealtimePostsTab.tsx
+++ b/components/shared/RealtimePostsTab.tsx
@@ -1,0 +1,44 @@
+import PostCard from "@/components/cards/PostCard";
+import { fetchUserRealtimePosts } from "@/lib/actions/realtimepost.actions";
+import { redirect } from "next/navigation";
+
+interface Props {
+  currentUserId: bigint;
+  accountId: bigint;
+}
+
+const RealtimePostsTab = async ({ currentUserId, accountId }: Props) => {
+  const posts = await fetchUserRealtimePosts({
+    realtimeRoomId: "global",
+    userId: accountId,
+    postTypes: ["TEXT", "VIDEO", "IMAGE", "IMAGE_COMPUTE", "GALLERY"],
+  });
+
+  if (!posts) redirect("/");
+
+  return (
+    <section className="mt-[0rem] flex flex-col gap-12">
+      {posts.length === 0 ? (
+        <p className="no-result">Nothing found</p>
+      ) : (
+        <>
+          {posts.map((post) => (
+            <PostCard
+              key={post.id}
+              currentUserId={currentUserId}
+              id={post.id}
+              content={post.content ? post.content : undefined}
+              image_url={post.image_url ? post.image_url : undefined}
+              video_url={post.video_url ? post.video_url : undefined}
+              type={post.type}
+              author={post.author!}
+              createdAt={post.created_at.toDateString()}
+            />
+          ))}
+        </>
+      )}
+    </section>
+  );
+};
+
+export default RealtimePostsTab;

--- a/lib/actions/realtimepost.actions.ts
+++ b/lib/actions/realtimepost.actions.ts
@@ -245,3 +245,36 @@ export async function fetchRealtimePostById({ id }: { id: string }) {
     throw new Error(`Failed to fetch real-time post: ${error.message}`);
   }
 }
+
+export async function fetchUserRealtimePosts({
+  realtimeRoomId,
+  userId,
+  postTypes,
+}: {
+  realtimeRoomId: string;
+  userId: bigint;
+  postTypes: realtime_post_type[];
+}) {
+  await prisma.$connect();
+  const realtimePosts = await prisma.realtimePost.findMany({
+    where: {
+      realtime_room_id: realtimeRoomId,
+      author_id: userId,
+      type: {
+        in: postTypes,
+      },
+    },
+    include: {
+      author: true,
+    },
+    orderBy: {
+      created_at: "desc",
+    },
+  });
+
+  return realtimePosts.map((realtimePost) => ({
+    ...realtimePost,
+    x_coordinate: realtimePost.x_coordinate.toNumber(),
+    y_coordinate: realtimePost.y_coordinate.toNumber(),
+  }));
+}


### PR DESCRIPTION
## Summary
- add `fetchUserRealtimePosts` to fetch posts by author
- create `RealtimePostsTab` component
- show `RealtimePostsTab` for profile posts tab

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_685ddd2098b88329be8cbb48f52baead