### PR TITLE
Implement communities modal

### DIFF
--- a/app/(root)/(standard)/profile/[id]/customize/customize-components.tsx
+++ b/app/(root)/(standard)/profile/[id]/customize/customize-components.tsx
@@ -14,6 +14,7 @@ import {
   fetchAlbums,
   fetchArtists,
   fetchInterests,
+  fetchCommunities,
   addInterest,
   fetchMovies,
   fetchBooks,
@@ -286,7 +287,15 @@ export default function CustomButtons({ userAttributes, initialOpen }: Props) {
             <hr />
 
             <div className="bg-black border border-white rounded-md px-3 pt-6  pb-16  mt-3 mb-3 ">
-              {/* <FancyMultiSelect /> */}
+              <FancyMultiSelect
+                fetchMultiselectData={fetchCommunities}
+                initialSelected={convertListToSelectables(
+                  userAttributes.communities
+                )}
+                submitEdits={(selectables) =>
+                  submitEdits("COMMUNITIES", selectables, userAttributes, path)
+                }
+              />
             </div>
             <hr />
             <div className="flex gap-4 mb-2 mt-2">
@@ -304,9 +313,6 @@ export default function CustomButtons({ userAttributes, initialOpen }: Props) {
               >
                 Close
               </DialogClose>
-            </div>
-            <div className="overlay w-full bg-white h-full text-center align-middle	 font-bold text-black">
-              {"UNDER CONSTRUCTION"}
             </div>
           </DialogContent>
         </Dialog>

--- a/lib/MultiSelectFunctions.ts
+++ b/lib/MultiSelectFunctions.ts
@@ -46,6 +46,28 @@ export const interestList: OptionType[] = [
   { value: "swimming", label: "Swimming" },
 ];
 
+export const communityList: OptionType[] = [
+  { value: "photography_club", label: "Photography Club" },
+  { value: "book_club", label: "Book Club" },
+  { value: "sports_fans", label: "Sports Fans" },
+  { value: "gaming", label: "Gaming" },
+  { value: "yoga_group", label: "Yoga Group" },
+  { value: "running_club", label: "Running Club" },
+  { value: "cooking", label: "Cooking" },
+  { value: "chess_club", label: "Chess Club" },
+  { value: "writers", label: "Writers" },
+  { value: "artists", label: "Artists" },
+  { value: "musicians", label: "Musicians" },
+  { value: "parents", label: "Parents" },
+  { value: "travelers", label: "Travelers" },
+  { value: "foodies", label: "Foodies" },
+  { value: "film_buff", label: "Film Buffs" },
+  { value: "startups", label: "Startups" },
+  { value: "open_source", label: "Open Source" },
+  { value: "nature_conservation", label: "Nature Conservation" },
+  { value: "volunteers", label: "Volunteers" },
+];
+
 export function addInterest(label: string): OptionType {
   const value = label.toLowerCase().replace(/\s+/g, "_");
   let option = interestList.find(
@@ -226,6 +248,12 @@ export async function fetchInterests(query: string): Promise<OptionType[]> {
   );
 }
 
+export async function fetchCommunities(query: string): Promise<OptionType[]> {
+  return communityList.filter((community) =>
+    community.label.toLowerCase().includes(query.toLowerCase())
+  );
+}
+
 export function convertListToSelectables(interests?: string[]) {
   if (!interests || interests.length === 0) {
     return [] as OptionType[];
@@ -251,7 +279,8 @@ export function submitEdits(
     | "MOVIES"
     | "TRACKS"
     | "ARTISTS"
-    | "BOOKS",
+    | "BOOKS"
+    | "COMMUNITIES",
   selectables: OptionType[],
   userAttributes: UserAttributes,
   path: string
@@ -310,6 +339,14 @@ export function submitEdits(
         userAttributes: {
           ...userAttributes,
           artists: convertSelectablesToList(selectables),
+        },
+        path,
+      });
+    case "COMMUNITIES":
+      return upsertUserAttributes({
+        userAttributes: {
+          ...userAttributes,
+          communities: convertSelectablesToList(selectables),
         },
         path,
       });


### PR DESCRIPTION
## Summary
- add `communityList` and `fetchCommunities` utilities
- support `COMMUNITIES` in `submitEdits`
- hook up communities modal with a `FancyMultiSelect`

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68605ccd053483299e6013e7f9f4f31a