### PR TITLE
Fix comment links for realtime posts

### DIFF
--- a/components/buttons/ExpandButton.tsx
+++ b/components/buttons/ExpandButton.tsx
@@ -12,7 +12,7 @@ interface Props {
   realtimePostId?: string;
 }
 
-const ExpandButton = ({ postId }: Props) => {
+const ExpandButton = ({ postId, realtimePostId }: Props) => {
   const user = useAuth();
   const router = useRouter();
   const isUserSignedIn = !!user.user;
@@ -20,18 +20,18 @@ const ExpandButton = ({ postId }: Props) => {
 
 
  
+  const href = realtimePostId ? `/post/${realtimePostId}` : `/thread/${postId}`;
+
   return (
-
-    <Link href={`/thread/${postId}`}>
-                    <Image
-                      src="/assets/add-comment.svg"
-                      alt="reply"
-                      width={28}
-                      height={28}
-                      className="cursor-pointer object-contain likebutton"
-                    />
-                  </Link>
-
+    <Link href={href}>
+      <Image
+        src="/assets/add-comment.svg"
+        alt="reply"
+        width={28}
+        height={28}
+        className="cursor-pointer object-contain likebutton"
+      />
+    </Link>
   );
   
 };

--- a/components/cards/PostCard.tsx
+++ b/components/cards/PostCard.tsx
@@ -136,7 +136,11 @@ const PostCard = async ({
                   initialLikeState={currentUserLike}
                 />
                   <>
-                    <ExpandButton postId={id} />
+                    <ExpandButton
+                      {...(isRealtimePost
+                        ? { realtimePostId: id.toString() }
+                        : { postId: id })}
+                    />
                   </>
             <ReplicateButton postId={id} />
           <ShareButton postId={id} />


### PR DESCRIPTION
## Summary
- handle realtime posts in ExpandButton
- pass realtime post ID to ExpandButton from PostCard

## Testing
- `yarn install`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6862dc14f8008329b6f18d215e575edf