### PR TITLE
Fix font path references

### DIFF
--- a/app/(auth)/login/page.tsx
+++ b/app/(auth)/login/page.tsx
@@ -8,7 +8,7 @@ import { useRouter } from "next/navigation";
 import { getAuth, signInWithEmailAndPassword } from "firebase/auth";
 import { app } from "@/lib/firebase/firebase";
 import BackgroundCanvas from "@/components/threejs/BackgroundCanvas";
-const founderslight = localFont({ src: "/NewEdgeTest-LightRounded.otf" });
+const founderslight = localFont({ src: "./NewEdgeTest-LightRounded.otf" });
 
 export default function Login() {
   const [email, setEmail] = useState("");

--- a/app/(auth)/onboarding/layout.tsx
+++ b/app/(auth)/onboarding/layout.tsx
@@ -1,7 +1,7 @@
 import localFont from "next/font/local";
 import "../../globals.css";
 
-const founderslight = localFont({ src: "/NewEdgeTest-LightRounded.otf" });
+const founderslight = localFont({ src: "./NewEdgeTest-LightRounded.otf" });
 
 export default function OnboardingLayout({
   children,

--- a/app/(root)/(standard)/layout.tsx
+++ b/app/(root)/(standard)/layout.tsx
@@ -19,8 +19,8 @@ export const metadata = {
   title: "Mesh",
   description: "A social media website",
 };
-const founders = localFont({ src: '/NewEdgeTest-RegularRounded.otf' })
-const founderslight = localFont({ src: '/NewEdgeTest-LightRounded.otf' })
+const founders = localFont({ src: './NewEdgeTest-RegularRounded.otf' })
+const founderslight = localFont({ src: './NewEdgeTest-LightRounded.otf' })
 
 const inter = Inter({ subsets: ["latin"] });
 const nunito = Nunito({ subsets: ['latin'] })

--- a/components/cards/PostCard.tsx
+++ b/components/cards/PostCard.tsx
@@ -16,7 +16,7 @@ import {
 import { Like, RealtimeLike } from "@prisma/client";
 import React from "react";
 import localFont from 'next/font/local'
-const founders = localFont({ src: '/NewEdgeTest-RegularRounded.otf' })
+const founders = localFont({ src: './NewEdgeTest-RegularRounded.otf' })
 const DrawCanvas = dynamic(() => import("./DrawCanvas"), { ssr: false })
 const LivechatCard = dynamic(() => import("./LivechatCard"), { ssr: false })
 

--- a/components/cards/ThreadCard.tsx
+++ b/components/cards/ThreadCard.tsx
@@ -13,7 +13,7 @@ import ReplicateButton from "../buttons/ReplicateButton";
 import ExpandButton from "../buttons/ExpandButton";
 import localFont from 'next/font/local'
 import TimerButton from "../buttons/TimerButton";
-const founders = localFont({ src: '/NewEdgeTest-RegularRounded.otf' })
+const founders = localFont({ src: './NewEdgeTest-RegularRounded.otf' })
 const comfortaa = Comfortaa({
   weight: ["400"],
   subsets: ["latin"],

--- a/components/shared/LeftSidebar.tsx
+++ b/components/shared/LeftSidebar.tsx
@@ -10,7 +10,7 @@ import Link from "next/link";
 import { useRouter } from "next/navigation";
 import localFont from 'next/font/local'
 import CreateFeedPost from "@/components/forms/CreateFeedPost";
-const parabole = localFont({ src: '/Parabole-DisplayRegular.woff2' })
+const parabole = localFont({ src: './Parabole-DisplayRegular.woff2' })
 
 interface Props {
   userRooms: RealtimeRoom[];

--- a/components/shared/Topbar.tsx
+++ b/components/shared/Topbar.tsx
@@ -9,7 +9,7 @@ import { app } from "@/lib/firebase/firebase";
 import { useAuth } from "@/lib/AuthContext";
 import { Chakra_Petch } from "next/font/google";
 import localFont from 'next/font/local'
-const parabole = localFont({ src: '/Parabole-DisplayRegular.woff2' })
+const parabole = localFont({ src: './Parabole-DisplayRegular.woff2' })
 
 
 const chakra = Chakra_Petch({


### PR DESCRIPTION
## Summary
- ensure local fonts use relative paths

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6864587d56b8832992cde95af20377da