### PR TITLE
Add timer modal and button

### DIFF
--- a/components/buttons/TimerButton.tsx
+++ b/components/buttons/TimerButton.tsx
@@ -1,38 +1,37 @@
 "use client";
 
-import { dislikePost, likePost, unlikePost } from "@/lib/actions/like.actions";
-import { useAuth } from "@/lib/AuthContext";
-import { Like } from "@prisma/client";
 import Image from "next/image";
-import { useRouter } from "next/navigation";
-import { useState } from "react";
+import useStore from "@/lib/reactflow/store";
+import { AppState } from "@/lib/reactflow/types";
+import { useShallow } from "zustand/react/shallow";
+import TimerModal from "../modals/TimerModal";
 
 interface Props {
-  postId?: bigint;
-  realtimePostId?: string;
+  isOwned: boolean;
+  expirationDate?: string | null;
 }
 
-const TimerButton = ({ postId }: Props) => {
-  const user = useAuth();
-  const router = useRouter();
-  const isUserSignedIn = !!user.user;
-  const userObjectId = user?.user?.userId;
-
-
- 
-  return (
-
-    <Image
-                  src="/assets/time.svg"
-                  alt="clock"
-                  width={24}
-                  height={24}
-                  className="cursor-pointer object-contain likebutton"
-                />
-
+const TimerButton = ({ isOwned, expirationDate }: Props) => {
+  const { openModal } = useStore(
+    useShallow((state: AppState) => ({
+      openModal: state.openModal,
+    }))
   );
-  
-};
 
+  return (
+    <Image
+      src="/assets/time.svg"
+      alt="clock"
+      width={24}
+      height={24}
+      className="cursor-pointer object-contain likebutton"
+      onClick={() =>
+        openModal(
+          <TimerModal isOwned={isOwned} expirationDate={expirationDate} />
+        )
+      }
+    />
+  );
+};
 
 export default TimerButton;

--- a/components/cards/PostCard.tsx
+++ b/components/cards/PostCard.tsx
@@ -31,6 +31,7 @@ interface Props {
   createdAt: string;
   isRealtimePost?: boolean;
   likeCount?: number;
+  expirationDate?: string | null;
 }
 
 const PostCard = async ({
@@ -44,6 +45,7 @@ const PostCard = async ({
   createdAt,
   isRealtimePost = false,
   likeCount = 0,
+  expirationDate = null,
   }: Props) => {
   let currentUserLike: Like | RealtimeLike | null = null;
   if (currentUserId) {
@@ -134,7 +136,10 @@ const PostCard = async ({
                   </>
             <ReplicateButton postId={id} />
           <ShareButton postId={id} />
-          <TimerButton postId={id} />
+          <TimerButton
+            isOwned={currentUserId === author.id}
+            expirationDate={expirationDate ?? undefined}
+          />
 
               </div>
             </div>

--- a/components/cards/ThreadCard.tsx
+++ b/components/cards/ThreadCard.tsx
@@ -36,6 +36,7 @@ interface Props {
   }[];
   isComment?: boolean;
   likeCount: number;
+  expirationDate?: string | null;
 }
 
 const ThreadCard = async ({
@@ -48,6 +49,7 @@ const ThreadCard = async ({
   comments,
   isComment,
   likeCount,
+  expirationDate = null,
 }: Props) => {
   let currentUserLike: Like | null = null;
   if (currentUserId) {
@@ -102,7 +104,10 @@ const ThreadCard = async ({
                   </>
             <ReplicateButton postId={id} />
           <ShareButton postId={id} />
-          <TimerButton postId={id} />
+          <TimerButton
+            isOwned={currentUserId === author.id}
+            expirationDate={expirationDate ?? undefined}
+          />
               </div>
             </div>
           </div>

--- a/components/modals/TimerModal.tsx
+++ b/components/modals/TimerModal.tsx
@@ -1,0 +1,96 @@
+"use client";
+
+import { useState, useMemo } from "react";
+import { Button } from "@/components/ui/button";
+import {
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogClose,
+} from "@/components/ui/dialog";
+import useStore from "@/lib/reactflow/store";
+import { AppState } from "@/lib/reactflow/types";
+import { useShallow } from "zustand/react/shallow";
+
+interface Props {
+  isOwned: boolean;
+  expirationDate?: string | null;
+}
+
+const TimerModal = ({ isOwned, expirationDate }: Props) => {
+  const { closeModal } = useStore(
+    useShallow((state: AppState) => ({
+      closeModal: state.closeModal,
+    }))
+  );
+  const [duration, setDuration] = useState("none");
+
+  const remaining = useMemo(() => {
+    if (!expirationDate) return "No expiration";
+    const diff = new Date(expirationDate).getTime() - Date.now();
+    if (diff <= 0) return "Expired";
+    const hours = Math.floor(diff / 3600000);
+    const minutes = Math.floor((diff % 3600000) / 60000);
+    return `${hours}h ${minutes}m remaining`;
+  }, [expirationDate]);
+
+  const renderOwned = () => (
+    <div>
+      <DialogHeader className="dialog-header text-white text-lg py-4 mt-[-4rem]">
+        <b>Set Expiration</b>
+      </DialogHeader>
+      <hr />
+      <div className="py-4 text-white flex flex-col gap-4">
+        <select
+          className="p-2 bg-gray-800 border border-gray-700"
+          value={duration}
+          onChange={(e) => setDuration(e.target.value)}
+        >
+          <option value="none">No expiration</option>
+          <option value="1h">1 Hour</option>
+          <option value="1d">1 Day</option>
+          <option value="1w">1 Week</option>
+        </select>
+      </div>
+      <hr />
+      <div className="py-4 flex justify-end">
+        <Button
+          variant="outline"
+          onClick={() => closeModal()}
+          className="px-4"
+        >
+          Save
+        </Button>
+      </div>
+    </div>
+  );
+
+  const renderView = () => (
+    <div>
+      <DialogHeader className="dialog-header text-white text-lg py-4 mt-[-4rem]">
+        <b>Post Expiration</b>
+      </DialogHeader>
+      <hr />
+      <div className="py-4 text-white">{remaining}</div>
+      <hr />
+      <div className="py-4">
+        <DialogClose id="animateButton" className="form-submit-button pl-2 py-2 pr-[1rem]">
+          <>Close</>
+        </DialogClose>
+      </div>
+    </div>
+  );
+
+  return (
+    <div>
+      <DialogContent className="max-w-[30rem]">
+        <DialogTitle>Timer</DialogTitle>
+        <div className="grid rounded-md px-4 py-2">
+          {isOwned ? renderOwned() : renderView()}
+        </div>
+      </DialogContent>
+    </div>
+  );
+};
+
+export default TimerModal;


### PR DESCRIPTION
## Summary
- add modal to configure or view post expiration
- update timer button to open the modal
- pass expiration info to PostCard and ThreadCard

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_685f73e28dfc8329933dbe965198f1ed