### PR TITLE
Fix comment tree indentation

### DIFF
--- a/app/(root)/(standard)/thread/[id]/page.tsx
+++ b/app/(root)/(standard)/thread/[id]/page.tsx
@@ -59,6 +59,7 @@ const Page = async ({ params }: { params: { id: string } }) => {
         comments={post.children}
         currentUserId={user.userId!}
         currentUserImg={user.photoURL!}
+        depth={1}
       />
       </div>
           </main>

--- a/components/cards/PostCard.tsx
+++ b/components/cards/PostCard.tsx
@@ -82,7 +82,7 @@ const PostCard = async ({
               </p>
               </div>
             </Link>
-            <hr className="mt-3 mb-4 w-[48rem] h-px border-t-0 bg-transparent bg-gradient-to-r from-transparent via-slate-100 to-transparent opacity-75" />
+            <hr className="mt-3 mb-4 w-full h-px border-t-0 bg-transparent bg-gradient-to-r from-transparent via-slate-100 to-transparent opacity-75" />
             {type === "TEXT" && content && (
               <p className="mt-2  text-[1.08rem] text-black tracking-[.05rem]">{content}</p>
             )}
@@ -117,7 +117,7 @@ const PostCard = async ({
                 ))}
               </div>
             )}
-            <hr className="mt-4 mb-3 w-[48rem] h-px border-t-0 bg-transparent bg-gradient-to-r from-transparent via-slate-100 to-transparent opacity-75" />
+            <hr className="mt-4 mb-3 w-full h-px border-t-0 bg-transparent bg-gradient-to-r from-transparent via-slate-100 to-transparent opacity-75" />
 
             <div className="mt-4 flex flex-col gap-x-3 gap-y-4">
               <div className="flex gap-x-12 gap-y-8">

--- a/components/cards/ThreadCard.tsx
+++ b/components/cards/ThreadCard.tsx
@@ -56,9 +56,9 @@ const ThreadCard = async ({
     });
   }
   return (
-    <article className="relative flex w-fit flex-col postcard  p-7 ">
+    <article className="relative flex w-full flex-col postcard p-7 ">
       <div className="flex-1 items-start justify-between ">
-        <div className="flex w-fit flex-1 flex-row gap-4 ">
+        <div className="flex w-full flex-1 flex-row gap-4 ">
           <div className="flex flex-col items-center  ">
             <Link
               href={`/profile/${author.id}`}
@@ -84,10 +84,10 @@ const ThreadCard = async ({
               </p>
               </div>
             </Link>
-            <hr className="mt-3 mb-4 w-[48rem] h-px border-t-0 bg-transparent bg-gradient-to-r from-transparent via-slate-100 to-transparent opacity-75" />
+            <hr className="mt-3 mb-4 w-full h-px border-t-0 bg-transparent bg-gradient-to-r from-transparent via-slate-100 to-transparent opacity-75" />
               <p className="mt-2  text-[1.08rem] text-black tracking-[.05rem]">{content}</p>
            
-            <hr className="mt-4 mb-3 w-[48rem] h-px border-t-0 bg-transparent bg-gradient-to-r from-transparent via-slate-100 to-transparent opacity-75" />
+            <hr className="mt-4 mb-3 w-full h-px border-t-0 bg-transparent bg-gradient-to-r from-transparent via-slate-100 to-transparent opacity-75" />
 
             <div className="mt-4 flex flex-col gap-x-3 gap-y-4">
               <div className="flex gap-x-12 gap-y-8">

--- a/components/shared/CommentTree.tsx
+++ b/components/shared/CommentTree.tsx
@@ -5,13 +5,23 @@ interface CommentTreeProps {
   comments: any[];
   currentUserId: bigint;
   currentUserImg: string;
+  depth?: number;
 }
 
-const CommentTree = ({ comments, currentUserId, currentUserImg }: CommentTreeProps) => {
+const MAX_DEPTH = 5;
+const INDENT_PX = 24;
+
+const CommentTree = ({ comments, currentUserId, currentUserImg, depth = 0 }: CommentTreeProps) => {
   return (
-    <div className="ml-6 flex flex-col gap-3">
-      {comments.map((comment) => (
-        <div key={comment.id} className="mt-4">
+    <div className="flex flex-col gap-3">
+      {comments.map((comment) => {
+        const indent = Math.min(depth, MAX_DEPTH) * INDENT_PX;
+        return (
+          <div
+            key={comment.id}
+            className="mt-4"
+            style={{ marginLeft: indent, width: `calc(100% - ${indent}px)` }}
+          >
           <ThreadCard
             id={comment.id}
             currentUserId={currentUserId}
@@ -23,7 +33,10 @@ const CommentTree = ({ comments, currentUserId, currentUserImg }: CommentTreePro
             isComment
             likeCount={comment.like_count}
           />
-          <div className="ml-6 mt-4">
+          <div
+            className="mt-4"
+            style={{ marginLeft: indent, width: `calc(100% - ${indent}px)` }}
+          >
             <Comment
               postId={comment.id}
               currentUserImg={currentUserImg}
@@ -34,11 +47,13 @@ const CommentTree = ({ comments, currentUserId, currentUserImg }: CommentTreePro
                 comments={comment.children}
                 currentUserId={currentUserId}
                 currentUserImg={currentUserImg}
+                depth={depth + 1}
               />
             )}
           </div>
-        </div>
-      ))}
+          </div>
+        );
+      })}
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- prevent comment cards from overlapping sidebar
- limit nested comment indentation with dynamic width

## Testing
- `yarn install`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_685f251bc5a88329b12f8824d3ab92ed