### PR TITLE
Implement user attribute API

### DIFF
--- a/app/api/user-attributes/route.ts
+++ b/app/api/user-attributes/route.ts
@@ -1,0 +1,24 @@
+import { NextRequest, NextResponse } from "next/server";
+import { fetchUserAttributes, upsertUserAttributes } from "@/lib/actions/userattributes.actions";
+
+export async function GET(req: NextRequest) {
+  const userId = req.nextUrl.searchParams.get("userId");
+  if (!userId) {
+    return NextResponse.json({ error: "Missing userId" }, { status: 400 });
+  }
+  const attrs = await fetchUserAttributes({ userId: BigInt(userId) });
+  if (!attrs) {
+    return NextResponse.json({ error: "User attributes not found" }, { status: 404 });
+  }
+  return NextResponse.json(attrs);
+}
+
+export async function POST(req: NextRequest) {
+  const data = await req.json();
+  const { userAttributes, path } = data;
+  if (!userAttributes || !path) {
+    return NextResponse.json({ error: "Missing payload" }, { status: 400 });
+  }
+  await upsertUserAttributes({ userAttributes, path });
+  return NextResponse.json({ success: true });
+}

--- a/lib/MultiSelectFunctions.ts
+++ b/lib/MultiSelectFunctions.ts
@@ -252,3 +252,31 @@ export function submitEdits(
       console.error("Nothing to update");
   }
 }
+
+export function submitFieldEdits(
+  field: "LOCATION" | "BIRTHDAY",
+  value: string,
+  userAttributes: UserAttributes,
+  path: string
+) {
+  switch (field) {
+    case "LOCATION":
+      return upsertUserAttributes({
+        userAttributes: {
+          ...userAttributes,
+          location: value,
+        },
+        path,
+      });
+    case "BIRTHDAY":
+      return upsertUserAttributes({
+        userAttributes: {
+          ...userAttributes,
+          birthday: new Date(value),
+        },
+        path,
+      });
+    default:
+      console.error("Nothing to update");
+  }
+}


### PR DESCRIPTION
## Summary
- create new API route `/api/user-attributes` to get or update user attributes
- add `submitFieldEdits` helper for updating plain fields

## Testing
- `yarn install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_685e1283e77c8329a91492a07990d961