### PR TITLE
Fix gallery carousel positioning

### DIFF
--- a/components/cards/PostCard.tsx
+++ b/components/cards/PostCard.tsx
@@ -112,8 +112,10 @@ const PostCard = async ({
                 ></iframe>
               </div>
             )}
-            {type === "GALLERY" && content && ( <div className="ml-[15rem] justify-center items-center">
-              <GalleryCarousel urls={JSON.parse(content)} /> </div>
+            {type === "GALLERY" && content && (
+              <div className="ml-[15rem] w-[500px] justify-center items-center">
+                <GalleryCarousel urls={JSON.parse(content)} />
+              </div>
             )}
             <hr className="mt-4 mb-3 w-[200%] h-px border-t-0 bg-transparent bg-gradient-to-r from-transparent via-slate-100 to-transparent opacity-75" />
 


### PR DESCRIPTION
## Summary
- keep gallery width fixed so arrows stay aligned

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_686202cd67208329b9b9bd4059284656