### PR TITLE
Add loading feedback for auth forms

### DIFF
--- a/app/(auth)/login/page.tsx
+++ b/app/(auth)/login/page.tsx
@@ -2,6 +2,7 @@
 import localFont from "next/font/local";
 
 import { FormEvent, useState } from "react";
+import Spinner from "@/components/ui/spinner";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { getAuth, signInWithEmailAndPassword } from "firebase/auth";
@@ -13,6 +14,7 @@ export default function Login() {
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const [error, setError] = useState("");
+  const [loading, setLoading] = useState(false);
   const router = useRouter();
 
   async function handleSubmit(event: FormEvent) {
@@ -20,6 +22,7 @@ export default function Login() {
     setError("");
 
     try {
+      setLoading(true);
       const credential = await signInWithEmailAndPassword(
         getAuth(app),
         email,
@@ -36,6 +39,8 @@ export default function Login() {
       router.push("/");
     } catch (e) {
       setError((e as Error).message);
+    } finally {
+      setLoading(false);
     }
   }
 
@@ -101,10 +106,10 @@ export default function Login() {
               )}
               <button
                 type="submit"
-                className="flex w-[50%] items-center justify-center text-center content-center mx-auto
-                text-white bg-transparent likebutton py-2 border-white rounded-md "
+                disabled={loading}
+                className="flex w-[50%] items-center justify-center text-center content-center mx-auto text-white bg-transparent likebutton py-2 border-white rounded-md"
               >
-                Next
+                {loading && <Spinner className="mr-2" />} {loading ? "Loading" : "Next"}
               </button>
               <p className="text-[1.2rem] text-center mx-auto text-gray-200 dark:text-gray-400">
                 No Account?{" "}

--- a/app/(auth)/register/page.tsx
+++ b/app/(auth)/register/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { FormEvent, useState } from "react";
+import Spinner from "@/components/ui/spinner";
 import Link from "next/link";
 import { getAuth, createUserWithEmailAndPassword } from "firebase/auth";
 import { app } from "@/lib/firebase/firebase";
@@ -12,6 +13,7 @@ export default function Register() {
   const [password, setPassword] = useState("");
   const [confirmation, setConfirmation] = useState("");
   const [error, setError] = useState("");
+  const [loading, setLoading] = useState(false);
   const router = useRouter();
 
   async function handleSubmit(event: FormEvent) {
@@ -25,10 +27,13 @@ export default function Register() {
     }
 
     try {
+      setLoading(true);
       await createUserWithEmailAndPassword(getAuth(app), email, password);
       router.push("/login");
     } catch (e) {
       setError((e as Error).message);
+    } finally {
+      setLoading(false);
     }
   }
 
@@ -112,9 +117,10 @@ export default function Register() {
               )}
               <button
                 type="submit"
+                disabled={loading}
                 className="w-full text-white bg-gray-600 hover:bg-gray-700 focus:ring-4 focus:outline-none focus:ring-primary-300 font-medium rounded-lg text-sm px-5 py-2.5 text-center dark:bg-gray-600 dark:hover:bg-gray-700 dark:focus:ring-primary-800"
               >
-                Create an account
+                {loading && <Spinner className="mr-2" />} {loading ? "Loading" : "Create an account"}
               </button>
               <p className="text-sm font-light text-gray-800 dark:text-gray-400">
                 Already have an account?{" "}

--- a/components/ui/spinner.tsx
+++ b/components/ui/spinner.tsx
@@ -1,0 +1,26 @@
+import { cn } from "@/lib/utils";
+
+export default function Spinner({ className }: { className?: string }) {
+  return (
+    <svg
+      className={cn("animate-spin h-5 w-5 text-current", className)}
+      xmlns="http://www.w3.org/2000/svg"
+      fill="none"
+      viewBox="0 0 24 24"
+    >
+      <circle
+        className="opacity-25"
+        cx="12"
+        cy="12"
+        r="10"
+        stroke="currentColor"
+        strokeWidth="4"
+      />
+      <path
+        className="opacity-75"
+        fill="currentColor"
+        d="M4 12a8 8 0 018-8v4a4 4 0 00-4 4H4z"
+      />
+    </svg>
+  );
+}


### PR DESCRIPTION
## Summary
- add reusable `<Spinner>` component
- show spinner on Login form submission
- show spinner on Register form submission

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6862dee79d8c8329ac763fb7babbac7e