### PR TITLE
Add canvas persistence for draw posts

### DIFF
--- a/components/cards/DrawCanvas.tsx
+++ b/components/cards/DrawCanvas.tsx
@@ -1,10 +1,16 @@
 "use client";
 
 import { useEffect, useRef, useState } from "react";
-import { Tldraw, track, useEditor } from 'tldraw'
+import { Tldraw, track, useEditor } from "tldraw";
+import { usePathname } from "next/navigation";
+import {
+  fetchRealtimePostById,
+  updateRealtimePost,
+} from "@/lib/actions/realtimepost.actions";
 import "tldraw/tldraw.css";
 
 interface DrawCanvasProps {
+  id: string;
   content?: string;
 }
 
@@ -72,14 +78,48 @@ const CustomUi = track(() => {
   )
 })
 
-const DrawCanvas = ({ content }: DrawCanvasProps) => {
+const DrawCanvas = ({ id, content }: DrawCanvasProps) => {
+  const path = usePathname();
   const editorRef = useRef<any>(null);
   const [editorReady, setEditorReady] = useState(false);
+  const lastLoaded = useRef<string | null>(null);
+  const timeoutRef = useRef<NodeJS.Timeout | null>(null);
 
   useEffect(() => {
-    if (editorReady && editorRef.current && content) {
+    if (!editorReady || !editorRef.current) return;
+    fetchRealtimePostById({ id }).then((post) => {
+      if (post?.content) {
+        try {
+          editorRef.current.store.loadStoreSnapshot(
+            JSON.parse(post.content)
+          );
+          lastLoaded.current = post.content;
+        } catch (e) {
+          console.error(e);
+        }
+      }
+    });
+
+    const unsub = editorRef.current.store.listen(() => {
+      if (timeoutRef.current) clearTimeout(timeoutRef.current);
+      timeoutRef.current = setTimeout(() => {
+        const snapshot = editorRef.current.store.getStoreSnapshot();
+        const json = JSON.stringify(snapshot);
+        lastLoaded.current = json;
+        updateRealtimePost({ id, path, content: json });
+      }, 500);
+    });
+    return () => {
+      unsub();
+      if (timeoutRef.current) clearTimeout(timeoutRef.current);
+    };
+  }, [editorReady, id, path]);
+
+  useEffect(() => {
+    if (editorReady && editorRef.current && content && content !== lastLoaded.current) {
       try {
         editorRef.current.store.loadStoreSnapshot(JSON.parse(content));
+        lastLoaded.current = content;
       } catch (e) {
         console.error(e);
       }

--- a/components/cards/PostCard.tsx
+++ b/components/cards/PostCard.tsx
@@ -141,7 +141,7 @@ const PostCard = async ({
             )}
             {type === "DRAW" && (
               <div className="mt-2 mb-2 flex justify-center items-center">
-                <DrawCanvas author={author.name} locked={true} content={content} />
+                <DrawCanvas id={id.toString()} content={content} />
               </div>
             )}
             <hr className="mt-4 mb-3 w-full h-px border-t-0 bg-transparent bg-gradient-to-r from-transparent via-slate-100 to-transparent opacity-75" />


### PR DESCRIPTION
## Summary
- load and persist drawing data in `DrawCanvas` using realtime post actions
- pass post id to `DrawCanvas` in `PostCard`

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68633af6e2b48329bdbb48a2e551a717