### PR TITLE
Add friends tab listing connections

### DIFF
--- a/app/(root)/(standard)/profile/[id]/page.tsx
+++ b/app/(root)/(standard)/profile/[id]/page.tsx
@@ -2,6 +2,7 @@ import ProfileHeader from "@/components/shared/ProfileHeader";
 import ThreadsTab from "@/components/shared/ThreadsTab";
 import RealtimePostsTab from "@/components/shared/RealtimePostsTab";
 import AboutTab from "@/components/shared/AboutTab";
+import FriendsTab from "@/components/shared/FriendsTab";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { profileTabs } from "@/constants";
 import { fetchUser } from "@/lib/actions/user.actions";
@@ -67,16 +68,18 @@ async function Page({ params }: { params: { id: string } }) {
                   currentUserId={activeUser.userId!}
                   accountId={profilePageUser.id}
                 />
-              ) : tab.label === "About" ? ( // Render ThreadsTab only if the tab's value is 'threads'
+              ) : tab.label === "About" ? (
                 <AboutTab
+                  currentUserId={activeUser.userId!}
+                  accountId={profilePageUser.id}
+                />
+              ) : tab.label === "Friends" ? (
+                <FriendsTab
                   currentUserId={activeUser.userId!}
                   accountId={profilePageUser.id}
                 />
               ) : (
                 <div className="placeholder">
-                  {" "}
-                  {/* Placeholder or other component for other tabs */}
-                  {/* You can add different components or placeholders for other tabs here */}
                   Content for {tab.label}
                 </div>
               )}

--- a/components/shared/FriendsTab.tsx
+++ b/components/shared/FriendsTab.tsx
@@ -1,0 +1,30 @@
+import Link from "next/link";
+import { fetchFollowRelations, FriendEntry } from "@/lib/actions/follow.actions";
+
+interface Props {
+  currentUserId: bigint;
+  accountId: bigint;
+}
+
+const FriendsTab = async ({ currentUserId, accountId }: Props) => {
+  const relations: FriendEntry[] = await fetchFollowRelations({ userId: accountId });
+
+  if (relations.length === 0) {
+    return <p className="no-result">No connections</p>;
+  }
+
+  return (
+    <ul className="mt-9 space-y-4">
+      {relations.map((rel) => (
+        <li key={rel.id} className="text-base-regular text-black">
+          <Link href={`/profile/${rel.id}`} className="text-primary-500 hover:underline">
+            {rel.name}
+          </Link>{" "}
+          <span className="text-light-3">- {rel.status}</span>
+        </li>
+      ))}
+    </ul>
+  );
+};
+
+export default FriendsTab;


### PR DESCRIPTION
## Summary
- implement `fetchFollowRelations` to gather followers and followings
- create `FriendsTab` component to display friends/follows
- show new Friends tab in profile page

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_685f68f0c2b083298ea225bf3d186790