### PR TITLE
Add new profile fields

### DIFF
--- a/lib/actions/userattributes.actions.ts
+++ b/lib/actions/userattributes.actions.ts
@@ -40,6 +40,14 @@ export async function upsertUserAttributes({
         movies: {
           set: userAttributes.movies,
         },
+        location: userAttributes.location,
+        birthday: userAttributes.birthday,
+        hobbies: {
+          set: userAttributes.hobbies,
+        },
+        communities: {
+          set: userAttributes.communities,
+        },
       },
       create: {
         user_id: user.userId!,
@@ -57,6 +65,14 @@ export async function upsertUserAttributes({
         },
         movies: {
           set: userAttributes.movies,
+        },
+        location: userAttributes.location,
+        birthday: userAttributes.birthday,
+        hobbies: {
+          set: userAttributes.hobbies,
+        },
+        communities: {
+          set: userAttributes.communities,
         },
       },
     });

--- a/lib/models/schema.prisma
+++ b/lib/models/schema.prisma
@@ -45,6 +45,10 @@ model UserAttributes {
   songs      String[]
   interests  String[]
   movies     String[]
+  location   String?
+  birthday   DateTime?
+  hobbies    String[]
+  communities String[]
 
   @@map("user_attributes")
 }


### PR DESCRIPTION
## Summary
- expand `UserAttributes` in Prisma schema to include location, birthday, hobbies and communities
- update `upsertUserAttributes` action to persist the new fields
- regenerate Prisma client

## Testing
- `yarn install`
- `npx prisma generate`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_685e0de70b988329a4ce92c4210b7738