### PR TITLE
Add user attribute search endpoint

### DIFF
--- a/app/api/user-attributes/search/route.ts
+++ b/app/api/user-attributes/search/route.ts
@@ -1,0 +1,21 @@
+import { NextRequest, NextResponse } from "next/server";
+import { searchUsersByAttributes } from "@/lib/actions/userattributes.actions";
+
+export async function GET(req: NextRequest) {
+  const params = req.nextUrl.searchParams;
+  const getAll = (key: string) => params.getAll(key);
+  const base = {
+    artists: getAll("artists"),
+    albums: getAll("albums"),
+    songs: getAll("songs"),
+    interests: getAll("interests"),
+    movies: getAll("movies"),
+    books: getAll("books"),
+    hobbies: getAll("hobbies"),
+    communities: getAll("communities"),
+    location: params.get("location") || undefined,
+  };
+  const limit = parseInt(params.get("limit") || "10", 10);
+  const users = await searchUsersByAttributes({ base, limit });
+  return NextResponse.json(users);
+}


### PR DESCRIPTION
## Summary
- implement `searchUsersByAttributes` action to compare user attributes
- add `/api/user-attributes/search` route for attribute based queries

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_686060c8739c83298149eadadcc4efba