### PR TITLE
Add realtime post comments

### DIFF
--- a/app/(root)/(realtime)/post/[id]/page.tsx
+++ b/app/(root)/(realtime)/post/[id]/page.tsx
@@ -3,6 +3,8 @@ import { redirect, notFound } from "next/navigation";
 import { getUserFromCookies } from "@/lib/serverutils";
 import PostCard from "@/components/cards/PostCard";
 import Modal from "@/components/modals/Modal";
+import Comment from "@/components/forms/Comment";
+import CommentTree from "@/components/shared/CommentTree";
 
 const Page = async ({ params }: { params: { id: string } }) => {
   if (!params?.id && params?.id?.length !== 1) return notFound();
@@ -35,6 +37,23 @@ const Page = async ({ params }: { params: { id: string } }) => {
           type={post.type}
           author={post.author!}
           createdAt={post.created_at.toDateString()}
+        />
+      </div>
+      <div className="flex-1 flex-row w-full mt-6 ml-4">
+        <Comment
+          realtimePostId={post.id.toString()}
+          currentUserImg={user.photoURL!}
+          currentUserId={user.userId!}
+        />
+      </div>
+      <hr className="mt-4 mb-3 w-full h-px border-t-0 bg-transparent bg-gradient-to-r from-transparent via-slate-900 to-transparent opacity-75" />
+      <div className="flex-1 flex-row w-full mt-2 ml-4">
+        <CommentTree
+          comments={post.children}
+          currentUserId={user.userId!}
+          currentUserImg={user.photoURL!}
+          depth={1}
+          isRealtimePost
         />
       </div>
     </section>

--- a/components/forms/Comment.tsx
+++ b/components/forms/Comment.tsx
@@ -20,14 +20,18 @@ import { z } from "zod";
 import { useRouter, usePathname } from "next/navigation";
 import { CommentValidation } from "@/lib/validations/thread";
 import Image from "next/image";
-import { addCommentToPost } from "@/lib/actions/thread.actions";
+import {
+  addCommentToPost,
+} from "@/lib/actions/thread.actions";
+import { addCommentToRealtimePost } from "@/lib/actions/realtimepost.actions";
 import ReplyButton from "../buttons/ReplyButton";
 interface Props {
-  postId: bigint;
+  postId?: bigint;
+  realtimePostId?: string;
   currentUserImg: string;
   currentUserId: bigint;
 }
-const Comment = ({ postId, currentUserImg, currentUserId }: Props) => {
+const Comment = ({ postId, realtimePostId, currentUserImg, currentUserId }: Props) => {
   const pathname = usePathname();
   const router = useRouter();
   const form = useForm({
@@ -39,12 +43,21 @@ const Comment = ({ postId, currentUserImg, currentUserId }: Props) => {
   });
 
   const onSubmit = async (values: z.infer<typeof CommentValidation>) => {
-    await addCommentToPost({
-      parentPostId: postId,
-      commentText: values.thread,
-      userId: currentUserId,
-      path: pathname,
-    });
+    if (realtimePostId) {
+      await addCommentToRealtimePost({
+        parentPostId: BigInt(realtimePostId),
+        commentText: values.thread,
+        userId: currentUserId,
+        path: pathname,
+      });
+    } else if (postId) {
+      await addCommentToPost({
+        parentPostId: postId,
+        commentText: values.thread,
+        userId: currentUserId,
+        path: pathname,
+      });
+    }
 
     form.reset();
   };

--- a/components/shared/CommentTree.tsx
+++ b/components/shared/CommentTree.tsx
@@ -6,12 +6,13 @@ interface CommentTreeProps {
   currentUserId: bigint;
   currentUserImg: string;
   depth?: number;
+  isRealtimePost?: boolean;
 }
 
 const MAX_DEPTH = 5;
 const INDENT_PX = 24;
 
-const CommentTree = ({ comments, currentUserId, currentUserImg, depth = 0 }: CommentTreeProps) => {
+const CommentTree = ({ comments, currentUserId, currentUserImg, depth = 0, isRealtimePost }: CommentTreeProps) => {
   return (
     <div className="flex flex-col gap-3">
       {comments.map((comment) => {
@@ -32,6 +33,7 @@ const CommentTree = ({ comments, currentUserId, currentUserImg, depth = 0 }: Com
             comments={comment.children}
             isComment
             likeCount={comment.like_count}
+            {...(isRealtimePost ? { isRealtimePost: true } : {})}
           />
           <div
             className="mt-4"
@@ -40,7 +42,7 @@ const CommentTree = ({ comments, currentUserId, currentUserImg, depth = 0 }: Com
                               <hr className="mt-4 mb-3 w-full h-px border-t-0 bg-transparent bg-gradient-to-r from-transparent via-slate-900 to-transparent opacity-75" />
 
             <Comment
-              postId={comment.id}
+              {...(isRealtimePost ? { realtimePostId: comment.id.toString() } : { postId: comment.id })}
               currentUserImg={currentUserImg}
               currentUserId={currentUserId}
             />
@@ -52,6 +54,7 @@ const CommentTree = ({ comments, currentUserId, currentUserImg, depth = 0 }: Com
                 currentUserId={currentUserId}
                 currentUserImg={currentUserImg}
                 depth={depth + 1}
+                isRealtimePost={isRealtimePost}
               />
             )}
           </div>

--- a/lib/models/schema.prisma
+++ b/lib/models/schema.prisma
@@ -147,6 +147,9 @@ model RealtimePost {
   collageLayoutStyle String? // "grid", "bento", "scrapbook"
   collageColumns     Int?
   collageGap         Int?
+  parent_id          BigInt?
+  realtimePost       RealtimePost? @relation("RealtimePostChildren", fields: [parent_id], references: [id], onDelete: Restrict)
+  children           RealtimePost[] @relation("RealtimePostChildren")
 
   @@map("realtime_posts")
 }


### PR DESCRIPTION
## Summary
- support comment threads for realtime posts
- allow commenting on realtime post pages
- update comment form and comment tree for realtime posts
- store realtime post comments in Prisma schema

## Testing
- `npm run lint`
- `npx prisma generate`


------
https://chatgpt.com/codex/tasks/task_e_6862de98615c832998df764bf7353c3b