### PR TITLE
Fix gallery edit appends images

### DIFF
--- a/components/forms/GalleryNodeForm.tsx
+++ b/components/forms/GalleryNodeForm.tsx
@@ -45,7 +45,9 @@ const GalleryNodeForm = ({ onSubmit, currentImages, isOwned }: Props) => {
             reader.readAsDataURL(file);
           })
       )
-    ).then((urls) => setImageURLs(urls));
+    ).then((urls) =>
+      setImageURLs((prev) => [...prev, ...urls])
+    );
   };
 
   return (

--- a/components/nodes/GalleryNode.tsx
+++ b/components/nodes/GalleryNode.tsx
@@ -44,13 +44,14 @@ function GalleryNode({ id, data }: NodeProps<GalleryNodeData>) {
       .filter((r) => !r.error)
       .map((r) => r.fileURL);
     if (urls.length > 0) {
-      setImages(urls);
+      const updatedGallery = [...images, ...urls];
+      setImages(updatedGallery);
       setCurrentIndex(0);
       await updateRealtimePost({
         id,
         path,
-        imageUrl: urls[0],
-        text: JSON.stringify(urls),
+        imageUrl: updatedGallery[0],
+        text: JSON.stringify(updatedGallery),
         ...(isOwned && { isPublic: values.isPublic }),
       });
     }


### PR DESCRIPTION
## Summary
- append new images to existing gallery images
- show all selected images during gallery edit

## Testing
- `yarn run lint`


------
https://chatgpt.com/codex/tasks/task_e_6861cde45aac8329b3ced033b5d158c7