### PR TITLE
Fix post deletion & repost

### DIFF
--- a/components/buttons/DeleteCardButton.tsx
+++ b/components/buttons/DeleteCardButton.tsx
@@ -3,6 +3,7 @@
 import Image from "next/image";
 import { deletePost } from "@/lib/actions/thread.actions";
 import { deleteRealtimePost } from "@/lib/actions/realtimepost.actions";
+import { useRouter, usePathname } from "next/navigation";
 
 interface Props {
   postId?: bigint;
@@ -10,13 +11,17 @@ interface Props {
 }
 
 const DeleteCardButton = ({ postId, realtimePostId }: Props) => {
+  const router = useRouter();
+  const pathname = usePathname();
+
   const handleDelete = async () => {
     if (!confirm("Are you sure you want to delete this post?")) return;
     if (realtimePostId) {
-      await deleteRealtimePost({ id: realtimePostId });
+      await deleteRealtimePost({ id: realtimePostId, path: pathname });
     } else if (postId) {
-      await deletePost({ id: postId });
+      await deletePost({ id: postId, path: pathname });
     }
+    router.refresh();
   };
 
   return (

--- a/components/buttons/ReplicateButton.tsx
+++ b/components/buttons/ReplicateButton.tsx
@@ -30,8 +30,8 @@ const ReplicateButton = ({ postId }: Props) => {
       return;
     }
     await replicatePost({
-      originalPostId: postId,
-      userId: userObjectId,
+      originalPostId: postId.toString(),
+      userId: userObjectId.toString(),
       path: pathname,
     });
     router.refresh();

--- a/lib/actions/realtimepost.actions.ts
+++ b/lib/actions/realtimepost.actions.ts
@@ -238,7 +238,13 @@ export async function fetchRealtimePosts({
   }));
 }
 
-export async function deleteRealtimePost({ id }: { id: string }) {
+export async function deleteRealtimePost({
+  id,
+  path,
+}: {
+  id: string;
+  path?: string;
+}) {
   const user = await getUserFromCookies();
   try {
     await prisma.$connect();
@@ -255,6 +261,7 @@ export async function deleteRealtimePost({ id }: { id: string }) {
         id: BigInt(id),
       },
     });
+    if (path) revalidatePath(path);
   } catch (error: any) {
     console.error("Failed to delete real-time post:", error);
   }

--- a/lib/actions/thread.actions.ts
+++ b/lib/actions/thread.actions.ts
@@ -336,7 +336,7 @@ export async function archiveExpiredPosts() {
   ]);
 }
 
-export async function deletePost({ id }: { id: bigint }) {
+export async function deletePost({ id, path }: { id: bigint; path?: string }) {
   const user = await getUserFromCookies();
   try {
     await prisma.$connect();
@@ -360,6 +360,7 @@ export async function deletePost({ id }: { id: bigint }) {
 
     await collect(id);
     await prisma.post.deleteMany({ where: { id: { in: ids } } });
+    if (path) revalidatePath(path);
   } catch (error: any) {
     console.error("Failed to delete post:", error);
   }


### PR DESCRIPTION
## Summary
- refresh feed on post deletion
- make replicate button stringify ids for server action
- revalidate path on post delete actions

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6864cc7eaae08329bfc39f7559c7413d