### PR TITLE
Add dynamic rendering flags

### DIFF
--- a/app/(root)/(realtime)/post/layout.tsx
+++ b/app/(root)/(realtime)/post/layout.tsx
@@ -14,6 +14,8 @@ export const metadata = {
   description: "A social media website",
 };
 
+export const dynamic = "force-dynamic";
+
 const chakra = Chakra_Petch({
   weight: ["400", "500", "700"],
   subsets: ["latin"],

--- a/app/(root)/(realtime)/room/layout.tsx
+++ b/app/(root)/(realtime)/room/layout.tsx
@@ -11,6 +11,8 @@ export const metadata = {
   description: "A social media website",
 };
 
+export const dynamic = "force-dynamic";
+
 const chakra = Chakra_Petch({
   weight: ["400", "500", "700"],
   subsets: ["latin"],

--- a/app/(root)/(standard)/create-room/page.tsx
+++ b/app/(root)/(standard)/create-room/page.tsx
@@ -1,5 +1,7 @@
 import CreateRoom from "@/components/forms/CreateRoom";
 
+export const dynamic = "force-dynamic";
+
 async function Page() {
   return (
     <>

--- a/app/(root)/(standard)/layout.tsx
+++ b/app/(root)/(standard)/layout.tsx
@@ -19,6 +19,8 @@ export const metadata = {
   title: "Mesh",
   description: "A social media website",
 };
+
+export const dynamic = "force-dynamic";
 const founders = localFont({ src: './NewEdgeTest-RegularRounded.otf' })
 const founderslight = localFont({ src: './NewEdgeTest-LightRounded.otf' })
 

--- a/app/(root)/(standard)/page.tsx
+++ b/app/(root)/(standard)/page.tsx
@@ -9,6 +9,9 @@ export const metadata = {
   description: "A website",
 };
 
+// Force this page to be rendered dynamically on every request
+export const dynamic = "force-dynamic";
+
 export default async function Home() {
   const result = await fetchRealtimePosts({
     realtimeRoomId: "global",


### PR DESCRIPTION
## Summary
- force dynamic rendering for main page and create-room route
- mark layouts as dynamic for authenticated sections

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68645bfa114c8329962e81e661827897