### PR TITLE
Fix unauthorized node drag

### DIFF
--- a/components/nodes/BaseNode.tsx
+++ b/components/nodes/BaseNode.tsx
@@ -53,7 +53,7 @@ function BaseNode({
     await lockRealtimePost({ id, lockState: newLockState, path: pathname });
   };
 
-  const canDrag = user && !isLocked;
+  const canDrag = user && isOwned && !isLocked;
 
   return (
     <div className={canDrag ? "" : "nodrag"}>

--- a/components/reactflow/Room.tsx
+++ b/components/reactflow/Room.tsx
@@ -286,11 +286,14 @@ function Room({ roomId, initialNodes, initialEdges }: Props) {
         (existing.position.x !== nodePositionChange.position.x ||
           existing.position.y !== nodePositionChange.position.y)
       ) {
-        updateRealtimePost({
-          id: nodePositionChange.id,
-          path: pathname,
-          coordinates: nodePositionChange.position,
-        });
+        const authorId = (existing.data.author as any).id;
+        if (user && Number(authorId) === Number(user.userId)) {
+          updateRealtimePost({
+            id: nodePositionChange.id,
+            path: pathname,
+            coordinates: nodePositionChange.position,
+          });
+        }
       }
     }
     onNodesChangeStore(changes);


### PR DESCRIPTION
## Summary
- restrict node dragging to the owner
- ensure backend update only runs for owned nodes

## Testing
- `yarn install`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6863050959608329968b1ef7d1acdadc