### PR TITLE
Add books support to profiles

### DIFF
--- a/app/(root)/(standard)/profile/[id]/customize/customize-components.tsx
+++ b/app/(root)/(standard)/profile/[id]/customize/customize-components.tsx
@@ -15,6 +15,7 @@ import {
   fetchArtists,
   fetchInterests,
   fetchMovies,
+  fetchBooks,
   fetchTracks,
   submitEdits,
 } from "@/lib/MultiSelectFunctions";
@@ -447,12 +448,18 @@ export default function CustomButtons({ userAttributes }: Props) {
             <hr />
 
             <div className="bg-black border border-white rounded-md px-3 pt-6  pb-16  mt-3 mb-3 ">
-              {/* <FancyMultiSelect /> */}
+              <FancyMultiSelect
+                fetchMultiselectData={fetchBooks}
+                initialSelected={convertListToSelectables(userAttributes.books)}
+                submitEdits={(selectables) =>
+                  submitEdits("BOOKS", selectables, userAttributes, path)
+                }
+              />
             </div>
             <hr />
             <div className="flex gap-4 mb-2 mt-2">
               <DialogClose
-                id="entermovie"
+                id="enterbooks"
                 type="submit"
                 className={`form-submit-button pl-4 py-1 pr-[1rem]`}
               >
@@ -465,9 +472,6 @@ export default function CustomButtons({ userAttributes }: Props) {
               >
                 Close
               </DialogClose>
-            </div>
-            <div className="overlay w-full bg-white h-full text-center align-middle	 font-bold text-black">
-              {"UNDER CONSTRUCTION"}
             </div>
           </DialogContent>
         </Dialog>

--- a/components/shared/AboutTab.tsx
+++ b/components/shared/AboutTab.tsx
@@ -36,6 +36,10 @@ const AboutTab = async ({ currentUserId, accountId }: Props) => {
       values: attributes?.movies || [],
     },
     {
+      label: "Books",
+      values: attributes?.books || [],
+    },
+    {
       label: "Interests",
       values: attributes?.interests || [],
     },

--- a/lib/MultiSelectFunctions.ts
+++ b/lib/MultiSelectFunctions.ts
@@ -30,6 +30,32 @@ export async function fetchMovies(query: string): Promise<OptionType[]> {
   }
 }
 
+export async function fetchBooks(query: string): Promise<OptionType[]> {
+  try {
+    const response = await fetch(
+      `https://openlibrary.org/search.json?q=${encodeURIComponent(query)}`
+    );
+    const data = await response.json();
+    if (data.docs && Array.isArray(data.docs)) {
+      const books = data.docs.map((doc: any) => ({
+        value: doc.key,
+        label: `${doc.title}${doc.author_name && doc.author_name.length ? ` by ${doc.author_name[0]}` : ""}`,
+      }));
+
+      const uniqueBooks = books.filter(
+        (book: any, index: number, self: any) =>
+          index === self.findIndex((b: any) => b.label === book.label)
+      );
+
+      return uniqueBooks;
+    }
+    return [];
+  } catch (error: any) {
+    console.error("Error fetching books:", error);
+    return [];
+  }
+}
+
 export async function fetchAlbums(query: string): Promise<OptionType[]> {
   try {
     const response = await fetch(
@@ -202,7 +228,13 @@ export function convertSelectablesToList(selectables: OptionType[]) {
 }
 
 export function submitEdits(
-  selectableType: "INTERESTS" | "ALBUMS" | "MOVIES" | "TRACKS" | "ARTISTS",
+  selectableType:
+    | "INTERESTS"
+    | "ALBUMS"
+    | "MOVIES"
+    | "TRACKS"
+    | "ARTISTS"
+    | "BOOKS",
   selectables: OptionType[],
   userAttributes: UserAttributes,
   path: string
@@ -229,6 +261,14 @@ export function submitEdits(
         userAttributes: {
           ...userAttributes,
           movies: convertSelectablesToList(selectables),
+        },
+        path,
+      });
+    case "BOOKS":
+      return upsertUserAttributes({
+        userAttributes: {
+          ...userAttributes,
+          books: convertSelectablesToList(selectables),
         },
         path,
       });

--- a/lib/actions/userattributes.actions.ts
+++ b/lib/actions/userattributes.actions.ts
@@ -27,6 +27,7 @@ export async function upsertUserAttributes({
       songs = [],
       interests = [],
       movies = [],
+      books = [],
       location = null,
       birthday = null,
       hobbies = [],
@@ -55,6 +56,9 @@ export async function upsertUserAttributes({
         movies: {
           set: sanitize(movies),
         },
+        books: {
+          set: sanitize(books),
+        },
         location,
         birthday,
         hobbies: {
@@ -80,6 +84,9 @@ export async function upsertUserAttributes({
         },
         movies: {
           set: sanitize(movies),
+        },
+        books: {
+          set: sanitize(books),
         },
         location,
         birthday,

--- a/lib/models/schema.prisma
+++ b/lib/models/schema.prisma
@@ -45,6 +45,7 @@ model UserAttributes {
   songs      String[]
   interests  String[]
   movies     String[]
+  books      String[]
   location   String?
   birthday   DateTime?
   hobbies    String[]


### PR DESCRIPTION
## Summary
- add `books` column to Prisma schema
- handle books in user attribute actions
- fetch books from Open Library
- show books in About tab
- allow editing books via multiselect in Customize Profile

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_685f356b8d608329807785fcdbc1f16d