### PR TITLE
Fix gallery carousel navigation arrows

### DIFF
--- a/components/cards/GalleryCarousel.tsx
+++ b/components/cards/GalleryCarousel.tsx
@@ -34,27 +34,24 @@ const GalleryCarousel = ({ urls }: Props) => {
       />
       {urls.length > 1 && (
         <div className="pointer-events-none absolute inset-0 flex items-center justify-between px-2">
-        
-        <button onClick={handlePrev}>
-          <Image
-
-                  src="/assets/leftarrow.svg"
-                  alt="share"
-                  width={48}
-                  height={48}
-                  className="cursor-pointer object-contain carouselbutton"
-                />
-</button>
-<button onClick={handlePrev}>
-<Image
-
-src="/assets/rightarrow.svg"
-alt="share"
-width={48}
-height={48}
-className="cursor-pointer object-contain carouselbutton"
-/>
-</button>
+          <button className="pointer-events-auto" onClick={handlePrev}>
+            <Image
+              src="/assets/leftarrow.svg"
+              alt="previous"
+              width={48}
+              height={48}
+              className="cursor-pointer object-contain carouselbutton"
+            />
+          </button>
+          <button className="pointer-events-auto" onClick={handleNext}>
+            <Image
+              src="/assets/rightarrow.svg"
+              alt="next"
+              width={48}
+              height={48}
+              className="cursor-pointer object-contain carouselbutton"
+            />
+          </button>
         </div>
       )}
     </div>


### PR DESCRIPTION
## Summary
- enable pointer events on gallery carousel arrow buttons
- correct right arrow click handler

## Testing
- `npm run lint`
- `npx jest` *(fails: ts-node not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68620e27200483299f7207a368c7441d