### PR TITLE
Add nested comment tree

### DIFF
--- a/app/(root)/(standard)/thread/[id]/page.tsx
+++ b/app/(root)/(standard)/thread/[id]/page.tsx
@@ -1,6 +1,7 @@
 import ThreadCard from "@/components/cards/ThreadCard";
 import Comment from "@/components/forms/Comment";
-import { fetchPostById } from "@/lib/actions/thread.actions";
+import { fetchPostTreeById } from "@/lib/actions/thread.actions";
+import CommentTree from "@/components/shared/CommentTree";
 import { redirect, notFound } from "next/navigation";
 import { getUserFromCookies } from "@/lib/serverutils";
 
@@ -8,7 +9,7 @@ const Page = async ({ params }: { params: { id: string } }) => {
   if (!params?.id && params?.id?.length !== 1) return notFound();
   const user = await getUserFromCookies();
   if (!user?.onboarded) redirect("/onboarding");
-  const post = await fetchPostById(BigInt(params.id));
+  const post = await fetchPostTreeById(BigInt(params.id));
   if (!post) notFound();
 
   return (
@@ -33,22 +34,11 @@ const Page = async ({ params }: { params: { id: string } }) => {
           currentUserId={user.userId!}
         />
       </div>
-      <section className="mt-10 flex flex-col gap-1">
-        {post.children.map((childItem) => (
-          <ThreadCard
-            key={childItem.id}
-            currentUserId={user?.userId}
-            id={childItem.id}
-            parentId={childItem.parent_id}
-            content={childItem.content}
-            author={childItem.author}
-            createdAt={childItem.created_at.toDateString()}
-            comments={childItem.children}
-            isComment
-            likeCount={childItem.like_count}
-          />
-        ))}
-      </section>
+      <CommentTree
+        comments={post.children}
+        currentUserId={user.userId!}
+        currentUserImg={user.photoURL!}
+      />
     </section>
   );
 };

--- a/components/shared/CommentTree.tsx
+++ b/components/shared/CommentTree.tsx
@@ -1,0 +1,46 @@
+import ThreadCard from "@/components/cards/ThreadCard";
+import Comment from "@/components/forms/Comment";
+
+interface CommentTreeProps {
+  comments: any[];
+  currentUserId: bigint;
+  currentUserImg: string;
+}
+
+const CommentTree = ({ comments, currentUserId, currentUserImg }: CommentTreeProps) => {
+  return (
+    <div className="ml-6 flex flex-col gap-3">
+      {comments.map((comment) => (
+        <div key={comment.id} className="mt-4">
+          <ThreadCard
+            id={comment.id}
+            currentUserId={currentUserId}
+            parentId={comment.parent_id}
+            content={comment.content}
+            author={comment.author}
+            createdAt={comment.created_at.toDateString()}
+            comments={comment.children}
+            isComment
+            likeCount={comment.like_count}
+          />
+          <div className="ml-6 mt-2">
+            <Comment
+              postId={comment.id}
+              currentUserImg={currentUserImg}
+              currentUserId={currentUserId}
+            />
+            {comment.children && comment.children.length > 0 && (
+              <CommentTree
+                comments={comment.children}
+                currentUserId={currentUserId}
+                currentUserImg={currentUserImg}
+              />
+            )}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+};
+
+export default CommentTree;


### PR DESCRIPTION
## Summary
- add `fetchPostTreeById` to fetch nested comments recursively
- display nested comments with new `CommentTree` component
- update thread page to use the new tree

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_685f009773148329b51095694646c8f5