### PR TITLE
Display user profile attributes

### DIFF
--- a/components/shared/AboutTab.tsx
+++ b/components/shared/AboutTab.tsx
@@ -1,12 +1,8 @@
-import { fetchUserThreads } from "@/lib/actions/user.actions";
-import { redirect,notFound } from "next/navigation";
-import { fetchUser } from "@/lib/actions/user.actions";
-import AccountProfile from "@/components/forms/AccountProfile";
 import { getUserFromCookies } from "@/lib/serverutils";
 import { Button } from "../ui/button";
-import ThreadCard from "@/components/cards/ThreadCard";
-import { Dialog } from "../ui/dialog";
-import Link from 'next/link'
+import Link from "next/link";
+import { fetchUserAttributes } from "@/lib/actions/userattributes.actions";
+import { format } from "date-fns";
 
 
 interface Props {
@@ -18,47 +14,87 @@ const AboutTab = async ({ currentUserId, accountId }: Props) => {
 
   const user = await getUserFromCookies();
   if (!user) return null;
-  let result = await fetchUserThreads(accountId);
 
-  if (!result) redirect("/");
-  const userData = {
-    authId: user.uid || "",
-    userId: user.userId || null,
-    username: user.email || "",
-    name: user.displayName || "",
-    bio: user.bio || "",
-    image: user?.photoURL || "",
-  };
+  const attributes =
+    (await fetchUserAttributes({ userId: accountId })) || null;
+
+  const categories = [
+    {
+      label: "Artists",
+      values: attributes?.artists || [],
+    },
+    {
+      label: "Albums",
+      values: attributes?.albums || [],
+    },
+    {
+      label: "Songs",
+      values: attributes?.songs || [],
+    },
+    {
+      label: "Movies",
+      values: attributes?.movies || [],
+    },
+    {
+      label: "Interests",
+      values: attributes?.interests || [],
+    },
+    {
+      label: "Hobbies",
+      values: attributes?.hobbies || [],
+    },
+    {
+      label: "Communities",
+      values: attributes?.communities || [],
+    },
+    {
+      label: "Location",
+      values: attributes?.location ? [attributes.location] : [],
+    },
+    {
+      label: "Birthday",
+      values: attributes?.birthday
+        ? [format(new Date(attributes.birthday), "yyyy-MM-dd")]
+        : [],
+    },
+  ];
+
+  const grid = (
+    <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4 mt-9">
+      {categories.map((cat) => (
+        <div
+          key={cat.label}
+          className="border border-light-3 rounded-md p-4 bg-light-2"
+        >
+          <h3 className="text-base-semibold mb-2 text-black">{cat.label}</h3>
+          {cat.values.length > 0 ? (
+            <ul className="list-disc pl-4 text-black text-base-regular space-y-1">
+              {cat.values.map((v) => (
+                <li key={v}>{v}</li>
+              ))}
+            </ul>
+          ) : (
+            <p className="text-sm text-light-3">No {cat.label.toLowerCase()} added</p>
+          )}
+        </div>
+      ))}
+    </div>
+  );
+
   if (BigInt(currentUserId) === BigInt(accountId)) {
-    // User is viewing their own profile, allow editing
     return (
-      <main className=" mt-9 items-center justify-center text-center">
-<Link href={`/profile/${accountId}/customize`}>
-        <Button size={"lg"} className="head-sub-text text-black  w-fit rounded-md p-8"> 
-       
-            Customize Profile</Button>
-            </Link>
-        <div className="mt-9">
-          {/* Placeholder for non-editable content */}
-          <p>Interests: [Sample interests here]</p>
-          <p>Favorites: [Sample favorites here]</p>
-          <p>Social Links: [Sample links here]</p>
-        </div>
-      </main>
-    );
-  } else {
-    // User is viewing someone else's profile, show non-editable version
-    return (
-      <main className="grid mt-9 text-center">
-        <div>
-          {/* Placeholder for non-editable content */}
-          <p>Interests: [Sample interests here]</p>
-          <p>Favorites: [Sample favorites here]</p>
-          <p>Social Links: [Sample links here]</p>
-        </div>
+      <main className="items-center justify-center text-center">
+        <Link href={`/profile/${accountId}/customize`}>
+          <Button size="lg" className="head-sub-text text-black w-fit rounded-md p-8">
+            Customize Profile
+          </Button>
+        </Link>
+        {grid}
       </main>
     );
   }
+
+  return <main className="text-center">{grid}</main>;
 };
 
 


### PR DESCRIPTION
## Summary
- fetch user attributes for About tab
- render attributes in a 3-column bento style grid

## Testing
- `yarn install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_685ee91f1f6483298d122615a6b63e07