### PR TITLE
Add onboarding customization flow

### DIFF
--- a/app/(auth)/onboarding/onboarding-flow.tsx
+++ b/app/(auth)/onboarding/onboarding-flow.tsx
@@ -1,0 +1,56 @@
+"use client";
+
+import { useState } from "react";
+import { UserAttributes } from "@prisma/client";
+import AccountProfile from "@/components/forms/AccountProfile";
+import CustomButtons from "@/app/(root)/(standard)/profile/[id]/customize/customize-components";
+import { useRouter } from "next/navigation";
+
+interface UserData {
+  authId: string;
+  userId: bigint | null;
+  username: string;
+  name: string;
+  bio: string | null;
+  image: string | null;
+}
+
+interface Props {
+  userData: UserData;
+  userAttributes: UserAttributes;
+}
+
+export default function OnboardingFlow({ userData, userAttributes }: Props) {
+  const [step, setStep] = useState<"profile" | "customize">("profile");
+  const router = useRouter();
+
+  const handleProfileComplete = () => {
+    setStep("customize");
+  };
+
+  const finishOnboarding = () => {
+    router.push("/room/global");
+  };
+
+  return (
+    <main className="mx-auto flex max-w-3xl flex-col justify-center items-center px-10 py-10 text-black">
+      {step === "profile" && (
+        <>
+          <h1 className="head-text">Edit Your Profile</h1>
+          <section className="postcard mt-5 bg-white bg-opacity-20 p-10 text-black">
+            <AccountProfile user={userData} btnTitle="Continue" onSuccess={handleProfileComplete} />
+          </section>
+        </>
+      )}
+      {step === "customize" && (
+        <>
+          <h1 className="head-text">Customize Profile</h1>
+          <CustomButtons userAttributes={userAttributes} initialOpen />
+          <button onClick={finishOnboarding} className="mt-8 bg-white px-5 py-2 rounded-md">
+            Finish
+          </button>
+        </>
+      )}
+    </main>
+  );
+}

--- a/app/(auth)/onboarding/page.tsx
+++ b/app/(auth)/onboarding/page.tsx
@@ -1,5 +1,7 @@
-import AccountProfile from "@/components/forms/AccountProfile";
 import { getUserFromCookies } from "@/lib/serverutils";
+import { fetchUserAttributes } from "@/lib/actions/userattributes.actions";
+import { UserAttributes } from "@prisma/client";
+import OnboardingFlow from "./onboarding-flow";
 
 async function Page() {
   const user = await getUserFromCookies();
@@ -13,16 +15,9 @@ async function Page() {
     bio: user.bio || "",
     image: user?.photoURL || "",
   };
-  return (
-    <main className="mx-auto flex max-w-3xl flex-col justify-center items-center px-10 py-10 text-black">
-      <h1 className="head-text">Edit Your Profile</h1>
-      {/* <p className="mt-3 text-base-regular text-light-2">
-        Complete your profile now to use mesh
-      </p> */}
-      <section className="postcard mt-5 bg-white bg-opacity-20 p-10 text-black">
-        <AccountProfile user={userData} btnTitle="Continue" />
-      </section>
-    </main>
-  );
+  const userAttributes =
+    (await fetchUserAttributes({ userId: user.userId! })) || ({} as UserAttributes);
+
+  return <OnboardingFlow userData={userData} userAttributes={userAttributes} />;
 }
 export default Page;

--- a/app/(root)/(standard)/profile/[id]/customize/customize-components.tsx
+++ b/app/(root)/(standard)/profile/[id]/customize/customize-components.tsx
@@ -26,13 +26,14 @@ import { useState } from "react";
 
 interface Props {
   userAttributes: UserAttributes;
+  initialOpen?: boolean;
 }
 
-export default function CustomButtons({ userAttributes }: Props) {
+export default function CustomButtons({ userAttributes, initialOpen }: Props) {
   const [isAboutOpen, setAboutOpen] = useState(false);
   const [isBirthdayOpen, setBirthdayOpen] = useState(false);
   const [isLocationOpen, setLocationOpen] = useState(false);
-  const [isInterestsOpen, setInterestsOpen] = useState(false);
+  const [isInterestsOpen, setInterestsOpen] = useState(initialOpen || false);
   const [isHobbiesOpen, setHobbiesOpen] = useState(false);
   const [isCommunitiesOpen, setCommunitiesOpen] = useState(false);
   const [isEventsOpen, setEventsOpen] = useState(false);

--- a/components/forms/AccountProfile.tsx
+++ b/components/forms/AccountProfile.tsx
@@ -34,9 +34,10 @@ interface Props {
     image: string | null;
   };
   btnTitle: string;
+  onSuccess?: () => void | Promise<void>;
 }
 
-const AccountProfile = ({ user, btnTitle }: Props) => {
+const AccountProfile = ({ user, btnTitle, onSuccess }: Props) => {
   const pathname = usePathname();
   const router = useRouter();
   const [files, setFiles] = useState<File[]>([]);
@@ -93,7 +94,9 @@ const AccountProfile = ({ user, btnTitle }: Props) => {
       path: pathname,
     });
 
-    if (pathname === "/profile/edit") {
+    if (onSuccess) {
+      await onSuccess();
+    } else if (pathname === "/profile/edit") {
       router.back();
     } else {
       await joinRoom({ roomId: "global" });


### PR DESCRIPTION
## Summary
- introduce `OnboardingFlow` client component to show profile form then customization dialogs
- open Interests dialog automatically in `CustomButtons`
- allow `AccountProfile` to call optional `onSuccess`
- integrate new flow in auth onboarding page

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_686053398d9483299cae2fa90934636f