### PR TITLE
Implement post replication

### DIFF
--- a/components/buttons/ReplicateButton.tsx
+++ b/components/buttons/ReplicateButton.tsx
@@ -1,11 +1,9 @@
 "use client";
 
-import { dislikePost, likePost, unlikePost } from "@/lib/actions/like.actions";
+import { replicatePost } from "@/lib/actions/thread.actions";
 import { useAuth } from "@/lib/AuthContext";
-import { Like } from "@prisma/client";
 import Image from "next/image";
-import { useRouter } from "next/navigation";
-import { useState } from "react";
+import { useRouter, usePathname } from "next/navigation";
 
 interface Props {
   postId?: bigint;
@@ -15,25 +13,38 @@ interface Props {
 const ReplicateButton = ({ postId }: Props) => {
   const user = useAuth();
   const router = useRouter();
+  const pathname = usePathname();
   const isUserSignedIn = !!user.user;
   const userObjectId = user?.user?.userId;
 
+  async function handleClick() {
+    if (!isUserSignedIn) {
+      router.push("/login");
+      return;
+    }
+    if (!userObjectId || !postId) {
+      router.push("/onboarding");
+      return;
+    }
+    await replicatePost({
+      originalPostId: postId,
+      userId: userObjectId,
+      path: pathname,
+    });
+    router.refresh();
+  }
 
- 
   return (
-<button>
-    <Image
-                  src="/assets/replicate.svg"
-                  alt="replicate"
-                  width={24}
-                  height={24}
-                  className="cursor-pointer object-contain likebutton"
-                />
-                </button>
-
+    <button onClick={handleClick}>
+      <Image
+        src="/assets/replicate.svg"
+        alt="replicate"
+        width={24}
+        height={24}
+        className="cursor-pointer object-contain likebutton"
+      />
+    </button>
   );
-  
 };
-
 
 export default ReplicateButton;

--- a/components/cards/PostCard.tsx
+++ b/components/cards/PostCard.tsx
@@ -8,6 +8,7 @@ import TimerButton from "../buttons/TimerButton";
 import ReplicateButton from "../buttons/ReplicateButton";
 import DeleteCardButton from "../buttons/DeleteCardButton";
 import GalleryCarousel from "./GalleryCarousel";
+import ReplicatedPostCard from "./ReplicatedPostCard";
 import dynamic from "next/dynamic";
 import {
   fetchLikeForCurrentUser,
@@ -61,6 +62,20 @@ const PostCard = async ({
           userId: currentUserId,
         })
       : await fetchLikeForCurrentUser({ postId: id, userId: currentUserId });
+  }
+  if (content && content.startsWith("REPLICATE:")) {
+    const originalId = BigInt(content.split(":" )[1]);
+    return (
+      <ReplicatedPostCard
+        id={id}
+        originalPostId={originalId}
+        currentUserId={currentUserId}
+        author={author}
+        createdAt={createdAt}
+        likeCount={likeCount}
+        expirationDate={expirationDate ?? undefined}
+      />
+    );
   }
   return (
     <article className="relative flex w-full flex-col postcard p-7 ">

--- a/components/cards/ReplicatedPostCard.tsx
+++ b/components/cards/ReplicatedPostCard.tsx
@@ -1,0 +1,58 @@
+import PostCard from "./PostCard";
+import { fetchPostById } from "@/lib/actions/thread.actions";
+
+interface Props {
+  id: bigint;
+  originalPostId: bigint;
+  currentUserId?: bigint | null;
+  author: {
+    name: string | null;
+    image: string | null;
+    id: bigint;
+  };
+  createdAt: string;
+  likeCount: number;
+  expirationDate?: string | null;
+}
+
+const ReplicatedPostCard = async ({
+  id,
+  originalPostId,
+  currentUserId,
+  author,
+  createdAt,
+  likeCount,
+  expirationDate,
+}: Props) => {
+  const original = await fetchPostById(originalPostId);
+  if (!original) return null;
+
+  return (
+    <article className="flex flex-col gap-4">
+      <PostCard
+        id={id}
+        currentUserId={currentUserId}
+        content="Replicated"
+        type="TEXT"
+        author={author}
+        createdAt={createdAt}
+        likeCount={likeCount}
+        expirationDate={expirationDate ?? undefined}
+      />
+      <div className="ml-6">
+        <PostCard
+          id={original.id}
+          currentUserId={currentUserId}
+          content={original.content}
+          type="TEXT"
+          author={original.author!}
+          createdAt={original.created_at.toDateString()}
+          likeCount={original.like_count}
+          expirationDate={original.expiration_date?.toISOString() ?? null}
+        />
+      </div>
+    </article>
+  );
+};
+
+export default ReplicatedPostCard;


### PR DESCRIPTION
## Summary
- add `replicatePost` server action
- show replicated posts through new `ReplicatedPostCard`
- trigger replication from `ReplicateButton`
- render replicated posts in `PostCard`

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_686487ef1e8c832984bf9b8e3deb9dab