### PR TITLE
Add random users to sidebar

### DIFF
--- a/app/api/random-users/route.ts
+++ b/app/api/random-users/route.ts
@@ -1,0 +1,9 @@
+import { NextRequest, NextResponse } from "next/server";
+import { fetchRandomUsers } from "@/lib/actions/user.actions";
+
+export async function GET(req: NextRequest) {
+  const countParam = req.nextUrl.searchParams.get("count");
+  const count = countParam ? parseInt(countParam, 10) : 3;
+  const users = await fetchRandomUsers(count);
+  return NextResponse.json(users);
+}

--- a/components/shared/RightSidebar.tsx
+++ b/components/shared/RightSidebar.tsx
@@ -1,26 +1,33 @@
 "use client";
 
 import { Button } from "@/components/ui/button";
-import { useAuth } from "@/lib/AuthContext";
-import { app } from "@/lib/firebase/firebase";
-import { RealtimeRoom } from "@prisma/client";
-import { getAuth, signOut } from "firebase/auth";
-import Image from "next/image";
 import Link from "next/link";
-import { useRouter } from "next/navigation";
-import localFont from 'next/font/local'
-import CreateFeedPost from "@/components/forms/CreateFeedPost";
-const parabole = localFont({ src: '/Parabole-DisplayRegular.woff2' })
+import { useEffect, useState } from "react";
 
-
-interface Props {
-    userRooms: RealtimeRoom[];
-  }
+interface RandomUser {
+  id: number;
+  name: string;
+  username: string;
+  image: string | null;
+}
 
 function RightSidebar() {
-    const router = useRouter();
-    const user = useAuth();
-    const isUserSignedIn = !!user.user;
+  const [users, setUsers] = useState<RandomUser[]>([]);
+
+  useEffect(() => {
+    async function load() {
+      try {
+        const res = await fetch("/api/random-users");
+        if (res.ok) {
+          const data = await res.json();
+          setUsers(data);
+        }
+      } catch (e) {
+        console.error(e);
+      }
+    }
+    load();
+  }, []);
     // return (
     // <section className="custom-scrollbar rightsidebar">
     //     <div className="flex flex-1 flex-col justify-start">
@@ -31,61 +38,27 @@ function RightSidebar() {
     //     </div>
     // </section>
     // )
-return(
+  return (
     <section className="custom-scrollbar rightsidebar  bg-transparent">
-    <div className="flex w-full flex-1 flex-col gap-6 px-2">
-    <h3 className="relative bottom-[4rem] text-[1.5rem] text-black">Find New Groups</h3>
-
-    </div>
-    <div className="flex w-full flex-1 flex-col gap-6 px-2">
-    <h3 className="relative bottom-[4rem] text-[1.5rem] text-black">Find New Users</h3>
-    </div>
-    <div className="absolute justify-start  top-[1.55rem] left-[2.7rem]"></div>
-    <div
-    className="absolute left-0 top-0 h-full min-h-[1em] w-[.1rem] border-t-0 bg-gradient-to-tr from-transparent via-rose-300 to-transparent opacity-50 dark:via-neutral-400 lg:block">
-</div>
-    </section>)
-//     <div className="mb-6 px-6 ">
-//       {isUserSignedIn && <CreateFeedPost />}
-//     </div>
-//     <div className="mb-6 px-6  ">
-//       {isUserSignedIn && (
-       
-//           <Image
-//             src="/assets/user-helsinki.svg"
-//             alt="profile"
-//             className="mr-2"
-//             width={24}
-//             height={24}
-//           />
-//       )}
-//     </div>
-//     <div className="mb-6 px-6 ">
-//       {isUserSignedIn && (
-       
-//           <Image
-//             src="/assets/signout-helsinki.svg"
-//             alt="logout"
-//             className="mr-2"
-//             width={24}
-//             height={24}
-//           />
-      
-//       )}
-//     </div>
-//     <div className="absolute justify-start  top-[1.55rem] left-[2.7rem] ">
-//     <Link href="/" className="flex items-center gap-2">
-//       <Image src="/assets/logo-black.svg" alt="logo" width={36} height={36} /> 
-//       <div className={`${parabole.className}`}>
-//       <span  className=" text-[2.5rem] font-bold text-black tracking-[.0rem] max-xs:hidden">MESH</span>
-//       </div>
-
-//     </Link>
-    
-//     </div>
-
-//   </section>
-
+      <div className="flex w-full flex-1 flex-col gap-6 px-2">
+        <h3 className="relative bottom-[4rem] text-[1.5rem] text-black">Find New Groups</h3>
+      </div>
+      <div className="flex w-full flex-1 flex-col gap-2 px-2">
+        <h3 className="relative bottom-[4rem] text-[1.5rem] text-black">Find New Users</h3>
+        <div className="relative bottom-[4rem] flex flex-col gap-2">
+          {users.map((u) => (
+            <Link key={u.id} href={`/profile/${u.id}`}>
+              <Button className="w-full rounded-md leftsidebar-item border-none">
+                {u.name}
+              </Button>
+            </Link>
+          ))}
+        </div>
+      </div>
+      <div className="absolute justify-start  top-[1.55rem] left-[2.7rem]"></div>
+      <div className="absolute left-0 top-0 h-full min-h-[1em] w-[.1rem] border-t-0 bg-gradient-to-tr from-transparent via-rose-300 to-transparent opacity-50 dark:via-neutral-400 lg:block"></div>
+    </section>
+  );
 }
 
 export default RightSidebar;

--- a/lib/actions/user.actions.ts
+++ b/lib/actions/user.actions.ts
@@ -224,3 +224,32 @@ export async function getActivity(userId: bigint) {
     throw new Error(`Failed to fetch activity ${error.message}`);
   }
 }
+
+export async function fetchRandomUsers(count = 3) {
+  try {
+    await prisma.$connect();
+    const total = await prisma.user.count({
+      where: { onboarded: true },
+    });
+    const take = Math.min(count, total);
+    if (take === 0) return [];
+    const skip = Math.max(0, Math.floor(Math.random() * Math.max(total - take + 1, 1)));
+    const users = await prisma.user.findMany({
+      where: { onboarded: true },
+      skip,
+      take,
+      select: {
+        id: true,
+        name: true,
+        username: true,
+        image: true,
+      },
+    });
+    return users.map((u) => ({
+      ...u,
+      id: Number(u.id),
+    }));
+  } catch (error: any) {
+    throw new Error(`Failed to fetch random users: ${error.message}`);
+  }
+}


### PR DESCRIPTION
## Summary
- add `fetchRandomUsers` server action and an API route
- update RightSidebar to load three random users and link to profiles

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_685f6ca1cc308329b63a7e16a26d0a71