### PR TITLE
Fix Dockerfile build error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,9 @@
-   FROM node:20
-   WORKDIR /app
-   COPY package.json yarn.lock ./
-   RUN yarn install --frozen-lockfile
-   COPY . .
+FROM node:20
+WORKDIR /app
+
+COPY package.json yarn.lock ./
+COPY lib/models/schema.prisma ./lib/models/
+
+RUN yarn install --frozen-lockfile
+
+COPY . .


### PR DESCRIPTION
## Summary
- ensure `prisma generate` can find the schema during `yarn install`

## Testing
- `npm run lint`
- `docker build -t my-mesh-image .` *(fails: `docker: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_686068c562ec8329a4e341a3118cc5ee