### PR TITLE
Fix tldraw duplication warning

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -7,8 +7,11 @@ const nextConfig = {
     });
     return config;
   },
+  experimental: {
+    serverComponentsExternalPackages: ["@tldraw/tldraw"],
+  },
     images: {
-      domains: ['localhost'], 
+      domains: ['localhost'],
 
       remotePatterns: [
         {


### PR DESCRIPTION
## Summary
- configure tldraw as an external server component package

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6861d01f5f8083299be641849160fea5