### PR TITLE
Add modal for user rooms

### DIFF
--- a/components/modals/UserRoomsModal.tsx
+++ b/components/modals/UserRoomsModal.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+import { RealtimeRoom } from "@prisma/client";
+import Link from "next/link";
+import Image from "next/image";
+import { DialogContent, DialogTitle, DialogClose } from "@/components/ui/dialog";
+
+interface Props {
+  userRooms: RealtimeRoom[];
+}
+
+const UserRoomsModal = ({ userRooms }: Props) => {
+  return (
+    <div>
+      <DialogContent className="max-w-[30rem]">
+        <DialogTitle>Your Rooms</DialogTitle>
+        <div className="grid rounded-md px-4 py-2">
+          <div className="custom-scrollbar max-h-60 overflow-y-auto flex flex-col gap-2 py-2">
+            {userRooms.length > 0 ? (
+              userRooms.map((room) => (
+                <Link
+                  href={`/room/${room.id}`}
+                  key={room.id}
+                  className="flex items-center gap-2 p-2 hover:bg-slate-100 rounded"
+                >
+                  <Image
+                    src={room.room_icon}
+                    alt={room.id}
+                    width={24}
+                    height={24}
+                    className="object-contain h-6 w-6"
+                  />
+                  <p className="text-black">{room.id}</p>
+                </Link>
+              ))
+            ) : (
+              <p className="text-black">No rooms</p>
+            )}
+          </div>
+          <div className="py-4">
+            <DialogClose id="animateButton" className="form-submit-button pl-2 py-2 pr-[1rem]">
+              <>Close</>
+            </DialogClose>
+          </div>
+        </div>
+      </DialogContent>
+    </div>
+  );
+};
+
+export default UserRoomsModal;

--- a/components/shared/LeftSidebar.tsx
+++ b/components/shared/LeftSidebar.tsx
@@ -8,8 +8,12 @@ import { getAuth, signOut } from "firebase/auth";
 import Image from "next/image";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
-import localFont from 'next/font/local'
+import localFont from "next/font/local";
 import CreateFeedPost from "@/components/forms/CreateFeedPost";
+import useStore from "@/lib/reactflow/store";
+import { AppState } from "@/lib/reactflow/types";
+import { useShallow } from "zustand/react/shallow";
+import UserRoomsModal from "../modals/UserRoomsModal";
 const parabole = localFont({ src: './Parabole-DisplayRegular.woff2' })
 
 interface Props {
@@ -20,6 +24,15 @@ function LeftSidebar({ userRooms }: Props) {
   const router = useRouter();
   const user = useAuth();
   const isUserSignedIn = !!user.user;
+  const store = useStore(
+    useShallow((state: AppState) => ({
+      openModal: state.openModal,
+    }))
+  );
+
+  const openRoomsModal = () => {
+    store.openModal(<UserRoomsModal userRooms={userRooms} />);
+  };
 
   async function handleLogout() {
     await signOut(getAuth(app));
@@ -73,18 +86,14 @@ function LeftSidebar({ userRooms }: Props) {
               <p className="text-black tracking-[.05rem] max-lg:hidden">{"Global"}</p>
             </Link>
        
-        <Link
-          href={`/create-room`}
-          className="leftsidebar_link leftsidebar-item  rounded-md hover:outline-2 hover:outline-double hover:outline-indigo-400"
+        <Button
+          variant="outline"
+          className="leftsidebar_link leftsidebar-item rounded-md hover:outline-2 hover:outline-double hover:outline-indigo-400"
+          onClick={openRoomsModal}
         >
-          <Image
-            src="/assets/3D-print-mesh.svg"
-            alt="YourRooms"
-            width={24}
-            height={24}
-          />
+          <Image src="/assets/3D-print-mesh.svg" alt="YourRooms" width={24} height={24} />
           <p className="text-black  max-lg:hidden">{"Your Rooms"}</p>
-        </Link>
+        </Button>
         <Link
           href={`/create-room`}
           className="leftsidebar_link leftsidebar-item border-[1px] border-rose-300 border-opacity-80	 rounded-md hover:outline-2 hover:outline-double hover:outline-red-400"


### PR DESCRIPTION
## Summary
- create `UserRoomsModal` for listing a user's rooms
- open modal from `LeftSidebar` instead of linking directly

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_686487f3a81883298876811fa5921242