### PR TITLE
Add DRAW posts to standard feed

### DIFF
--- a/app/(root)/(standard)/page.tsx
+++ b/app/(root)/(standard)/page.tsx
@@ -11,7 +11,7 @@ export const metadata = {
 export default async function Home() {
   const result = await fetchRealtimePosts({
     realtimeRoomId: "global",
-    postTypes: ["TEXT", "VIDEO", "IMAGE", "IMAGE_COMPUTE", "GALLERY"],
+    postTypes: ["TEXT", "VIDEO", "IMAGE", "IMAGE_COMPUTE", "GALLERY", "DRAW"],
   });
   const user = await getUserFromCookies();
 

--- a/components/cards/DrawCanvas.tsx
+++ b/components/cards/DrawCanvas.tsx
@@ -1,0 +1,16 @@
+"use client";
+
+import { Tldraw } from "tldraw";
+import "tldraw/tldraw.css";
+
+const DrawCanvas = () => {
+  return (
+    <div className="flex justify-center">
+      <div className="w-[400px] h-[400px] border-black border-2 rounded-sm">
+        <Tldraw />
+      </div>
+    </div>
+  );
+};
+
+export default DrawCanvas;

--- a/components/cards/PostCard.tsx
+++ b/components/cards/PostCard.tsx
@@ -6,6 +6,7 @@ import ExpandButton from "../buttons/ExpandButton";
 import TimerButton from "../buttons/TimerButton";
 import ReplicateButton from "../buttons/ReplicateButton";
 import GalleryCarousel from "./GalleryCarousel";
+import dynamic from "next/dynamic";
 import {
   fetchLikeForCurrentUser,
   fetchRealtimeLikeForCurrentUser,
@@ -14,6 +15,7 @@ import { Like, RealtimeLike } from "@prisma/client";
 import React from "react";
 import localFont from 'next/font/local'
 const founders = localFont({ src: '/NewEdgeTest-RegularRounded.otf' })
+const DrawCanvas = dynamic(() => import("./DrawCanvas"), { ssr: false })
 
 interface Props {
   id: bigint;
@@ -115,6 +117,11 @@ const PostCard = async ({
             {type === "GALLERY" && content && (
               <div className="ml-[7rem] w-[500px] justify-center items-center">
                 <GalleryCarousel urls={JSON.parse(content)} />
+              </div>
+            )}
+            {type === "DRAW" && (
+              <div className="mt-2 mb-2 flex justify-center">
+                <DrawCanvas />
               </div>
             )}
             <hr className="mt-4 mb-3 w-full h-px border-t-0 bg-transparent bg-gradient-to-r from-transparent via-slate-100 to-transparent opacity-75" />

--- a/components/shared/RealtimePostsTab.tsx
+++ b/components/shared/RealtimePostsTab.tsx
@@ -11,7 +11,7 @@ const RealtimePostsTab = async ({ currentUserId, accountId }: Props) => {
   const posts = await fetchUserRealtimePosts({
     realtimeRoomId: "global",
     userId: accountId,
-    postTypes: ["TEXT", "VIDEO", "IMAGE", "IMAGE_COMPUTE", "GALLERY"],
+    postTypes: ["TEXT", "VIDEO", "IMAGE", "IMAGE_COMPUTE", "GALLERY", "DRAW"],
   });
 
   if (!posts) redirect("/");


### PR DESCRIPTION
## Summary
- display Tldraw drawings inside `PostCard`
- include DRAW posts when fetching posts for the standard feed and profile feed
- add client component `DrawCanvas` to render the drawing canvas

## Testing
- `yarn install`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_686254dcba248329a517f2f7baf91a84