### PR TITLE
Add deepseek friend suggestions

### DIFF
--- a/app/api/suggested-friends/route.ts
+++ b/app/api/suggested-friends/route.ts
@@ -1,0 +1,12 @@
+import { NextResponse } from "next/server";
+import { getUserFromCookies } from "@/lib/serverutils";
+import { fetchFriendSuggestions } from "@/lib/actions/friend-suggestions.actions";
+
+export async function GET() {
+  const user = await getUserFromCookies();
+  if (!user?.userId) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 403 });
+  }
+  const suggestions = await fetchFriendSuggestions(user.userId);
+  return NextResponse.json(suggestions);
+}

--- a/components/shared/RightSidebar.tsx
+++ b/components/shared/RightSidebar.tsx
@@ -4,20 +4,21 @@ import { Button } from "@/components/ui/button";
 import Link from "next/link";
 import { useEffect, useState } from "react";
 
-interface RandomUser {
+interface SuggestedUser {
   id: number;
-  name: string;
+  name: string | null;
   username: string;
   image: string | null;
+  score?: number;
 }
 
 function RightSidebar() {
-  const [users, setUsers] = useState<RandomUser[]>([]);
+  const [users, setUsers] = useState<SuggestedUser[]>([]);
 
   useEffect(() => {
     async function load() {
       try {
-        const res = await fetch("/api/random-users");
+        const res = await fetch("/api/suggested-friends");
         if (res.ok) {
           const data = await res.json();
           setUsers(data);

--- a/lib/actions/friend-suggestions.actions.ts
+++ b/lib/actions/friend-suggestions.actions.ts
@@ -1,0 +1,77 @@
+"use server";
+
+import { prisma } from "../prismaclient";
+import { deepseekEmbedding } from "../deepseekclient";
+
+function cosineSimilarity(a: number[], b: number[]) {
+  const dot = a.reduce((sum, val, i) => sum + val * b[i], 0);
+  const normA = Math.sqrt(a.reduce((sum, val) => sum + val * val, 0));
+  const normB = Math.sqrt(b.reduce((sum, val) => sum + val * val, 0));
+  return dot / (normA * normB);
+}
+
+export async function updateUserEmbedding(userId: bigint) {
+  await prisma.$connect();
+  const attrs = await prisma.userAttributes.findUnique({
+    where: { user_id: userId },
+  });
+  if (!attrs) return;
+  const desc = [
+    attrs.interests.join(" "),
+    attrs.hobbies.join(" "),
+    attrs.artists.join(" "),
+    attrs.albums.join(" "),
+    attrs.movies.join(" "),
+    attrs.books.join(" "),
+    attrs.communities.join(" "),
+  ].join(" \n");
+  const embedding = await deepseekEmbedding(desc);
+  await prisma.userEmbedding.upsert({
+    where: { user_id: userId },
+    update: { embedding },
+    create: { user_id: userId, embedding },
+  });
+}
+
+export async function generateFriendSuggestions(userId: bigint) {
+  await prisma.$connect();
+  const base = await prisma.userEmbedding.findUnique({ where: { user_id: userId } });
+  if (!base) return [];
+  const others = await prisma.userEmbedding.findMany({ where: { user_id: { not: userId } } });
+  if (others.length === 0) return [];
+  const sample = others.sort(() => Math.random() - 0.5).slice(0, 20);
+  const scored = sample.map((o) => ({
+    id: o.user_id,
+    score: cosineSimilarity(base.embedding, o.embedding),
+  }));
+  scored.sort((a, b) => b.score - a.score);
+  const top = scored.slice(0, 5);
+  await prisma.friendSuggestion.deleteMany({ where: { user_id: userId } });
+  for (const s of top) {
+    await prisma.friendSuggestion.create({
+      data: {
+        user_id: userId,
+        suggested_user_id: s.id,
+        score: s.score,
+      },
+    });
+  }
+  return top;
+}
+
+export async function fetchFriendSuggestions(userId: bigint) {
+  await prisma.$connect();
+  const suggestions = await prisma.friendSuggestion.findMany({
+    where: { user_id: userId },
+    include: { suggestedUser: true },
+    orderBy: { score: "desc" },
+    take: 5,
+  });
+  return suggestions.map((s) => ({
+    id: s.suggested_user_id,
+    name: s.suggestedUser.name,
+    username: s.suggestedUser.username,
+    image: s.suggestedUser.image,
+    score: s.score,
+  }));
+}

--- a/lib/deepseekclient.ts
+++ b/lib/deepseekclient.ts
@@ -1,0 +1,19 @@
+export async function deepseekEmbedding(input: string) {
+  const apiKey = process.env.DEEPSEEK_API_KEY;
+  if (!apiKey) throw new Error("Missing DEEPSEEK_API_KEY");
+  const res = await fetch("https://api.deepseek.com/v1/embeddings", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${apiKey}`,
+    },
+    body: JSON.stringify({
+      input,
+    }),
+  });
+  if (!res.ok) {
+    throw new Error(`Deepseek error: ${res.status}`);
+  }
+  const data = await res.json();
+  return data.embedding as number[];
+}

--- a/lib/models/schema.prisma
+++ b/lib/models/schema.prisma
@@ -233,3 +233,25 @@ model ArchivedPost {
 
   @@map("archived_posts")
 }
+
+model UserEmbedding {
+  user_id   BigInt   @id
+  user      User     @relation(fields: [user_id], references: [id], onDelete: Cascade)
+  embedding Float[]
+  updated_at DateTime @default(now()) @updatedAt @db.Timestamptz(6)
+
+  @@map("user_embeddings")
+}
+
+model FriendSuggestion {
+  id               BigInt   @id @default(autoincrement())
+  user_id          BigInt
+  suggested_user_id BigInt
+  score            Float
+  created_at       DateTime @default(now()) @db.Timestamptz(6)
+  user             User     @relation("SuggestionsCreator", fields: [user_id], references: [id], onDelete: Cascade)
+  suggestedUser    User     @relation("SuggestionsTarget", fields: [suggested_user_id], references: [id], onDelete: Cascade)
+
+  @@unique([user_id, suggested_user_id])
+  @@map("friend_suggestions")
+}


### PR DESCRIPTION
## Summary
- add `UserEmbedding` and `FriendSuggestion` models
- integrate DeepSeek via `deepseekEmbedding`
- implement friend suggestion actions
- expose `/api/suggested-friends` endpoint
- update `RightSidebar` to load suggested friends

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68607b7e822883299d6236b000807668