### PR TITLE
Add share modal for posts

### DIFF
--- a/components/buttons/ShareButton.tsx
+++ b/components/buttons/ShareButton.tsx
@@ -1,39 +1,39 @@
 "use client";
 
-import { dislikePost, likePost, unlikePost } from "@/lib/actions/like.actions";
-import { useAuth } from "@/lib/AuthContext";
-import { Like } from "@prisma/client";
 import Image from "next/image";
-import { useRouter } from "next/navigation";
-import { useState } from "react";
+import useStore from "@/lib/reactflow/store";
+import { AppState } from "@/lib/reactflow/types";
+import { useShallow } from "zustand/react/shallow";
+import SharePostModal from "../modals/SharePostModal";
 
 interface Props {
   postId?: bigint;
   realtimePostId?: string;
 }
 
-const ShareButton = ({ postId }: Props) => {
-  const user = useAuth();
-  const router = useRouter();
-  const isUserSignedIn = !!user.user;
-  const userObjectId = user?.user?.userId;
-
-
- 
-  return (
-<button>
-    <Image
-                  src="/assets/send--alt.svg"
-                  alt="share"
-                  width={24}
-                  height={24}
-                  className="cursor-pointer object-contain likebutton"
-                />
-                </button>
-
+const ShareButton = ({ postId, realtimePostId }: Props) => {
+  const { openModal } = useStore(
+    useShallow((state: AppState) => ({
+      openModal: state.openModal,
+    }))
   );
-  
-};
 
+  return (
+    <button>
+      <Image
+        src="/assets/send--alt.svg"
+        alt="share"
+        width={24}
+        height={24}
+        className="cursor-pointer object-contain likebutton"
+        onClick={() =>
+          openModal(
+            <SharePostModal postId={postId} realtimePostId={realtimePostId} />
+          )
+        }
+      />
+    </button>
+  );
+};
 
 export default ShareButton;

--- a/components/modals/SharePostModal.tsx
+++ b/components/modals/SharePostModal.tsx
@@ -1,0 +1,57 @@
+import { CopyIcon } from "lucide-react";
+import { Button } from "../ui/button";
+import {
+  DialogClose,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "../ui/dialog";
+import { Input } from "../ui/input";
+
+interface Props {
+  postId?: bigint;
+  realtimePostId?: string;
+}
+
+const SharePostModal = ({ postId, realtimePostId }: Props) => {
+  const shareLink = realtimePostId
+    ? `${window.location.origin}/post/${realtimePostId}`
+    : `${window.location.origin}/thread/${postId?.toString()}`;
+  return (
+    <div>
+      <DialogContent className="max-w-[57rem]">
+        <DialogTitle>Share Post</DialogTitle>
+        <div className="grid rounded-md px-4 py-2">
+          <div>
+            <DialogHeader className="dialog-header text-white text-lg py-4 mt-[-4rem]">
+              <b>Share Post</b>
+            </DialogHeader>
+            <div className="flex">
+              <Input
+                readOnly
+                value={shareLink}
+                className="w-[45%] bg-gray-300"
+              />
+              <Button type="submit" size="icon" className="">
+                <CopyIcon
+                  className="h-6 w-6"
+                  onClick={() => {
+                    navigator.clipboard.writeText(shareLink);
+                  }}
+                />
+              </Button>
+            </div>
+          </div>
+        </div>
+        <div className="py-4">
+          <DialogClose id="animateButton" className={`form-submit-button pl-2 py-2 pr-[1rem]`}>
+            <div className="w-2"></div>
+            <> Close </>
+          </DialogClose>
+        </div>
+      </DialogContent>
+    </div>
+  );
+};
+
+export default SharePostModal;


### PR DESCRIPTION
## Summary
- create `SharePostModal` to share post links
- update `ShareButton` to use the modal via `useStore().openModal`

## Testing
- `yarn install`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_686487f0d34083298402f0857c22aba0