### PR TITLE
Fix carousel height

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -279,7 +279,7 @@
 }
 .carousel{
   width: auto;
-  height: auto;
+  height: 300px;
   max-width: 500px;
   justify-content: center;
   align-items: center;
@@ -289,6 +289,7 @@
   padding: 0px;
   position: relative;
   bottom: -4px;
+  object-fit: contain;
 }
 
 

--- a/components/cards/GalleryCarousel.tsx
+++ b/components/cards/GalleryCarousel.tsx
@@ -23,7 +23,7 @@ const GalleryCarousel = ({ urls }: Props) => {
   if (urls.length === 0) return null;
 
   return (
-    <div >
+    <div className="relative flex justify-center">
       <Image
         className="carousel"
         src={urls[currentIndex]}


### PR DESCRIPTION
## Summary
- prevent postcard shrinking by fixing `.carousel` height
- center carousel images with a relative wrapper

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6861fcad961083298d73222909faa73c