### PR TITLE
Fix duplicate archiving

### DIFF
--- a/lib/actions/thread.actions.ts
+++ b/lib/actions/thread.actions.ts
@@ -264,6 +264,7 @@ export async function archiveExpiredPosts() {
         like_count: p.like_count,
         expiration_date: p.expiration_date ?? undefined,
       })),
+      skipDuplicates: true,
     }),
     prisma.post.deleteMany({ where: { id: { in: ids } } }),
   ]);


### PR DESCRIPTION
## Summary
- ignore duplicates when archiving posts

## Testing
- `yarn install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6862d1b3dda88329931065311a10b2c8