### PR TITLE
Enable likes for realtime posts

### DIFF
--- a/app/(root)/(realtime)/post/[id]/page.tsx
+++ b/app/(root)/(realtime)/post/[id]/page.tsx
@@ -18,6 +18,7 @@ const Page = async ({ params }: { params: { id: string } }) => {
           currentUserId={user?.userId}
           id={post.id}
           isRealtimePost
+          likeCount={post.like_count}
           content={
             post.type === "TEXT" || post.type === "GALLERY"
               ? post.content!

--- a/app/(root)/(standard)/page.tsx
+++ b/app/(root)/(standard)/page.tsx
@@ -27,6 +27,7 @@ export default async function Home() {
                 currentUserId={user?.userId}
                 id={realtimePost.id}
                 isRealtimePost
+                likeCount={realtimePost.like_count}
                 content={
                   realtimePost.content ? realtimePost.content : undefined
                 }

--- a/components/buttons/LikeButton.tsx
+++ b/components/buttons/LikeButton.tsx
@@ -1,8 +1,15 @@
 "use client";
 
-import { dislikePost, likePost, unlikePost } from "@/lib/actions/like.actions";
+import {
+  dislikePost,
+  likePost,
+  unlikePost,
+  likeRealtimePost,
+  unlikeRealtimePost,
+  dislikeRealtimePost,
+} from "@/lib/actions/like.actions";
 import { useAuth } from "@/lib/AuthContext";
-import { Like } from "@prisma/client";
+import { Like, RealtimeLike } from "@prisma/client";
 import Image from "next/image";
 import { useRouter } from "next/navigation";
 import { useState } from "react";
@@ -11,10 +18,10 @@ interface Props {
   postId?: bigint;
   realtimePostId?: string;
   likeCount: number;
-  initialLikeState: Like | null;
+  initialLikeState: Like | RealtimeLike | null;
 }
 
-const LikeButton = ({ postId, likeCount, initialLikeState }: Props) => {
+const LikeButton = ({ postId, realtimePostId, likeCount, initialLikeState }: Props) => {
   const user = useAuth();
   const router = useRouter();
   const isUserSignedIn = !!user.user;
@@ -37,11 +44,17 @@ const LikeButton = ({ postId, likeCount, initialLikeState }: Props) => {
       if (postId) {
         unlikePost({ userId: userObjectId, postId });
       }
+      if (realtimePostId) {
+        unlikeRealtimePost({ userId: userObjectId, realtimePostId });
+      }
       setCurrentLikeType("NONE");
       setDisplayLikeCount(displayLikeCount - 1);
     } else {
       if (postId) {
         likePost({ userId: userObjectId, postId });
+      }
+      if (realtimePostId) {
+        likeRealtimePost({ userId: userObjectId, realtimePostId });
       }
       if (currentLikeType === "NONE") {
         setDisplayLikeCount(displayLikeCount + 1);
@@ -65,11 +78,17 @@ const LikeButton = ({ postId, likeCount, initialLikeState }: Props) => {
       if (postId) {
         unlikePost({ userId: userObjectId, postId });
       }
+      if (realtimePostId) {
+        unlikeRealtimePost({ userId: userObjectId, realtimePostId });
+      }
       setCurrentLikeType("NONE");
       setDisplayLikeCount(displayLikeCount + 1);
     } else {
       if (postId) {
         dislikePost({ userId: userObjectId, postId });
+      }
+      if (realtimePostId) {
+        dislikeRealtimePost({ userId: userObjectId, realtimePostId });
       }
       if (currentLikeType === "NONE") {
         setDisplayLikeCount(displayLikeCount - 1);

--- a/components/cards/PostCard.tsx
+++ b/components/cards/PostCard.tsx
@@ -4,8 +4,11 @@ import LikeButton from "../buttons/LikeButton";
 import ShareButton from "../buttons/ShareButton";
 import ExpandButton from "../buttons/ExpandButton";
 import ReplicateButton from "../buttons/ReplicateButton";
-// import { fetchLikeForCurrentUser } from "@/lib/actions/like.actions";
-import { Like } from "@prisma/client";
+import {
+  fetchLikeForCurrentUser,
+  fetchRealtimeLikeForCurrentUser,
+} from "@/lib/actions/like.actions";
+import { Like, RealtimeLike } from "@prisma/client";
 import React from "react";
 import localFont from 'next/font/local'
 const founders = localFont({ src: '/NewEdgeTest-RegularRounded.otf' })
@@ -26,10 +29,12 @@ interface Props {
   };
   createdAt: string;
   isRealtimePost?: boolean;
+  likeCount?: number;
 }
 
 const PostCard = async ({
   id,
+  currentUserId,
   content,
   author,
   image_url,
@@ -37,9 +42,17 @@ const PostCard = async ({
   type,
   createdAt,
   isRealtimePost = false,
-}: Props) => {
-  let currentUserLike: Like | null = null;
-  let likeCount = 0;
+  likeCount = 0,
+  }: Props) => {
+  let currentUserLike: Like | RealtimeLike | null = null;
+  if (currentUserId) {
+    currentUserLike = isRealtimePost
+      ? await fetchRealtimeLikeForCurrentUser({
+          realtimePostId: id,
+          userId: currentUserId,
+        })
+      : await fetchLikeForCurrentUser({ postId: id, userId: currentUserId });
+  }
   return (
     <article className="flex w-full flex-col postcard  p-7 ">
       <div className="flex items-start justify-between ">

--- a/components/shared/RealtimePostsTab.tsx
+++ b/components/shared/RealtimePostsTab.tsx
@@ -28,6 +28,7 @@ const RealtimePostsTab = async ({ currentUserId, accountId }: Props) => {
               currentUserId={currentUserId}
               id={post.id}
               isRealtimePost
+              likeCount={post.like_count}
               content={post.content ? post.content : undefined}
               image_url={post.image_url ? post.image_url : undefined}
               video_url={post.video_url ? post.video_url : undefined}

--- a/lib/models/schema.prisma
+++ b/lib/models/schema.prisma
@@ -80,6 +80,21 @@ model Like {
   @@map("likes")
 }
 
+model RealtimeLike {
+  id              BigInt    @id @default(autoincrement())
+  created_at      DateTime  @default(now()) @db.Timestamptz(6)
+  score           Int
+  type            like_type @default(LIKE)
+  user_id         BigInt
+  realtime_post_id BigInt
+  updated_at      DateTime? @default(now()) @updatedAt @db.Timestamptz(6)
+  realtime_post   RealtimePost @relation(fields: [realtime_post_id], references: [id], onDelete: Cascade)
+  user            User        @relation(fields: [user_id], references: [id], onDelete: Cascade)
+
+  @@unique([realtime_post_id, user_id])
+  @@map("realtime_likes")
+}
+
 enum like_type {
   LIKE
   DISLIKE
@@ -106,6 +121,7 @@ model RealtimePost {
   author_id        BigInt
   updated_at       DateTime?          @default(now()) @updatedAt @db.Timestamptz(6)
   like_count       Int                @default(0)
+  likes            RealtimeLike[]
   author           User               @relation(fields: [author_id], references: [id], onDelete: Restrict)
   x_coordinate     Decimal
   y_coordinate     Decimal


### PR DESCRIPTION
## Summary
- support realtime post likes in Prisma schema and actions
- hook up LikeButton to save likes for realtime posts
- fetch like data for realtime posts in PostCard
- pass like counts from global post pages

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_685de30fe4188329891b4c62e960bf00