### PR TITLE
Allow editing gallery visibility

### DIFF
--- a/components/forms/GalleryNodeForm.tsx
+++ b/components/forms/GalleryNodeForm.tsx
@@ -1,4 +1,7 @@
-import { GalleryPostValidation } from "@/lib/validations/thread";
+import {
+  GalleryPostValidation,
+  GalleryEditValidation,
+} from "@/lib/validations/thread";
 import { zodResolver } from "@hookform/resolvers/zod";
 import Image from "next/image";
 import { ChangeEvent, useState } from "react";
@@ -16,16 +19,29 @@ import {
 import { Input } from "../ui/input";
 
 interface Props {
-  onSubmit: (values: z.infer<typeof GalleryPostValidation>) => void;
+  onSubmit: (
+    values:
+      | z.infer<typeof GalleryPostValidation>
+      | z.infer<typeof GalleryEditValidation>
+  ) => void;
   currentImages: string[];
+  currentIsPublic: boolean;
   isOwned: boolean;
 }
 
-const GalleryNodeForm = ({ onSubmit, currentImages, isOwned }: Props) => {
+const GalleryNodeForm = ({
+  onSubmit,
+  currentImages,
+  currentIsPublic,
+  isOwned,
+}: Props) => {
   const [imageURLs, setImageURLs] = useState<string[]>(currentImages);
+  const isEditing = currentImages.length > 0;
   const form = useForm({
-    resolver: zodResolver(GalleryPostValidation),
-    defaultValues: { images: [] as File[], isPublic: false },
+    resolver: zodResolver(
+      isEditing ? GalleryEditValidation : GalleryPostValidation
+    ),
+    defaultValues: { images: [] as File[], isPublic: currentIsPublic },
   });
 
   const handleImages = (

--- a/components/modals/GalleryNodeModal.tsx
+++ b/components/modals/GalleryNodeModal.tsx
@@ -17,23 +17,49 @@ interface Props {
   currentImages: string[];
 }
 
-const renderCreate = ({ onSubmit }: { onSubmit?: (values: z.infer<typeof GalleryPostValidation>) => void }) => (
+const renderCreate = ({
+  onSubmit,
+  currentIsPublic,
+}: {
+  onSubmit?: (values: z.infer<typeof GalleryPostValidation>) => void;
+  currentIsPublic: boolean;
+}) => (
   <div>
     <DialogHeader className="dialog-header text-white text-lg py-4 mt-[-4rem]">
       <b>Create Gallery</b>
     </DialogHeader>
     <hr />
-    <GalleryNodeForm onSubmit={onSubmit!} currentImages={[]} isOwned={true} />
+    <GalleryNodeForm
+      onSubmit={onSubmit!}
+      currentImages={[]}
+      currentIsPublic={currentIsPublic}
+      isOwned={true}
+    />
   </div>
 );
 
-const renderEdit = ({ onSubmit, currentImages, isOwned }: { onSubmit?: (values: z.infer<typeof GalleryPostValidation>) => void; currentImages: string[]; isOwned: boolean }) => (
+const renderEdit = ({
+  onSubmit,
+  currentImages,
+  isOwned,
+  currentIsPublic,
+}: {
+  onSubmit?: (values: z.infer<typeof GalleryPostValidation>) => void;
+  currentImages: string[];
+  isOwned: boolean;
+  currentIsPublic: boolean;
+}) => (
   <div>
     <DialogHeader className="dialog-header text-white text-lg py-4 mt-[-4rem]">
       <b>Edit Gallery</b>
     </DialogHeader>
     <hr />
-    <GalleryNodeForm onSubmit={onSubmit!} currentImages={currentImages} isOwned={isOwned} />
+    <GalleryNodeForm
+      onSubmit={onSubmit!}
+      currentImages={currentImages}
+      currentIsPublic={currentIsPublic}
+      isOwned={isOwned}
+    />
   </div>
 );
 
@@ -66,8 +92,14 @@ const GalleryNodeModal = ({ id, isOwned, isPublic, onSubmit, currentImages }: Pr
       <DialogContent className="max-w-[57rem]">
         <DialogTitle>GalleryNodeModal</DialogTitle>
         <div className="grid rounded-md px-4 py-2">
-          {isCreate && renderCreate({ onSubmit })}
-          {isEdit && renderEdit({ onSubmit, currentImages, isOwned })}
+          {isCreate && renderCreate({ onSubmit, currentIsPublic: isPublic })}
+          {isEdit &&
+            renderEdit({
+              onSubmit,
+              currentImages,
+              isOwned,
+              currentIsPublic: isPublic,
+            })}
           {isView && renderView(currentImages)}
         </div>
       </DialogContent>

--- a/components/nodes/GalleryNode.tsx
+++ b/components/nodes/GalleryNode.tsx
@@ -43,18 +43,22 @@ function GalleryNode({ id, data }: NodeProps<GalleryNodeData>) {
     const urls = uploads
       .filter((r) => !r.error)
       .map((r) => r.fileURL);
+    const updatedGallery = urls.length > 0 ? [...images, ...urls] : images;
+
     if (urls.length > 0) {
-      const updatedGallery = [...images, ...urls];
       setImages(updatedGallery);
       setCurrentIndex(0);
-      await updateRealtimePost({
-        id,
-        path,
+    }
+
+    await updateRealtimePost({
+      id,
+      path,
+      ...(urls.length > 0 && {
         imageUrl: updatedGallery[0],
         text: JSON.stringify(updatedGallery),
-        ...(isOwned && { isPublic: values.isPublic }),
-      });
-    }
+      }),
+      ...(isOwned && { isPublic: values.isPublic }),
+    });
     store.closeModal();
   }
 

--- a/lib/validations/thread.ts
+++ b/lib/validations/thread.ts
@@ -57,6 +57,21 @@ export const GalleryPostValidation = z.object({
     .min(1),
   isPublic: z.boolean().optional(),
 });
+
+export const GalleryEditValidation = z.object({
+  images: z
+    .array(
+      z
+        .any()
+        .refine((file) => file?.size <= MAX_FILE_SIZE, `Max image size is 5MB.`)
+        .refine(
+          (file) => ACCEPTED_IMAGE_TYPES.includes(file?.type),
+          "Only .jpg, .jpeg, .png and .webp formats are supported."
+        )
+    )
+    .optional(),
+  isPublic: z.boolean().optional(),
+});
 export const CommentValidation = z.object({
   thread: z.string().min(3, { message: "Minimum of 3 characters" }),
 });


### PR DESCRIPTION
## Summary
- add `GalleryEditValidation` for editing galleries
- enable empty images in `GalleryNodeForm` when editing
- pass current visibility state to gallery modals
- update gallery node submit handler to update visibility without new images

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6861e95852d48329918b1b6192fbdc50