### PR TITLE
Add fallback for deepseek embeddings

### DIFF
--- a/lib/deepseekclient.ts
+++ b/lib/deepseekclient.ts
@@ -1,19 +1,30 @@
+import { openai } from "./openaiclient";
+
 export async function deepseekEmbedding(input: string) {
-  const apiKey = process.env.DEEPSEEK_API_KEY;
-  if (!apiKey) throw new Error("Missing DEEPSEEK_API_KEY");
-  const res = await fetch("https://api.deepseek.com/v1/embeddings", {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-      Authorization: `Bearer ${apiKey}`,
-    },
-    body: JSON.stringify({
-      input,
-    }),
-  });
-  if (!res.ok) {
-    throw new Error(`Deepseek error: ${res.status}`);
+  try {
+    const apiKey = process.env.DEEPSEEK_API_KEY;
+    if (!apiKey) throw new Error("Missing DEEPSEEK_API_KEY");
+    const res = await fetch("https://api.deepseek.com/v1/embeddings", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${apiKey}`,
+      },
+      body: JSON.stringify({
+        input,
+      }),
+    });
+    if (res.ok) {
+      const data = await res.json();
+      return data.embedding as number[];
+    }
+  } catch (err) {
+    console.warn("Deepseek embedding failed", err);
   }
-  const data = await res.json();
-  return data.embedding as number[];
+
+  const resp = await openai.embeddings.create({
+    model: "text-embedding-3-small",
+    input,
+  });
+  return resp.data[0].embedding as number[];
 }


### PR DESCRIPTION
## Summary
- fallback to OpenAI embeddings when Deepseek fails

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_686099cdb3d88329bf18d2a0f59c0156