### PR TITLE
Display other user's name in livechat

### DIFF
--- a/components/cards/LivechatCard.tsx
+++ b/components/cards/LivechatCard.tsx
@@ -2,6 +2,7 @@
 import { useEffect, useState } from "react";
 import { supabase } from "@/lib/supabaseclient";
 import { useAuth } from "@/lib/AuthContext";
+import { fetchUser } from "@/lib/actions/user.actions";
 
 interface LivechatCardProps {
   id: string;
@@ -14,6 +15,7 @@ function LivechatCard({ id, inviteeId, authorId }: LivechatCardProps) {
   const [myText, setMyText] = useState("");
   const [otherText, setOtherText] = useState("");
   const [channel, setChannel] = useState<any>(null);
+  const [otherUsername, setOtherUsername] = useState("");
 
   useEffect(() => {
     const ch = supabase.channel(`livechat-${id}`);
@@ -32,6 +34,14 @@ function LivechatCard({ id, inviteeId, authorId }: LivechatCardProps) {
       supabase.removeChannel(ch);
     };
   }, [id, currentUser]);
+
+  useEffect(() => {
+    if (!currentUser) return;
+    const otherId =
+      Number(currentUser.userId) === Number(authorId) ? inviteeId : authorId;
+    if (!otherId) return;
+    fetchUser(BigInt(otherId)).then((u) => u && setOtherUsername(u.username));
+  }, [currentUser, inviteeId, authorId]);
 
   const sendMessage = () => {
     if (!channel) return;
@@ -68,7 +78,7 @@ function LivechatCard({ id, inviteeId, authorId }: LivechatCardProps) {
   return (
     <div className="livechat-canvas-node flex flex-col py-[2rem] gap-4">
       <label htmlFor="other" className="text-[1.25rem] mb-0 mt-0">
-        Other Person
+        {otherUsername || "Other Person"}
       </label>
       <textarea
         id="other"

--- a/components/nodes/LivechatNode.tsx
+++ b/components/nodes/LivechatNode.tsx
@@ -33,6 +33,12 @@ function LivechatNode({ id, data }: NodeProps<LivechatNodeData>) {
   const [otherText, setOtherText] = useState("");
   const [channel, setChannel] = useState<any>(null);
   const [inviteeUsername, setInviteeUsername] = useState("");
+  const otherUsername =
+    Number(currentUser?.userId) === Number(data.author.id)
+      ? inviteeUsername
+      : "username" in author
+      ? author.username
+      : "";
 
   useEffect(() => {
     if ("username" in author) return;
@@ -120,7 +126,7 @@ function LivechatNode({ id, data }: NodeProps<LivechatNodeData>) {
     >
 
       <div className="livechat-updater-node  flex flex-col py-[4rem] gap-4 ">
-      <label htmlFor="other" className="text-[1rem] mb-0 mt-0">Other Person</label>
+      <label htmlFor="other" className="text-[1rem] mb-0 mt-0">{otherUsername || "Other Person"}</label>
 
         <textarea 
         id="other"


### PR DESCRIPTION
## Summary
- show the username of the other chat member in `LivechatNode` and `LivechatCard`
- fetch the other user's info when rendering the livechat card

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68642e91d9a883299009ffba404370f1