### PR TITLE
Allow public gallery edits

### DIFF
--- a/components/forms/GalleryNodeForm.tsx
+++ b/components/forms/GalleryNodeForm.tsx
@@ -18,13 +18,14 @@ import { Input } from "../ui/input";
 interface Props {
   onSubmit: (values: z.infer<typeof GalleryPostValidation>) => void;
   currentImages: string[];
+  isOwned: boolean;
 }
 
-const GalleryNodeForm = ({ onSubmit, currentImages }: Props) => {
+const GalleryNodeForm = ({ onSubmit, currentImages, isOwned }: Props) => {
   const [imageURLs, setImageURLs] = useState<string[]>(currentImages);
   const form = useForm({
     resolver: zodResolver(GalleryPostValidation),
-    defaultValues: { images: [] as File[] },
+    defaultValues: { images: [] as File[], isPublic: false },
   });
 
   const handleImages = (
@@ -87,6 +88,25 @@ const GalleryNodeForm = ({ onSubmit, currentImages }: Props) => {
             </FormItem>
           )}
         />
+        {isOwned && (
+          <FormField
+            control={form.control}
+            name="isPublic"
+            render={({ field }) => (
+              <FormItem className="flex flex-row items-center gap-2 mb-4">
+                <FormLabel className="text-xl">Public</FormLabel>
+                <FormControl>
+                  <Input
+                    type="checkbox"
+                    checked={field.value}
+                    onChange={field.onChange}
+                  />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+        )}
         <Button type="submit" className="w-[100%] h-max image-submit-button mt-2">
           Submit
         </Button>

--- a/components/modals/GalleryNodeModal.tsx
+++ b/components/modals/GalleryNodeModal.tsx
@@ -12,6 +12,7 @@ import Image from "next/image";
 interface Props {
   id?: string;
   isOwned: boolean;
+  isPublic: boolean;
   onSubmit?: (values: z.infer<typeof GalleryPostValidation>) => void;
   currentImages: string[];
 }
@@ -22,17 +23,17 @@ const renderCreate = ({ onSubmit }: { onSubmit?: (values: z.infer<typeof Gallery
       <b>Create Gallery</b>
     </DialogHeader>
     <hr />
-    <GalleryNodeForm onSubmit={onSubmit!} currentImages={[]} />
+    <GalleryNodeForm onSubmit={onSubmit!} currentImages={[]} isOwned={true} />
   </div>
 );
 
-const renderEdit = ({ onSubmit, currentImages }: { onSubmit?: (values: z.infer<typeof GalleryPostValidation>) => void; currentImages: string[] }) => (
+const renderEdit = ({ onSubmit, currentImages, isOwned }: { onSubmit?: (values: z.infer<typeof GalleryPostValidation>) => void; currentImages: string[]; isOwned: boolean }) => (
   <div>
     <DialogHeader className="dialog-header text-white text-lg py-4 mt-[-4rem]">
       <b>Edit Gallery</b>
     </DialogHeader>
     <hr />
-    <GalleryNodeForm onSubmit={onSubmit!} currentImages={currentImages} />
+    <GalleryNodeForm onSubmit={onSubmit!} currentImages={currentImages} isOwned={isOwned} />
   </div>
 );
 
@@ -56,17 +57,17 @@ const renderView = (images: string[]) => (
   </div>
 );
 
-const GalleryNodeModal = ({ id, isOwned, onSubmit, currentImages }: Props) => {
+const GalleryNodeModal = ({ id, isOwned, isPublic, onSubmit, currentImages }: Props) => {
   const isCreate = !id && isOwned;
-  const isEdit = id && isOwned;
-  const isView = id && !isOwned;
+  const isEdit = id && (isOwned || isPublic);
+  const isView = id && !isOwned && !isPublic;
   return (
     <div>
       <DialogContent className="max-w-[57rem]">
         <DialogTitle>GalleryNodeModal</DialogTitle>
         <div className="grid rounded-md px-4 py-2">
           {isCreate && renderCreate({ onSubmit })}
-          {isEdit && renderEdit({ onSubmit, currentImages })}
+          {isEdit && renderEdit({ onSubmit, currentImages, isOwned })}
           {isView && renderView(currentImages)}
         </div>
       </DialogContent>

--- a/components/nodes/GalleryNode.tsx
+++ b/components/nodes/GalleryNode.tsx
@@ -34,6 +34,7 @@ function GalleryNode({ id, data }: NodeProps<GalleryNodeData>) {
   const isOwned = currentActiveUser
     ? Number(currentActiveUser.userId) === Number(data.author.id)
     : false;
+  const isPublic = data.isPublic;
 
   async function onGallerySubmit(values: z.infer<typeof GalleryPostValidation>) {
     const uploads = await Promise.all(
@@ -50,6 +51,7 @@ function GalleryNode({ id, data }: NodeProps<GalleryNodeData>) {
         path,
         imageUrl: urls[0],
         text: JSON.stringify(urls),
+        ...(isOwned && { isPublic: values.isPublic }),
       });
     }
     store.closeModal();
@@ -70,6 +72,7 @@ function GalleryNode({ id, data }: NodeProps<GalleryNodeData>) {
         <GalleryNodeModal
           id={id}
           isOwned={isOwned}
+          isPublic={isPublic}
           currentImages={images}
           onSubmit={onGallerySubmit}
         />

--- a/components/shared/NodeSidebar.tsx
+++ b/components/shared/NodeSidebar.tsx
@@ -207,6 +207,7 @@ export default function NodeSidebar({
         store.openModal(
           <GalleryNodeModal
             isOwned={true}
+            isPublic={false}
             currentImages={[]}
             onSubmit={async (vals) => {
               const uploads = await Promise.all(
@@ -221,6 +222,7 @@ export default function NodeSidebar({
                   coordinates: centerPosition,
                   type: "GALLERY",
                   realtimeRoomId: roomId,
+                  isPublic: vals.isPublic,
                   imageUrl: urls[0],
                   text: JSON.stringify(urls),
                 });

--- a/lib/actions/realtimepost.actions.ts
+++ b/lib/actions/realtimepost.actions.ts
@@ -13,6 +13,7 @@ export interface CreateRealtimePostParams {
   coordinates: { x: number; y: number };
   type: realtime_post_type;
   realtimeRoomId: string;
+  isPublic?: boolean;
   collageLayoutStyle?: string;  // or some enum
   collageColumns?: number;
   collageGap?: number;
@@ -25,6 +26,7 @@ interface UpdateRealtimePostParams {
   videoUrl?: string;
   coordinates?: { x: number; y: number };
   path: string;
+  isPublic?: boolean;
   collageLayoutStyle?: string;  // or some enum
   collageColumns?: number;
   collageGap?: number;
@@ -38,6 +40,7 @@ export async function createRealtimePost({
   coordinates,
   type,
   realtimeRoomId,
+  isPublic = false,
    //  collage fields
    collageLayoutStyle,
    collageColumns,
@@ -61,6 +64,7 @@ export async function createRealtimePost({
         type,
         realtime_room_id: realtimeRoomId,
         locked: false,
+        isPublic,
 
          // Collage fields
          ...(collageLayoutStyle && { collageLayoutStyle }),
@@ -100,6 +104,7 @@ export async function updateRealtimePost({
   imageUrl,
   coordinates,
   path,
+  isPublic,
   //  <-- Add these lines
   collageLayoutStyle,
   collageColumns,
@@ -114,7 +119,16 @@ export async function updateRealtimePost({
       },
     });
     if (user!.userId != originalPost!.author_id) {
-      if (text || videoUrl || imageUrl) {
+      if (!originalPost.isPublic) {
+        throw new Error(`User is not allowed to update this post`);
+      }
+      if (
+        coordinates ||
+        isPublic !== undefined ||
+        collageLayoutStyle ||
+        collageColumns !== undefined ||
+        collageGap !== undefined
+      ) {
         throw new Error(`User is not allowed to update this post`);
       }
     }
@@ -132,6 +146,7 @@ export async function updateRealtimePost({
         ...(collageLayoutStyle && { collageLayoutStyle }),
         ...(collageColumns !== undefined && { collageColumns }),
         ...(collageGap !== undefined && { collageGap }),
+        ...(isPublic !== undefined && { isPublic }),
 
         ...(coordinates && {
           x_coordinate: new Prisma.Decimal(coordinates.x),

--- a/lib/models/schema.prisma
+++ b/lib/models/schema.prisma
@@ -143,6 +143,7 @@ model RealtimePost {
   realtimeroom       RealtimeRoom       @relation(fields: [realtime_room_id], references: [id])
   realtime_room_id   String
   locked             Boolean
+  isPublic           Boolean        @default(false)
   collageLayoutStyle String? // "grid", "bento", "scrapbook"
   collageColumns     Int?
   collageGap         Int?

--- a/lib/reactflow/reactflowutils.ts
+++ b/lib/reactflow/reactflowutils.ts
@@ -150,6 +150,7 @@ export function convertPostToNode(
             images: galleryImages,
             author: authorToSet,
             locked: realtimePost.locked,
+            isPublic: (realtimePost as any).isPublic ?? false,
           },
           position: {
             x: realtimePost.x_coordinate,

--- a/lib/reactflow/types.ts
+++ b/lib/reactflow/types.ts
@@ -80,6 +80,7 @@ export type GalleryNodeData = Node<
     images: string[];
     author: AuthorOrAuthorId;
     locked: boolean;
+    isPublic: boolean;
     layoutStyle?: string;
     columns?: number;
     gap?: number;

--- a/lib/validations/thread.ts
+++ b/lib/validations/thread.ts
@@ -55,6 +55,7 @@ export const GalleryPostValidation = z.object({
         )
     )
     .min(1),
+  isPublic: z.boolean().optional(),
 });
 export const CommentValidation = z.object({
   thread: z.string().min(3, { message: "Minimum of 3 characters" }),

--- a/scripts/seed.ts
+++ b/scripts/seed.ts
@@ -260,6 +260,7 @@ async function createSampleData() {
             y_coordinate: new Prisma.Decimal(Math.random() * 100),
             type: "TEXT",
             locked: false,
+            isPublic: false,
           },
         });
       }


### PR DESCRIPTION
## Summary
- enable public gallery edits in `GalleryNodeModal`
- handle `isPublic` flag in gallery forms and nodes
- store gallery visibility in Prisma schema
- pass visibility through realtime post actions

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6861c71c6b208329a7185cd21c8c5925