### PR TITLE
Fix livechat node user check

### DIFF
--- a/components/nodes/LivechatNode.tsx
+++ b/components/nodes/LivechatNode.tsx
@@ -90,9 +90,12 @@ function LivechatNode({ id, data }: NodeProps<LivechatNodeData>) {
     channel?.send({ type: "broadcast", event: "typing", payload: { sender: Number(currentUser?.userId), text: val } });
   };
 
-  if (currentUser &&
-      currentUser.userId !== data.inviteeId &&
-      currentUser.userId !== ("id" in data.author ? data.author.id : data.author.id)) {
+  if (
+    currentUser &&
+    Number(currentUser.userId) !== Number(data.inviteeId) &&
+    Number(currentUser.userId) !==
+      Number("id" in data.author ? data.author.id : data.author.id)
+  ) {
     return null;
   }
 


### PR DESCRIPTION
## Summary
- handle `bigint` userIds when rendering LivechatNode so invitee can see the node

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68630eedc9c083298e05fd11ce7cef84