### PR TITLE
Add recommendations API and explore page

### DIFF
--- a/app/(root)/(standard)/explore/page.tsx
+++ b/app/(root)/(standard)/explore/page.tsx
@@ -1,0 +1,68 @@
+import UserCard from "@/components/cards/UserCard";
+import Image from "next/image";
+import Link from "next/link";
+import { fetchRecommendations } from "@/lib/actions/recommendation.actions";
+import { getUserFromCookies } from "@/lib/serverutils";
+import { redirect } from "next/navigation";
+
+export const metadata = {
+  title: "Explore",
+  description: "Discover new users and rooms",
+};
+
+export default async function Page() {
+  const user = await getUserFromCookies();
+  if (!user?.onboarded) redirect("/onboarding");
+  if (!user.userId) redirect("/login");
+  const { users, rooms } = await fetchRecommendations({ userId: user.userId });
+
+  return (
+    <section>
+      <h1 className="head-text mb-10">Explore</h1>
+
+      <h2 className="text-heading2-semibold mb-3">People you may like</h2>
+      <div className="flex flex-col gap-4">
+        {users.length === 0 ? (
+          <p className="no-result">No suggestions</p>
+        ) : (
+          users.map((u) => (
+            <UserCard
+              key={u.id.toString()}
+              userId={u.id}
+              name={u.name || ""}
+              username={u.username}
+              imgUrl={u.image}
+              personType="User"
+            />
+          ))
+        )}
+      </div>
+
+      <h2 className="text-heading2-semibold mb-3 mt-8">Rooms to join</h2>
+      <div className="flex flex-col gap-3">
+        {rooms.length === 0 ? (
+          <p className="no-result">No rooms</p>
+        ) : (
+          rooms.map((r) => (
+            <Link
+              key={r.id}
+              href={`/room/${r.id}`}
+              className="leftsidebar_link leftsidebar-item rounded-md hover:outline-2 hover:outline-double hover:outline-indigo-400"
+            >
+              <div className="rounded_icon_container shadow-sm shadow-black h-6 w-6">
+                <Image
+                  src={r.room_icon}
+                  alt={r.id}
+                  width={48}
+                  height={48}
+                  className="object-contain"
+                />
+              </div>
+              <p className="text-black tracking-[.05rem] max-lg:hidden">{r.id}</p>
+            </Link>
+          ))
+        )}
+      </div>
+    </section>
+  );
+}

--- a/app/api/recommendations/route.ts
+++ b/app/api/recommendations/route.ts
@@ -1,0 +1,18 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getUserFromCookies } from "@/lib/serverutils";
+import { fetchRecommendations } from "@/lib/actions/recommendation.actions";
+
+export async function GET(req: NextRequest) {
+  const user = await getUserFromCookies();
+  if (!user || !user.userId) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 403 });
+  }
+  const limitUsers = parseInt(req.nextUrl.searchParams.get("users") || "7", 10);
+  const limitRooms = parseInt(req.nextUrl.searchParams.get("rooms") || "5", 10);
+  const data = await fetchRecommendations({
+    userId: user.userId,
+    limitUsers,
+    limitRooms,
+  });
+  return NextResponse.json(data);
+}

--- a/lib/actions/recommendation.actions.ts
+++ b/lib/actions/recommendation.actions.ts
@@ -1,0 +1,110 @@
+"use server";
+
+import { prisma } from "../prismaclient";
+import { Prisma } from "@prisma/client";
+
+export interface RecommendedUser {
+  id: bigint;
+  name: string | null;
+  username: string;
+  image: string | null;
+  score: number;
+}
+
+export interface RecommendedRoom {
+  id: string;
+  room_icon: string;
+  score: number;
+}
+
+interface RecommendationParams {
+  userId: bigint;
+  limitUsers?: number;
+  limitRooms?: number;
+}
+
+export async function fetchRecommendations({
+  userId,
+  limitUsers = 7,
+  limitRooms = 5,
+}: RecommendationParams) {
+  await prisma.$connect();
+  const base = await prisma.userAttributes.findUnique({
+    where: { user_id: userId },
+  });
+  if (!base) return { users: [] as RecommendedUser[], rooms: [] as RecommendedRoom[] };
+
+  const others = await prisma.userAttributes.findMany({
+    where: { user_id: { not: userId } },
+    include: { user: true },
+  });
+
+  const intersection = (a: string[], b: string[]) => a.filter((v) => b.includes(v));
+
+  const calcScore = (a: typeof base, b: typeof base) => {
+    let score = 0;
+    const fields: (keyof typeof base)[] = [
+      "artists",
+      "albums",
+      "songs",
+      "interests",
+      "movies",
+      "books",
+      "hobbies",
+      "communities",
+    ];
+    for (const field of fields) {
+      const arrA = (a as any)[field] as string[];
+      const arrB = (b as any)[field] as string[];
+      score += intersection(arrA || [], arrB || []).length;
+    }
+    if (a.location && b.location && a.location === b.location) score += 1;
+    return score;
+  };
+
+  const scored = others
+    .map((o) => ({
+      score: calcScore(base, o),
+      user: o.user,
+    }))
+    .filter((s) => s.score > 0)
+    .sort((a, b) => b.score - a.score)
+    .slice(0, limitUsers);
+
+  const users: RecommendedUser[] = scored.map((s) => ({
+    id: s.user.id,
+    name: s.user.name,
+    username: s.user.username,
+    image: s.user.image,
+    score: s.score,
+  }));
+
+  const memberships = await prisma.userRealtimeRoom.findMany({
+    where: {
+      user_id: { in: users.map((u) => u.id) },
+    },
+    include: { realtime_room: true },
+  });
+
+  const roomScores = new Map<string, RecommendedRoom>();
+  for (const m of memberships) {
+    const match = users.find((u) => u.id === m.user_id);
+    if (!match) continue;
+    const current = roomScores.get(m.realtime_room_id);
+    if (current) {
+      current.score += match.score;
+    } else {
+      roomScores.set(m.realtime_room_id, {
+        id: m.realtime_room_id,
+        room_icon: m.realtime_room.room_icon,
+        score: match.score,
+      });
+    }
+  }
+
+  const rooms = Array.from(roomScores.values())
+    .sort((a, b) => b.score - a.score)
+    .slice(0, limitRooms);
+
+  return { users, rooms };
+}


### PR DESCRIPTION
## Summary
- compute user similarity in `fetchRecommendations`
- expose `/api/recommendations` endpoint
- show recommended users and rooms on new Explore page

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_686053368d2883298beba18318deb961