### PR TITLE
Add friend suggestion debug info

### DIFF
--- a/components/shared/RightSidebar.tsx
+++ b/components/shared/RightSidebar.tsx
@@ -10,6 +10,7 @@ interface SuggestedUser {
   username: string;
   image: string | null;
   score?: number;
+  overlap?: Record<string, string[]>;
 }
 
 function RightSidebar() {
@@ -21,6 +22,7 @@ function RightSidebar() {
         const res = await fetch("/api/suggested-friends");
         if (res.ok) {
           const data = await res.json();
+          console.log("suggestions", data);
           setUsers(data);
         }
       } catch (e) {
@@ -51,6 +53,11 @@ function RightSidebar() {
             <Link key={u.id} href={`/profile/${u.id}`}>
               <Button className="w-full rounded-md rightsidebar-item border-none">
                 {u.name}
+                {u.score !== undefined && (
+                  <span className="ml-2 text-xs text-gray-600">
+                    {u.score.toFixed(2)}
+                  </span>
+                )}
               </Button>
             </Link>
           ))}


### PR DESCRIPTION
## Summary
- show friend suggestion overlap and scores via `fetchFriendSuggestions`
- log and display similarity scores in `RightSidebar`

## Testing
- `yarn lint`

------
https://chatgpt.com/codex/tasks/task_e_6860806d1e0083299a5958c3e60d3c90