### PR TITLE
Fix Hobbies modal overlay

### DIFF
--- a/app/(root)/(standard)/profile/[id]/customize/customize-components.tsx
+++ b/app/(root)/(standard)/profile/[id]/customize/customize-components.tsx
@@ -265,9 +265,6 @@ export default function CustomButtons({ userAttributes, initialOpen }: Props) {
                 Close
               </DialogClose>
             </div>
-            <div className="overlay w-full bg-white h-full text-center align-middle	 font-bold text-black">
-              {"UNDER CONSTRUCTION"}
-            </div>
           </DialogContent>
         </Dialog>
 


### PR DESCRIPTION
## Summary
- remove overlay from Hobbies modal so FancyMultiSelect is usable

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68605ccc689c83298d50747b234614fb