### PR TITLE
Add LLM instruction node

### DIFF
--- a/components/nodes/LLMInstructionNode.tsx
+++ b/components/nodes/LLMInstructionNode.tsx
@@ -1,0 +1,92 @@
+"use client";
+
+import { runLLMInstruction } from "@/lib/actions/llm.actions";
+import { useAuth } from "@/lib/AuthContext";
+import useStore from "@/lib/reactflow/store";
+import { AppState, LLMInstructionNode as LLMNodeType } from "@/lib/reactflow/types";
+import { NodeProps, getOutgoers } from "@xyflow/react";
+import { usePathname } from "next/navigation";
+import { useEffect, useState } from "react";
+import BaseNode from "./BaseNode";
+import { fetchUser } from "@/lib/actions/user.actions";
+import { useShallow } from "zustand/react/shallow";
+
+function LLMInstructionNode({ id, data }: NodeProps<LLMNodeType>) {
+  const path = usePathname();
+  const currentUser = useAuth().user;
+  const store = useStore(
+    useShallow((state: AppState) => ({
+      nodes: state.nodes,
+      edges: state.edges,
+      setNodes: state.setNodes,
+    }))
+  );
+  const [prompt, setPrompt] = useState(data.prompt);
+  const [output, setOutput] = useState(data.output);
+  const [status, setStatus] = useState<"pending" | "running" | "complete">(
+    data.status || "pending"
+  );
+  const [author, setAuthor] = useState(data.author);
+
+  useEffect(() => {
+    if ("username" in author) return;
+    fetchUser(data.author.id).then((u) => u && setAuthor(u));
+  }, [data.author]);
+
+  const isOwned = currentUser ? Number(currentUser.userId) === Number(data.author.id) : false;
+
+  const runInstruction = async () => {
+    setStatus("running");
+    try {
+      const result = await runLLMInstruction({ prompt, model: data.model });
+      setOutput(result);
+      setStatus("complete");
+      const updatedNodes = store.nodes.map((n) => {
+        if (n.id === id && n.type === "LLM_INSTRUCTION") {
+          return { ...n, data: { ...(n as any).data, prompt, output: result, status: "complete" } } as LLMNodeType;
+        }
+        if (n.id !== id && n.type === "LLM_INSTRUCTION") {
+          return n;
+        }
+        return n;
+      });
+      const outgoers = getOutgoers({ id }, store.nodes, store.edges);
+      outgoers.forEach((node) => {
+        if (node.type === "LLM_INSTRUCTION") {
+          (node as any).data.prompt = result;
+        }
+      });
+      store.setNodes(updatedNodes);
+    } catch (err) {
+      console.error(err);
+      setStatus("pending");
+    }
+  };
+
+  return (
+    <BaseNode
+      modalContent={null}
+      id={id}
+      author={author}
+      isOwned={isOwned}
+      type={"LLM_INSTRUCTION"}
+      generateOnClick={runInstruction}
+      isLocked={data.locked}
+    >
+      <div className="flex flex-col gap-2 p-2">
+        <textarea
+          className="w-full rounded text-black p-1 text-sm"
+          rows={3}
+          value={prompt}
+          onChange={(e) => setPrompt(e.target.value)}
+        />
+        <div className="text-xs">Status: {status}</div>
+        <div className="border rounded p-2 text-sm min-h-[3rem] bg-white text-black">
+          {output || "No output"}
+        </div>
+      </div>
+    </BaseNode>
+  );
+}
+
+export default LLMInstructionNode;

--- a/components/reactflow/Room.tsx
+++ b/components/reactflow/Room.tsx
@@ -41,6 +41,7 @@ import CollageNode from "../nodes/CollageNode";
 import GalleryNode from "../nodes/GalleryNode";
 import DrawNode from "../nodes/DrawNode";
 import LivechatNode from "../nodes/LivechatNode";
+import LLMInstructionNode from "../nodes/LLMInstructionNode";
 import HamburgerMenu from "../shared/HamburgerMenu";
 import NodeSidebar from "../shared/NodeSidebar";
 import { createRealtimeEdge } from "@/lib/actions/realtimeedge.actions";
@@ -318,6 +319,7 @@ function Room({ roomId, initialNodes, initialEdges }: Props) {
     PORTAL: PortalNode,
     DRAW: DrawNode,
     LIVECHAT: LivechatNode,
+    LLM_INSTRUCTION: LLMInstructionNode,
   };
   const edgeTypes = {
     DEFAULT: DefaultEdge,

--- a/lib/actions/llm.actions.ts
+++ b/lib/actions/llm.actions.ts
@@ -1,0 +1,20 @@
+"use server";
+
+import OpenAI from "openai";
+
+const apiKey = process.env.OPENAI_API_KEY;
+const openai = new OpenAI({ apiKey });
+
+export async function runLLMInstruction({ prompt, model = "gpt-3.5-turbo" }: { prompt: string; model?: string }) {
+  try {
+    if (!apiKey) throw new Error("Missing OPENAI_API_KEY");
+    const completion = await openai.chat.completions.create({
+      model,
+      messages: [{ role: "user", content: prompt }],
+    });
+    return completion.choices[0]?.message?.content || "";
+  } catch (error) {
+    console.error("LLM instruction failed", error);
+    return "";
+  }
+}

--- a/lib/reactflow/types.ts
+++ b/lib/reactflow/types.ts
@@ -152,6 +152,18 @@ export type CodeNode = Node<
   "CODE"
 >;
 
+export type LLMInstructionNode = Node<
+  {
+    prompt: string;
+    output: string;
+    status: "pending" | "running" | "complete";
+    author: AuthorOrAuthorId;
+    locked: boolean;
+    model?: string;
+  },
+  "LLM_INSTRUCTION"
+>;
+
 
 
 export type DefaultEdge = Edge<{}, "DEFAULT">;
@@ -171,6 +183,7 @@ export const NodeTypeMap = {
   DOCUMENT: {} as DocumentNode,
   THREAD: {} as ThreadNode,
   CODE: {} as CodeNode,
+  LLM_INSTRUCTION: {} as LLMInstructionNode,
 };
 
 export interface AppEdgeMapping {
@@ -204,7 +217,8 @@ export type AppNode =
   | AudioNode
   | DocumentNode
   | ThreadNode
-  | CodeNode;
+  | CodeNode
+  | LLMInstructionNode;
 
 export type AppEdgeType = keyof AppEdgeMapping;
 
@@ -226,6 +240,7 @@ export const DEFAULT_NODE_VALUES: Record<AppNodeType, string> = {
   ["DOCUMENT"]: "",
   ["THREAD"]: "",
   ["CODE"]: "",
+  ["LLM_INSTRUCTION"]: "",
 };
 
 export type AppState = {


### PR DESCRIPTION
## Summary
- create `LLMInstructionNode` component
- support calling OpenAI via `runLLMInstruction` server action
- extend `NodeTypeMap` and room mapping for new node type

## Testing
- `yarn install`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6864ae2107b883298a56ec4af46afd31