### PR TITLE
Add friend suggestion cron script

### DIFF
--- a/lib/actions/userattributes.actions.ts
+++ b/lib/actions/userattributes.actions.ts
@@ -4,6 +4,10 @@ import { Prisma, realtime_post_type, UserAttributes } from "@prisma/client";
 import { prisma } from "../prismaclient";
 import { revalidatePath } from "next/cache";
 import { getUserFromCookies } from "@/lib/serverutils";
+import {
+  updateUserEmbedding,
+  generateFriendSuggestions,
+} from "@/lib/actions/friend-suggestions.actions";
 
 export interface UpsertUserAttributes {
   userAttributes: UserAttributes;
@@ -99,6 +103,8 @@ export async function upsertUserAttributes({
       },
     });
     revalidatePath(path);
+    await updateUserEmbedding(user.userId!);
+    await generateFriendSuggestions(user.userId!);
   } catch (error: any) {
     throw new Error(`Failed to upsert user attributes: ${error.message}`);
   }

--- a/scripts/friend-suggestions-cron.ts
+++ b/scripts/friend-suggestions-cron.ts
@@ -1,0 +1,24 @@
+import { prisma } from "../lib/prismaclient";
+import { generateFriendSuggestions, updateUserEmbedding } from "../lib/actions/friend-suggestions.actions";
+
+async function run() {
+  await prisma.$connect();
+  const users = await prisma.user.findMany({
+    where: { onboarded: true },
+    select: { id: true },
+  });
+
+  for (const user of users) {
+    await updateUserEmbedding(user.id);
+    await generateFriendSuggestions(user.id);
+  }
+}
+
+run()
+  .catch((err) => {
+    console.error(err);
+    process.exit(1);
+  })
+  .finally(async () => {
+    await prisma.$disconnect();
+  });


### PR DESCRIPTION
## Summary
- create `friend-suggestions-cron.ts` to refresh suggestions for onboarded users
- call `updateUserEmbedding` and `generateFriendSuggestions` when user attributes change

## Testing
- `yarn install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68608067ae7c832980b49122ec9eec12