### PR TITLE
Implement Livechat node

### DIFF
--- a/components/forms/CreateFeedPost.tsx
+++ b/components/forms/CreateFeedPost.tsx
@@ -17,6 +17,7 @@ import YoutubeNodeModal from "@/components/modals/YoutubeNodeModal";
 import CollageCreationModal from "@/components/modals/CollageCreationModal";
 import GalleryNodeModal from "@/components/modals/GalleryNodeModal";
 import PortalNodeModal from "@/components/modals/PortalNodeModal";
+import LivechatNodeModal from "@/components/modals/LivechatNodeModal";
 import { uploadFileToSupabase } from "@/lib/utils";
 import { createRealtimePost } from "@/lib/actions/realtimepost.actions";
 import { useRouter } from "next/navigation";
@@ -40,6 +41,7 @@ const nodeOptions: { label: string; nodeType: AppNodeType }[] = [
   { label: "GALLERY", nodeType: "GALLERY" },
   { label: "PORTAL", nodeType: "PORTAL" },
   { label: "DRAW", nodeType: "DRAW" },
+  { label: "LIVECHAT", nodeType: "LIVECHAT" },
 ];
 
 const CreateFeedPost = () => {
@@ -190,6 +192,24 @@ const CreateFeedPost = () => {
         );
       case "PORTAL":
         return <PortalNodeModal isOwned={true} onSubmit={handlePortalSubmit} currentX={0} currentY={0} />;
+      case "LIVECHAT":
+        return (
+          <LivechatNodeModal
+            isOwned={true}
+            currentInviteeId={0}
+            onSubmit={async (vals) => {
+              await createRealtimePost({
+                path: "/",
+                coordinates: { x: 0, y: 0 },
+                type: "LIVECHAT",
+                realtimeRoomId: "global",
+                text: JSON.stringify({ inviteeId: vals.inviteeId }),
+              });
+              reset();
+              router.refresh();
+            }}
+          />
+        );
       default:
         return (
           <DialogContent className="max-w-[24rem]">

--- a/components/forms/LivechatNodeForm.tsx
+++ b/components/forms/LivechatNodeForm.tsx
@@ -1,0 +1,38 @@
+import { LivechatInviteValidation } from "@/lib/validations/thread";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useForm } from "react-hook-form";
+import { z } from "zod";
+import { Button } from "../ui/button";
+import { Input } from "../ui/input";
+
+interface Props {
+  onSubmit: (values: z.infer<typeof LivechatInviteValidation>) => void;
+  currentInviteeId: number;
+}
+
+function LivechatNodeForm({ onSubmit, currentInviteeId }: Props) {
+  const form = useForm({
+    resolver: zodResolver(LivechatInviteValidation),
+    defaultValues: { inviteeId: currentInviteeId },
+  });
+
+  return (
+    <form method="post" className="ml-3 mr-3" onSubmit={form.handleSubmit(onSubmit)}>
+      <hr />
+      <div className="py-4 grid gap-2">
+        <label className="flex flex-col text-slate-500 gap-3 text-xl">
+          Invitee User ID:
+          <Input type="number" {...form.register("inviteeId", { valueAsNumber: true })} />
+        </label>
+      </div>
+      <hr />
+      <div className="py-4 mb-4">
+        <Button type="submit" className="form-submit-button" size={"lg"}>
+          Save Changes
+        </Button>
+      </div>
+    </form>
+  );
+}
+
+export default LivechatNodeForm;

--- a/components/modals/LivechatNodeModal.tsx
+++ b/components/modals/LivechatNodeModal.tsx
@@ -1,0 +1,73 @@
+import { LivechatInviteValidation } from "@/lib/validations/thread";
+import { z } from "zod";
+import LivechatNodeForm from "@/components/forms/LivechatNodeForm";
+import {
+  DialogClose,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+
+interface Props {
+  id?: string;
+  isOwned: boolean;
+  onSubmit?: (values: z.infer<typeof LivechatInviteValidation>) => void;
+  currentInviteeId: number;
+}
+
+const renderCreate = ({ onSubmit }: { onSubmit?: (v: z.infer<typeof LivechatInviteValidation>) => void }) => (
+  <div>
+    <DialogHeader className="dialog-header text-white text-lg py-4 mt-[-4rem]">
+      <b>Create Chat</b>
+    </DialogHeader>
+    <hr />
+    <LivechatNodeForm onSubmit={onSubmit!} currentInviteeId={0} />
+  </div>
+);
+
+const renderEdit = ({ onSubmit, currentInviteeId }: { onSubmit?: (v: z.infer<typeof LivechatInviteValidation>) => void; currentInviteeId: number }) => (
+  <div>
+    <DialogHeader className="dialog-header text-white text-lg py-4 mt-[-4rem]">
+      <b>Edit Chat</b>
+    </DialogHeader>
+    <hr />
+    <LivechatNodeForm onSubmit={onSubmit!} currentInviteeId={currentInviteeId} />
+  </div>
+);
+
+const renderView = (currentInviteeId: number) => (
+  <div>
+    <DialogHeader className="dialog-header text-white text-lg py-4 mt-[-3rem]">
+      <b>View Chat</b>
+    </DialogHeader>
+    <hr />
+    <div className="py-4 grid gap-2 text-white">Invitee ID: {currentInviteeId}</div>
+    <hr />
+    <div className="py-4">
+      <DialogClose id="animateButton" className={`form-submit-button pl-2 py-2 pr-[1rem]`}>
+        <div className="w-2"></div>
+        <> Close </>
+      </DialogClose>
+    </div>
+  </div>
+);
+
+function LivechatNodeModal({ id, isOwned, onSubmit, currentInviteeId }: Props) {
+  const isCreate = !id && isOwned;
+  const isEdit = id && isOwned;
+  const isView = id && !isOwned;
+  return (
+    <div>
+      <DialogContent className="max-w-[57rem]">
+        <DialogTitle>LivechatNodeModal</DialogTitle>
+        <div className="grid rounded-md px-4 py-2">
+          {isCreate && renderCreate({ onSubmit })}
+          {isEdit && renderEdit({ onSubmit, currentInviteeId })}
+          {isView && renderView(currentInviteeId)}
+        </div>
+      </DialogContent>
+    </div>
+  );
+}
+
+export default LivechatNodeModal;

--- a/components/nodes/LivechatNode.tsx
+++ b/components/nodes/LivechatNode.tsx
@@ -1,0 +1,120 @@
+"use client";
+import { fetchUser } from "@/lib/actions/user.actions";
+import { updateRealtimePost } from "@/lib/actions/realtimepost.actions";
+import { useAuth } from "@/lib/AuthContext";
+import { AuthorOrAuthorId, AppState } from "@/lib/reactflow/types";
+import { NodeProps } from "@xyflow/react";
+import { useEffect, useState } from "react";
+import { supabase } from "@/lib/supabaseclient";
+import { usePathname } from "next/navigation";
+import BaseNode from "./BaseNode";
+import LivechatNodeModal from "../modals/LivechatNodeModal";
+import useStore from "@/lib/reactflow/store";
+import { useShallow } from "zustand/react/shallow";
+import { LivechatInviteValidation } from "@/lib/validations/thread";
+import { z } from "zod";
+
+interface LivechatNodeData {
+  inviteeId: number;
+  author: AuthorOrAuthorId;
+  locked: boolean;
+}
+
+function LivechatNode({ id, data }: NodeProps<LivechatNodeData>) {
+  const path = usePathname();
+  const currentUser = useAuth().user;
+  const [author, setAuthor] = useState(data.author);
+  const store = useStore(
+    useShallow((state: AppState) => ({
+      closeModal: state.closeModal,
+    }))
+  );
+  const [myText, setMyText] = useState("");
+  const [otherText, setOtherText] = useState("");
+  const [channel, setChannel] = useState<any>(null);
+
+  useEffect(() => {
+    if ("username" in author) return;
+    fetchUser(data.author.id).then((user) => user && setAuthor(user));
+  }, [data]);
+
+  useEffect(() => {
+    const ch = supabase.channel(`livechat-${id}`);
+    ch
+      .on("broadcast", { event: "typing" }, ({ payload }) => {
+        if (payload.sender !== currentUser?.userId) {
+          setOtherText(payload.text);
+        }
+      })
+      .on("broadcast", { event: "send" }, () => {
+        setOtherText("");
+      })
+      .subscribe();
+    setChannel(ch);
+    return () => {
+      supabase.removeChannel(ch);
+    };
+  }, [id, currentUser]);
+
+  const isOwned = currentUser ? Number(currentUser.userId) === Number(data.author.id) : false;
+
+  async function onSubmit(values: z.infer<typeof LivechatInviteValidation>) {
+    await updateRealtimePost({
+      id,
+      path,
+      content: JSON.stringify({ inviteeId: values.inviteeId }),
+    });
+    store.closeModal();
+  }
+
+  const sendMessage = () => {
+    if (!channel) return;
+    channel.send({ type: "broadcast", event: "send", payload: { sender: currentUser?.userId } });
+    setMyText("");
+    channel.send({ type: "broadcast", event: "typing", payload: { sender: currentUser?.userId, text: "" } });
+  };
+
+  const handleTyping = (val: string) => {
+    setMyText(val);
+    channel?.send({ type: "broadcast", event: "typing", payload: { sender: currentUser?.userId, text: val } });
+  };
+
+  if (currentUser &&
+      currentUser.userId !== data.inviteeId &&
+      currentUser.userId !== ("id" in data.author ? data.author.id : data.author.id)) {
+    return null;
+  }
+
+  return (
+    <BaseNode
+      modalContent={
+        <LivechatNodeModal
+          id={id}
+          isOwned={isOwned}
+          currentInviteeId={data.inviteeId}
+          onSubmit={onSubmit}
+        />
+      }
+      id={id}
+      author={author}
+      isOwned={isOwned}
+      type={"LIVECHAT"}
+      isLocked={data.locked}
+    >
+      <div className="flex flex-col space-y-2 p-2">
+        <textarea className="w-full border rounded text-black p-1" disabled value={otherText} rows={2} />
+        <textarea
+          className="w-full border rounded text-black p-1"
+          value={myText}
+          onChange={(e) => handleTyping(e.target.value)}
+          rows={2}
+        />
+        <button onClick={sendMessage} className="bg-blue-500 text-white rounded px-2 py-1">
+          Send
+        </button>
+      </div>
+    </BaseNode>
+  );
+}
+
+export default LivechatNode;

--- a/components/reactflow/Room.tsx
+++ b/components/reactflow/Room.tsx
@@ -40,6 +40,7 @@ import YoutubeNode from "../nodes/YoutubeNode";
 import CollageNode from "../nodes/CollageNode";
 import GalleryNode from "../nodes/GalleryNode";
 import DrawNode from "../nodes/DrawNode";
+import LivechatNode from "../nodes/LivechatNode";
 import HamburgerMenu from "../shared/HamburgerMenu";
 import NodeSidebar from "../shared/NodeSidebar";
 import { createRealtimeEdge } from "@/lib/actions/realtimeedge.actions";
@@ -313,6 +314,7 @@ function Room({ roomId, initialNodes, initialEdges }: Props) {
     GALLERY: GalleryNode,
     PORTAL: PortalNode,
     DRAW: DrawNode,
+    LIVECHAT: LivechatNode,
   };
   const edgeTypes = {
     DEFAULT: DefaultEdge,

--- a/components/shared/NodeSidebar.tsx
+++ b/components/shared/NodeSidebar.tsx
@@ -41,6 +41,7 @@ const nodeTypes: { label: string; nodeType: AppNodeType }[] = [
   { label: "GALLERY", nodeType: "GALLERY" },
   { label: "PORTAL", nodeType: "PORTAL" },
   { label: "DRAW", nodeType: "DRAW" },
+  { label: "LIVECHAT", nodeType: "LIVECHAT" },
 ];
 
 // Import your modals
@@ -50,6 +51,7 @@ import YoutubeNodeModal from "@/components/modals/YoutubeNodeModal";
 import CollageCreationModal from "@/components/modals/CollageCreationModal";
 import PortalNodeModal from "@/components/modals/PortalNodeModal";
 import GalleryNodeModal from "@/components/modals/GalleryNodeModal";
+import LivechatNodeModal from "@/components/modals/LivechatNodeModal";
 
 export default function NodeSidebar({
   reactFlowRef,
@@ -256,6 +258,24 @@ export default function NodeSidebar({
           type: "DRAW",
           realtimeRoomId: roomId,
         });
+        break;
+
+      case "LIVECHAT":
+        store.openModal(
+          <LivechatNodeModal
+            isOwned={true}
+            currentInviteeId={0}
+            onSubmit={(vals) => {
+              createPostAndAddToCanvas({
+                path: pathname,
+                coordinates: centerPosition,
+                type: "LIVECHAT",
+                realtimeRoomId: roomId,
+                text: JSON.stringify({ inviteeId: vals.inviteeId }),
+              });
+            }}
+          />
+        );
         break;
 
       default:

--- a/lib/models/schema.prisma
+++ b/lib/models/schema.prisma
@@ -182,6 +182,7 @@ enum realtime_post_type {
   PORTAL
   AUDIO
   DRAW
+  LIVECHAT
   DOCUMENT
   THREAD
   CODE

--- a/lib/reactflow/reactflowutils.ts
+++ b/lib/reactflow/reactflowutils.ts
@@ -10,7 +10,8 @@ import {
   GalleryNodeData,
   PortalNode,
   DrawNode,
-  
+  LivechatNode,
+
   AppEdge,
 } from "./types";
 
@@ -194,6 +195,22 @@ export function convertPostToNode(
             y: realtimePost.y_coordinate,
           },
         } as DrawNode;
+      case "LIVECHAT": {
+        let inviteeId = 0;
+        if (realtimePost.content) {
+          try {
+            inviteeId = JSON.parse(realtimePost.content).inviteeId;
+          } catch (e) {
+            inviteeId = 0;
+          }
+        }
+        return {
+          id: realtimePost.id.toString(),
+          type: realtimePost.type,
+          data: { inviteeId, author: authorToSet, locked: realtimePost.locked },
+          position: { x: realtimePost.x_coordinate, y: realtimePost.y_coordinate }
+        } as LivechatNode;
+      }
     
           default:
             throw new Error("Unsupported real-time post type");

--- a/lib/reactflow/types.ts
+++ b/lib/reactflow/types.ts
@@ -107,6 +107,15 @@ export type DrawNode = Node<
   "DRAW"
 >;
 
+export type LivechatNode = Node<
+  {
+    inviteeId: number;
+    author: AuthorOrAuthorId;
+    locked: boolean;
+  },
+  "LIVECHAT"
+>;
+
 export type AudioNode = Node<
   {
     audioUrl: string;
@@ -157,6 +166,7 @@ export const NodeTypeMap = {
   GALLERY: {} as GalleryNodeData,
   PORTAL: {} as PortalNode,
   DRAW: {} as DrawNode,
+  LIVECHAT: {} as LivechatNode,
   AUDIO: {} as AudioNode,
   DOCUMENT: {} as DocumentNode,
   THREAD: {} as ThreadNode,
@@ -177,6 +187,7 @@ export const NodeTypeToModalMap = {
   COLLAGE: CollageCreationModal,
   GALLERY: GalleryNodeModal,
   PORTAL: ShareRoomModal,
+  LIVECHAT: ShareRoomModal,
 };
 
 export type AppNode =
@@ -189,6 +200,7 @@ export type AppNode =
   | GalleryNodeData
   | PortalNode
   | DrawNode
+  | LivechatNode
   | AudioNode
   | DocumentNode
   | ThreadNode
@@ -209,6 +221,7 @@ export const DEFAULT_NODE_VALUES: Record<AppNodeType, string> = {
   ["GALLERY"]: "",
   ["PORTAL"]: "",
   ["DRAW"]: "",
+  ["LIVECHAT"]: "",
   ["AUDIO"]: "",
   ["DOCUMENT"]: "",
   ["THREAD"]: "",

--- a/lib/validations/thread.ts
+++ b/lib/validations/thread.ts
@@ -80,3 +80,7 @@ export const PortalNodeValidation = z.object({
   x: z.number(),
   y: z.number(),
 });
+
+export const LivechatInviteValidation = z.object({
+  inviteeId: z.number(),
+});


### PR DESCRIPTION
## Summary
- add LIVECHAT enum in schema
- create LivechatNode component with Supabase channel support
- add forms and modals for inviting a user
- update node types and mappings
- integrate Livechat in room and sidebar creation
- extend feed post creation options
- add LivechatInviteValidation schema

## Testing
- `npm run lint` *(fails: next not found)*
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6862fa1d14d08329a00b83222980a52e