### PR TITLE
Enable livechat posts on home feed

### DIFF
--- a/app/(root)/(standard)/page.tsx
+++ b/app/(root)/(standard)/page.tsx
@@ -11,7 +11,15 @@ export const metadata = {
 export default async function Home() {
   const result = await fetchRealtimePosts({
     realtimeRoomId: "global",
-    postTypes: ["TEXT", "VIDEO", "IMAGE", "IMAGE_COMPUTE", "GALLERY", "DRAW"],
+    postTypes: [
+      "TEXT",
+      "VIDEO",
+      "IMAGE",
+      "IMAGE_COMPUTE",
+      "GALLERY",
+      "DRAW",
+      "LIVECHAT",
+    ],
   });
   const user = await getUserFromCookies();
 

--- a/components/cards/LivechatCard.tsx
+++ b/components/cards/LivechatCard.tsx
@@ -1,0 +1,100 @@
+"use client";
+import { useEffect, useState } from "react";
+import { supabase } from "@/lib/supabaseclient";
+import { useAuth } from "@/lib/AuthContext";
+
+interface LivechatCardProps {
+  id: string;
+  inviteeId: number;
+  authorId: number;
+}
+
+function LivechatCard({ id, inviteeId, authorId }: LivechatCardProps) {
+  const { user: currentUser } = useAuth();
+  const [myText, setMyText] = useState("");
+  const [otherText, setOtherText] = useState("");
+  const [channel, setChannel] = useState<any>(null);
+
+  useEffect(() => {
+    const ch = supabase.channel(`livechat-${id}`);
+    ch
+      .on("broadcast", { event: "typing" }, ({ payload }) => {
+        if (Number(payload.sender) !== Number(currentUser?.userId)) {
+          setOtherText(payload.text);
+        }
+      })
+      .on("broadcast", { event: "send" }, () => {
+        setOtherText("");
+      })
+      .subscribe();
+    setChannel(ch);
+    return () => {
+      supabase.removeChannel(ch);
+    };
+  }, [id, currentUser]);
+
+  const sendMessage = () => {
+    if (!channel) return;
+    channel.send({
+      type: "broadcast",
+      event: "send",
+      payload: { sender: Number(currentUser?.userId) },
+    });
+    setMyText("");
+    channel.send({
+      type: "broadcast",
+      event: "typing",
+      payload: { sender: Number(currentUser?.userId), text: "" },
+    });
+  };
+
+  const handleTyping = (val: string) => {
+    setMyText(val);
+    channel?.send({
+      type: "broadcast",
+      event: "typing",
+      payload: { sender: Number(currentUser?.userId), text: val },
+    });
+  };
+
+  if (
+    currentUser &&
+    Number(currentUser.userId) !== Number(inviteeId) &&
+    Number(currentUser.userId) !== Number(authorId)
+  ) {
+    return null;
+  }
+
+  return (
+    <div className="livechat-updater-node flex flex-col py-[2rem] gap-4">
+      <label htmlFor="other" className="text-[1rem] mb-0 mt-0">
+        Other Person
+      </label>
+      <textarea
+        id="other"
+        className="w-[90%] text-block border rounded text-black p-3 custom-scrollbar"
+        disabled
+        value={otherText}
+        rows={5}
+      />
+      <label htmlFor="you" className="text-[1rem] mb-0 mt-0">
+        You
+      </label>
+      <textarea
+        id="you"
+        className="w-[90%] text-block border rounded text-black p-3 mb-4 custom-scrollbar"
+        value={myText}
+        onChange={(e) => handleTyping(e.target.value)}
+        rows={5}
+      />
+      <button
+        onClick={sendMessage}
+        className="bg-transparent likebutton border-none outline-black outline-blue w-[50%] text-black text-[1rem] rounded-xl px-2 py-2"
+      >
+        Clear
+      </button>
+    </div>
+  );
+}
+
+export default LivechatCard;

--- a/components/cards/PostCard.tsx
+++ b/components/cards/PostCard.tsx
@@ -16,6 +16,7 @@ import React from "react";
 import localFont from 'next/font/local'
 const founders = localFont({ src: '/NewEdgeTest-RegularRounded.otf' })
 const DrawCanvas = dynamic(() => import("./DrawCanvas"), { ssr: false })
+const LivechatCard = dynamic(() => import("./LivechatCard"), { ssr: false })
 
 interface Props {
   id: bigint;
@@ -119,11 +120,30 @@ const PostCard = async ({
                 <GalleryCarousel urls={JSON.parse(content)} />
               </div>
             )}
-              {type === "DRAW" && (
-                <div className="mt-2 mb-2 flex justify-center items-center">
-                  <DrawCanvas content={content} />
-                </div>
-              )}
+            {type === "LIVECHAT" && content && (
+              (() => {
+                let inviteeId = 0;
+                try {
+                  inviteeId = JSON.parse(content).inviteeId;
+                } catch (e) {
+                  inviteeId = 0;
+                }
+                return (
+                  <div className="mt-2 mb-2 flex justify-center items-center">
+                    <LivechatCard
+                      id={id.toString()}
+                      inviteeId={inviteeId}
+                      authorId={Number(author.id)}
+                    />
+                  </div>
+                );
+              })()
+            )}
+            {type === "DRAW" && (
+              <div className="mt-2 mb-2 flex justify-center items-center">
+                <DrawCanvas content={content} />
+              </div>
+            )}
             <hr className="mt-4 mb-3 w-full h-px border-t-0 bg-transparent bg-gradient-to-r from-transparent via-slate-100 to-transparent opacity-75" />
 
             <div className="mt-4 flex flex-col gap-x-3 gap-y-4">


### PR DESCRIPTION
## Summary
- create `LivechatCard` for chat functionality
- render `LivechatCard` in `PostCard`
- include `LIVECHAT` type when fetching home feed posts

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6863205ae8a08329a5c9deda8659a0c2