### PR TITLE
Handle missing user ID for attributes

### DIFF
--- a/app/(auth)/onboarding/page.tsx
+++ b/app/(auth)/onboarding/page.tsx
@@ -16,7 +16,8 @@ async function Page() {
     image: user?.photoURL || "",
   };
   const userAttributes =
-    (await fetchUserAttributes({ userId: user.userId! })) || ({} as UserAttributes);
+    (await fetchUserAttributes({ userId: user.userId ?? null })) ||
+    ({} as UserAttributes);
 
   return <OnboardingFlow userData={userData} userAttributes={userAttributes} />;
 }

--- a/app/(root)/(standard)/profile/[id]/customize/page.tsx
+++ b/app/(root)/(standard)/profile/[id]/customize/page.tsx
@@ -12,7 +12,7 @@ async function Page({ params }: { params: { id: string } }) {
   const profilePageUser = await fetchUser(BigInt(params.id));
   const userAttributes =
     (await fetchUserAttributes({
-      userId: activeUser.userId!,
+      userId: activeUser.userId ?? null,
     })) || ({} as UserAttributes);
   if (!profilePageUser?.onboarded) notFound();
   return (

--- a/lib/actions/userattributes.actions.ts
+++ b/lib/actions/userattributes.actions.ts
@@ -110,7 +110,12 @@ export async function upsertUserAttributes({
   }
 }
 
-export async function fetchUserAttributes({ userId }: { userId: bigint }) {
+export async function fetchUserAttributes({
+  userId,
+}: {
+  userId: bigint | null;
+}) {
+  if (!userId) return null;
   await prisma.$connect();
 
   const userAttributes = await prisma.userAttributes.findUnique({


### PR DESCRIPTION
## Summary
- avoid calling Prisma with null user IDs
- pass nullable IDs when fetching user attributes

## Testing
- `npm run lint`
- `npx jest` *(fails: "Your test suite must contain at least one test" and mock initialization errors)*

------
https://chatgpt.com/codex/tasks/task_e_6860c24a3468832997fa9b2904b64349