### PR TITLE
Fix replicate error for realtime posts

### DIFF
--- a/components/cards/PostCard.tsx
+++ b/components/cards/PostCard.tsx
@@ -183,7 +183,7 @@ const PostCard = async ({
                       commentCount={commentCount}
                     />
                   </>
-            <ReplicateButton postId={id} />
+            {!isRealtimePost && <ReplicateButton postId={id} />}
           <ShareButton postId={id} />
           <TimerButton
             postId={id}


### PR DESCRIPTION
## Summary
- hide the ReplicateButton on realtime posts so server action isn't called with invalid IDs

## Testing
- `yarn install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68649c40f3508329b698ab5e1e9f6844