### PR TITLE
Implement tldraw persistence

### DIFF
--- a/components/nodes/DrawNode.tsx
+++ b/components/nodes/DrawNode.tsx
@@ -1,27 +1,78 @@
 "use client";
 
 import { fetchUser } from "@/lib/actions/user.actions";
+import {
+  fetchRealtimePostById,
+  updateRealtimePost,
+} from "@/lib/actions/realtimepost.actions";
 import { useAuth } from "@/lib/AuthContext";
 import { AuthorOrAuthorId } from "@/lib/reactflow/types";
 import BaseNode from "./BaseNode";
 import { NodeProps } from "@xyflow/react";
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
+import { usePathname } from "next/navigation";
 import { Tldraw } from "tldraw";
 import "tldraw/tldraw.css";
 
 interface DrawNodeData {
   author: AuthorOrAuthorId;
   locked: boolean;
+  content?: string;
 }
 
 function DrawNode({ id, data }: NodeProps<DrawNodeData>) {
   const currentUser = useAuth().user;
+  const path = usePathname();
   const [author, setAuthor] = useState(data.author);
+  const editorRef = useRef<any>(null);
+  const lastLoaded = useRef<string | null>(null);
+  const timeoutRef = useRef<NodeJS.Timeout | null>(null);
 
   useEffect(() => {
     if ("username" in author) return;
     fetchUser(data.author.id).then((user) => user && setAuthor(user));
   }, [data]);
+
+  useEffect(() => {
+    if (!editorRef.current) return;
+    fetchRealtimePostById({ id }).then((post) => {
+      if (post?.content) {
+        try {
+          editorRef.current.store.loadStoreSnapshot(
+            JSON.parse(post.content)
+          );
+          lastLoaded.current = post.content;
+        } catch (e) {
+          console.error(e);
+        }
+      }
+    });
+
+    const unsub = editorRef.current.store.listen(() => {
+      if (timeoutRef.current) clearTimeout(timeoutRef.current);
+      timeoutRef.current = setTimeout(() => {
+        const snapshot = editorRef.current.store.getStoreSnapshot();
+        const json = JSON.stringify(snapshot);
+        lastLoaded.current = json;
+        updateRealtimePost({ id, path, content: json });
+      }, 500);
+    });
+    return () => {
+      unsub();
+      if (timeoutRef.current) clearTimeout(timeoutRef.current);
+    };
+  }, [id, path]);
+
+  useEffect(() => {
+    if (editorRef.current && data.content && data.content !== lastLoaded.current) {
+      try {
+        editorRef.current.store.loadStoreSnapshot(JSON.parse(data.content));
+        lastLoaded.current = data.content;
+      } catch (e) {
+        console.error(e);
+      }
+    }
+  }, [data.content]);
 
   const isOwned = currentUser
     ? Number(currentUser.userId) === Number(data.author.id)
@@ -39,7 +90,7 @@ function DrawNode({ id, data }: NodeProps<DrawNodeData>) {
       <div className="draw-container">
         <div className="nodrag nopan">
           <div className="w-[400px] h-[400px] border-black border-2 rounded-sm">
-            <Tldraw />
+            <Tldraw onMount={(editor) => (editorRef.current = editor)} />
           </div>
         </div>
       </div>

--- a/lib/actions/realtimepost.actions.ts
+++ b/lib/actions/realtimepost.actions.ts
@@ -30,6 +30,7 @@ interface UpdateRealtimePostParams {
   collageLayoutStyle?: string;  // or some enum
   collageColumns?: number;
   collageGap?: number;
+  content?: string;
 }
 
 export async function createRealtimePost({
@@ -109,6 +110,7 @@ export async function updateRealtimePost({
   collageLayoutStyle,
   collageColumns,
   collageGap,
+  content,
 }: UpdateRealtimePostParams) {
   const user = await getUserFromCookies();
   try {
@@ -144,6 +146,7 @@ export async function updateRealtimePost({
       ...(text && { content: text }),
       ...(imageUrl && { image_url: imageUrl }),
       ...(videoUrl && { video_url: videoUrl }),
+      ...(content && { content }),
       ...(collageLayoutStyle && { collageLayoutStyle }),
       ...(collageColumns !== undefined && { collageColumns }),
       ...(collageGap !== undefined && { collageGap }),

--- a/lib/reactflow/reactflowutils.ts
+++ b/lib/reactflow/reactflowutils.ts
@@ -180,19 +180,20 @@ export function convertPostToNode(
               y: realtimePost.y_coordinate,
             },
           } as PortalNode;
-        case "DRAW":
-          return {
-            id: realtimePost.id.toString(),
-            type: realtimePost.type,
-            data: {
-              author: authorToSet,
-              locked: realtimePost.locked,
-            },
-            position: {
-              x: realtimePost.x_coordinate,
-              y: realtimePost.y_coordinate,
-            },
-          } as DrawNode;
+      case "DRAW":
+        return {
+          id: realtimePost.id.toString(),
+          type: realtimePost.type,
+          data: {
+            author: authorToSet,
+            locked: realtimePost.locked,
+            content: realtimePost.content ?? undefined,
+          },
+          position: {
+            x: realtimePost.x_coordinate,
+            y: realtimePost.y_coordinate,
+          },
+        } as DrawNode;
     
           default:
             throw new Error("Unsupported real-time post type");

--- a/lib/reactflow/types.ts
+++ b/lib/reactflow/types.ts
@@ -102,6 +102,7 @@ export type DrawNode = Node<
   {
     author: AuthorOrAuthorId;
     locked: boolean;
+    content?: string;
   },
   "DRAW"
 >;


### PR DESCRIPTION
## Summary
- add content field to DrawNode type
- persist DrawNode drawings via updateRealtimePost
- load stored drawing snapshots on mount
- handle live drawing updates

## Testing
- `yarn install`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6862c8c704508329841c1568565a7f08