### PR TITLE
Fix tldraw mount and load content

### DIFF
--- a/components/cards/DrawCanvas.tsx
+++ b/components/cards/DrawCanvas.tsx
@@ -1,13 +1,30 @@
 "use client";
 
+import { useEffect, useRef } from "react";
 import { Tldraw } from "tldraw";
 import "tldraw/tldraw.css";
 
-const DrawCanvas = () => {
+interface DrawCanvasProps {
+  content?: string;
+}
+
+const DrawCanvas = ({ content }: DrawCanvasProps) => {
+  const editorRef = useRef<any>(null);
+
+  useEffect(() => {
+    if (editorRef.current && content) {
+      try {
+        editorRef.current.store.loadStoreSnapshot(JSON.parse(content));
+      } catch (e) {
+        console.error(e);
+      }
+    }
+  }, [content]);
+
   return (
     <div className="flex justify-center">
       <div className="w-[400px] h-[400px] border-black border-2 rounded-sm">
-        <Tldraw />
+        <Tldraw onMount={(editor) => { editorRef.current = editor; }} />
       </div>
     </div>
   );

--- a/components/cards/PostCard.tsx
+++ b/components/cards/PostCard.tsx
@@ -119,11 +119,11 @@ const PostCard = async ({
                 <GalleryCarousel urls={JSON.parse(content)} />
               </div>
             )}
-            {type === "DRAW" && (
-              <div className="mt-2 mb-2 flex justify-center">
-                <DrawCanvas />
-              </div>
-            )}
+              {type === "DRAW" && (
+                <div className="mt-2 mb-2 flex justify-center">
+                  <DrawCanvas content={content} />
+                </div>
+              )}
             <hr className="mt-4 mb-3 w-full h-px border-t-0 bg-transparent bg-gradient-to-r from-transparent via-slate-100 to-transparent opacity-75" />
 
             <div className="mt-4 flex flex-col gap-x-3 gap-y-4">

--- a/components/nodes/DrawNode.tsx
+++ b/components/nodes/DrawNode.tsx
@@ -90,7 +90,7 @@ function DrawNode({ id, data }: NodeProps<DrawNodeData>) {
       <div className="draw-container">
         <div className="nodrag nopan">
           <div className="w-[400px] h-[400px] border-black border-2 rounded-sm">
-            <Tldraw onMount={(editor) => (editorRef.current = editor)} />
+            <Tldraw onMount={(editor) => { editorRef.current = editor; }} />
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- fix onMount handler to avoid returning editor object
- load drawing content in DrawCanvas
- pass drawing content to DrawCanvas in PostCard

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6862d4a27c70832993bed04557e4a3ad