### PR TITLE
Fix global room join after onboarding

### DIFF
--- a/app/(auth)/onboarding/onboarding-flow.tsx
+++ b/app/(auth)/onboarding/onboarding-flow.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import { UserAttributes } from "@prisma/client";
 import AccountProfile from "@/components/forms/AccountProfile";
 import CustomButtons from "@/app/(root)/(standard)/profile/[id]/customize/customize-components";
+import { joinRoom } from "@/lib/actions/realtimeroom.actions";
 import { useRouter } from "next/navigation";
 
 interface UserData {
@@ -28,7 +29,8 @@ export default function OnboardingFlow({ userData, userAttributes }: Props) {
     setStep("customize");
   };
 
-  const finishOnboarding = () => {
+  const finishOnboarding = async () => {
+    await joinRoom({ roomId: "global" });
     router.push("/room/global");
   };
 


### PR DESCRIPTION
## Summary
- ensure onboarding joins the global room by calling `joinRoom` in `onboarding-flow`

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6861c19dbef88329831531011cdf7c06