### PR TITLE
Fix username fetch

### DIFF
--- a/lib/actions/user.actions.ts
+++ b/lib/actions/user.actions.ts
@@ -89,7 +89,7 @@ export async function fetchUser(userId: bigint) {
 export async function fetchUserByUsername(username: string) {
   try {
     await prisma.$connect();
-    return await prisma.user.findUnique({
+    return await prisma.user.findFirst({
       where: { username: username.toLowerCase() },
     });
   } catch (error: any) {


### PR DESCRIPTION
## Summary
- use `findFirst` when fetching a user by username

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68630b8f45148329b31237aafa53e94f