### PR TITLE
Implement recursive post deletion

### DIFF
--- a/components/buttons/DeleteCardButton.tsx
+++ b/components/buttons/DeleteCardButton.tsx
@@ -1,46 +1,36 @@
 "use client";
 
 import Image from "next/image";
-import useStore from "@/lib/reactflow/store";
-import { AppState } from "@/lib/reactflow/types";
-import { useShallow } from "zustand/react/shallow";
-import TimerModal from "../modals/TimerModal";
-
-interface Props {
-  postId: bigint;
-  isOwned: boolean;
-  expirationDate?: string | null;
-}
+import { deletePost } from "@/lib/actions/thread.actions";
+import { deleteRealtimePost } from "@/lib/actions/realtimepost.actions";
 
 interface Props {
   postId?: bigint;
   realtimePostId?: string;
 }
 
-const DeleteCardButton = ({ postId, isOwned, expirationDate }: Props) => {
-    const { openModal } = useStore(
-      useShallow((state: AppState) => ({
-        openModal: state.openModal,
-      }))
-    );
-  
-    return (
-      <button>
+const DeleteCardButton = ({ postId, realtimePostId }: Props) => {
+  const handleDelete = async () => {
+    if (!confirm("Are you sure you want to delete this post?")) return;
+    if (realtimePostId) {
+      await deleteRealtimePost({ id: realtimePostId });
+    } else if (postId) {
+      await deletePost({ id: postId });
+    }
+  };
+
+  return (
+    <button onClick={handleDelete}>
       <Image
         src="/assets/trash-can.svg"
         alt="trash"
         width={24}
         height={24}
         className="cursor-pointer object-contain likebutton"
-        onClick={() =>
-          openModal(
-            <TimerModal postId={postId} isOwned={isOwned} expirationDate={expirationDate} />
-          )
-        }
       />
-      </button>
-    );
-  };
+    </button>
+  );
+};
   
 
 export default DeleteCardButton;

--- a/components/cards/PostCard.tsx
+++ b/components/cards/PostCard.tsx
@@ -171,11 +171,7 @@ const PostCard = async ({
             isOwned={currentUserId === author.id}
             expirationDate={expirationDate ?? undefined}
           />
-          <DeleteCardButton
-            postId={id}
-            isOwned={currentUserId === author.id}
-            expirationDate={expirationDate ?? undefined}
-          />
+          <DeleteCardButton postId={id} />
 
               </div>
             </div>

--- a/lib/actions/thread.actions.ts
+++ b/lib/actions/thread.actions.ts
@@ -2,6 +2,7 @@
 
 import { prisma } from "../prismaclient";
 import { revalidatePath } from "next/cache";
+import { getUserFromCookies } from "../serverutils";
 
 interface CreatePostParams {
   text: string;
@@ -268,4 +269,33 @@ export async function archiveExpiredPosts() {
     }),
     prisma.post.deleteMany({ where: { id: { in: ids } } }),
   ]);
+}
+
+export async function deletePost({ id }: { id: bigint }) {
+  const user = await getUserFromCookies();
+  try {
+    await prisma.$connect();
+    const originalPost = await prisma.post.findUniqueOrThrow({
+      where: {
+        id: id,
+      },
+    });
+    if (!user || user.userId != originalPost.author_id) {
+      return;
+    }
+
+    const ids: bigint[] = [];
+    const collect = async (postId: bigint) => {
+      const children = await prisma.post.findMany({ where: { parent_id: postId } });
+      for (const child of children) {
+        await collect(child.id);
+      }
+      ids.push(postId);
+    };
+
+    await collect(id);
+    await prisma.post.deleteMany({ where: { id: { in: ids } } });
+  } catch (error: any) {
+    console.error("Failed to delete post:", error);
+  }
 }


### PR DESCRIPTION
## Summary
- add `deletePost` in `thread.actions.ts` that checks ownership and removes a post with all its children
- update `DeleteCardButton` to confirm then delete posts or realtime posts
- adjust `PostCard` to use new `DeleteCardButton`

## Testing
- `yarn install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_686487ee39ac8329976f0e21b4d79087