### PR TITLE
Trigger friend suggestions on attribute update

### DIFF
--- a/lib/actions/userattributes.actions.ts
+++ b/lib/actions/userattributes.actions.ts
@@ -4,6 +4,10 @@ import { Prisma, realtime_post_type, UserAttributes } from "@prisma/client";
 import { prisma } from "../prismaclient";
 import { revalidatePath } from "next/cache";
 import { getUserFromCookies } from "@/lib/serverutils";
+import {
+  updateUserEmbedding,
+  generateFriendSuggestions,
+} from "./friend-suggestions.actions";
 
 export interface UpsertUserAttributes {
   userAttributes: UserAttributes;
@@ -98,6 +102,8 @@ export async function upsertUserAttributes({
         },
       },
     });
+    await updateUserEmbedding(user.userId!);
+    await generateFriendSuggestions(user.userId!);
     revalidatePath(path);
   } catch (error: any) {
     throw new Error(`Failed to upsert user attributes: ${error.message}`);

--- a/tests/upsertUserAttributes.test.ts
+++ b/tests/upsertUserAttributes.test.ts
@@ -1,0 +1,12 @@
+import fs from "fs";
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+const file = fs.readFileSync("lib/actions/userattributes.actions.ts", "utf8");
+
+// Simple check that the update functions are called in upsertUserAttributes
+
+test("upsertUserAttributes triggers friend suggestions", () => {
+  assert.ok(file.includes("updateUserEmbedding"));
+  assert.ok(file.includes("generateFriendSuggestions"));
+});


### PR DESCRIPTION
## Summary
- invoke friend suggestion updates when user attributes change
- add minimal test to ensure calls are present

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68607f8df32c8329af58d3648972dd95