### PR TITLE
Implement gallery carousel

### DIFF
--- a/components/cards/GalleryCarousel.tsx
+++ b/components/cards/GalleryCarousel.tsx
@@ -1,0 +1,55 @@
+"use client";
+
+import Image from "next/image";
+import { useState } from "react";
+
+interface Props {
+  urls: string[];
+}
+
+const GalleryCarousel = ({ urls }: Props) => {
+  const [currentIndex, setCurrentIndex] = useState(0);
+
+  const handlePrev = (e: React.MouseEvent<HTMLButtonElement>) => {
+    e.stopPropagation();
+    setCurrentIndex((prev) => (prev - 1 + urls.length) % urls.length);
+  };
+
+  const handleNext = (e: React.MouseEvent<HTMLButtonElement>) => {
+    e.stopPropagation();
+    setCurrentIndex((prev) => (prev + 1) % urls.length);
+  };
+
+  if (urls.length === 0) return null;
+
+  return (
+    <div className="img-container relative">
+      <Image
+        className="img-frame"
+        src={urls[currentIndex]}
+        alt={`img-${currentIndex}`}
+        width={0}
+        height={0}
+        sizes="200vw"
+      />
+      {urls.length > 1 && (
+        <>
+          <button
+            className="absolute left-0 top-1/2 -translate-y-1/2 bg-black/50 text-white px-1"
+            onClick={handlePrev}
+          >
+            ‹
+          </button>
+          <button
+            className="absolute right-0 top-1/2 -translate-y-1/2 bg-black/50 text-white px-1"
+            onClick={handleNext}
+          >
+            ›
+          </button>
+        </>
+      )}
+    </div>
+  );
+};
+
+export default GalleryCarousel;

--- a/components/cards/PostCard.tsx
+++ b/components/cards/PostCard.tsx
@@ -5,6 +5,7 @@ import ShareButton from "../buttons/ShareButton";
 import ExpandButton from "../buttons/ExpandButton";
 import TimerButton from "../buttons/TimerButton";
 import ReplicateButton from "../buttons/ReplicateButton";
+import GalleryCarousel from "./GalleryCarousel";
 import {
   fetchLikeForCurrentUser,
   fetchRealtimeLikeForCurrentUser,
@@ -112,14 +113,7 @@ const PostCard = async ({
               </div>
             )}
             {type === "GALLERY" && content && (
-              <div className="grid      gap-2 mt-2 mb-2">
-                {JSON.parse(content).map((url: string, idx: number) => (
-                  <div key={idx} className="relative w-[20rem] h-[20rem]">
-                    <Image src={url} alt={`img-${idx}`} fill style={{ objectFit: "contain" }} />
-                  </div>
-                ))}
-              </div>
-              
+              <GalleryCarousel urls={JSON.parse(content)} />
             )}
             <hr className="mt-4 mb-3 w-[200%] h-px border-t-0 bg-transparent bg-gradient-to-r from-transparent via-slate-100 to-transparent opacity-75" />
 


### PR DESCRIPTION
## Summary
- add GalleryCarousel client component for navigating gallery images
- use the new carousel in `PostCard` for GALLERY posts

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6861f897db6483299c64e6ab51882ac8