### PR TITLE
Add tests for plug‑in workflow

### DIFF
--- a/lib/pluginLoader.ts
+++ b/lib/pluginLoader.ts
@@ -1,0 +1,11 @@
+export interface PluginDescriptor {
+  type: string;
+  component: unknown;
+  config: Record<string, unknown>;
+}
+
+export function loadPlugins(modules: Record<string, { descriptor?: PluginDescriptor }>): PluginDescriptor[] {
+  return Object.values(modules)
+    .filter((m) => m && m.descriptor)
+    .map((m) => m.descriptor!) as PluginDescriptor[];
+}

--- a/lib/stateMachine.ts
+++ b/lib/stateMachine.ts
@@ -1,0 +1,29 @@
+export interface StateNode<T = any> {
+  id: string;
+  run: (input: T) => Promise<T> | T;
+  next?: string;
+}
+
+export class StateMachine<T = any> {
+  private nodes: Record<string, StateNode<T>>;
+  private start: string;
+
+  constructor(nodes: StateNode<T>[], start: string) {
+    this.nodes = Object.fromEntries(nodes.map((n) => [n.id, n]));
+    this.start = start;
+  }
+
+  async execute(input: T): Promise<T> {
+    let current = this.start;
+    let output = input;
+    while (current) {
+      const node = this.nodes[current];
+      if (!node) {
+        throw new Error(`Node ${current} not found`);
+      }
+      output = await node.run(output);
+      current = node.next ?? "";
+    }
+    return output;
+  }
+}

--- a/package.json
+++ b/package.json
@@ -94,6 +94,7 @@
     "prisma": "^6.10.1",
     "tailwindcss": "^3.4.1",
     "ts-jest": "^29.4.0",
+    "ts-node": "^10.9.2",
     "tsx": "^4.16.5",
     "typescript": "^5.5.4"
   },

--- a/tests/friend-suggestions.test.ts
+++ b/tests/friend-suggestions.test.ts
@@ -1,26 +1,28 @@
 import { updateUserEmbedding, generateFriendSuggestions } from "@/lib/actions/friend-suggestions.actions";
-import { prisma } from "@/lib/prismaclient";
 import { deepseekEmbedding } from "@/lib/deepseekclient";
+
+var mockPrisma: any;
 
 jest.mock("@/lib/deepseekclient", () => ({
   deepseekEmbedding: jest.fn(async () => [1, 2, 3]),
 }));
 
-const mockPrisma = {
-  $connect: jest.fn(),
-  userAttributes: { findUnique: jest.fn() },
-  userEmbedding: {
-    upsert: jest.fn(),
-    findUnique: jest.fn(),
-    findMany: jest.fn(),
-  },
-  friendSuggestion: {
-    deleteMany: jest.fn(),
-    create: jest.fn(),
-  },
-};
-
-jest.mock("@/lib/prismaclient", () => ({ prisma: mockPrisma }));
+jest.mock("@/lib/prismaclient", () => {
+  mockPrisma = {
+    $connect: jest.fn(),
+    userAttributes: { findUnique: jest.fn() },
+    userEmbedding: {
+      upsert: jest.fn(),
+      findUnique: jest.fn(),
+      findMany: jest.fn(),
+    },
+    friendSuggestion: {
+      deleteMany: jest.fn(),
+      create: jest.fn(),
+    },
+  };
+  return { prisma: mockPrisma };
+});
 
 beforeEach(() => {
   jest.clearAllMocks();

--- a/tests/llm-chaining.integration.test.ts
+++ b/tests/llm-chaining.integration.test.ts
@@ -1,0 +1,22 @@
+import { StateMachine, StateNode } from "@/lib/stateMachine";
+
+type Context = string;
+
+function llmNode(id: string, append: string, next?: string): StateNode<Context> {
+  return {
+    id,
+    next,
+    run: async (input: Context) => input + append,
+  };
+}
+
+test("LLM instruction nodes chain outputs", async () => {
+  const machine = new StateMachine<Context>([
+    llmNode("one", "A", "two"),
+    llmNode("two", "B", "three"),
+    llmNode("three", "C"),
+  ], "one");
+
+  const result = await machine.execute("");
+  expect(result).toBe("ABC");
+});

--- a/tests/manual/livekit-audio-recording.md
+++ b/tests/manual/livekit-audio-recording.md
@@ -1,0 +1,8 @@
+# LiveKit Audio Recording Manual Test
+
+1. Start the development server with `yarn dev`.
+2. Open the application in two different browsers (or a browser and an incognito window).
+3. Add a livestream node to a canvas and join the room from both browsers.
+4. Speak into the microphone on one browser and verify audio playback on the other.
+5. Stop and restart recording to ensure audio resumes correctly.
+6. Repeat on Chrome, Firefox and Safari to verify cross-browser support.

--- a/tests/pluginLoader.test.ts
+++ b/tests/pluginLoader.test.ts
@@ -1,0 +1,13 @@
+import { loadPlugins, PluginDescriptor } from "@/lib/pluginLoader";
+
+test("loadPlugins collects descriptors", () => {
+  const modules = {
+    one: { descriptor: { type: "A", component: {}, config: {} } as PluginDescriptor },
+    two: {},
+    three: { descriptor: { type: "B", component: {}, config: { key: 1 } } as PluginDescriptor },
+  };
+  const result = loadPlugins(modules);
+  expect(result).toHaveLength(2);
+  expect(result[0].type).toBe("A");
+  expect(result[1].type).toBe("B");
+});

--- a/tests/stateMachine.test.ts
+++ b/tests/stateMachine.test.ts
@@ -1,0 +1,28 @@
+import { StateMachine, StateNode } from "@/lib/stateMachine";
+
+test("state machine executes in order", async () => {
+  const events: string[] = [];
+  const nodes: StateNode<string>[] = [
+    {
+      id: "a",
+      next: "b",
+      run: async (input) => {
+        events.push("a");
+        return input + "a";
+      },
+    },
+    {
+      id: "b",
+      run: async (input) => {
+        events.push("b");
+        return input + "b";
+      },
+    },
+  ];
+
+  const machine = new StateMachine(nodes, "a");
+  const result = await machine.execute("");
+
+  expect(result).toBe("ab");
+  expect(events).toEqual(["a", "b"]);
+});

--- a/tests/upsertUserAttributes.test.ts
+++ b/tests/upsertUserAttributes.test.ts
@@ -1,12 +1,10 @@
 import fs from "fs";
-import { test } from "node:test";
-import assert from "node:assert/strict";
 
 const file = fs.readFileSync("lib/actions/userattributes.actions.ts", "utf8");
 
 // Simple check that the update functions are called in upsertUserAttributes
 
 test("upsertUserAttributes triggers friend suggestions", () => {
-  assert.ok(file.includes("updateUserEmbedding"));
-  assert.ok(file.includes("generateFriendSuggestions"));
+  expect(file.includes("updateUserEmbedding")).toBe(true);
+  expect(file.includes("generateFriendSuggestions")).toBe(true);
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -632,6 +632,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@cspotcode/source-map-support@npm:^0.8.0":
+  version: 0.8.1
+  resolution: "@cspotcode/source-map-support@npm:0.8.1"
+  dependencies:
+    "@jridgewell/trace-mapping": "npm:0.3.9"
+  checksum: 10c0/05c5368c13b662ee4c122c7bfbe5dc0b613416672a829f3e78bc49a357a197e0218d6e74e7c66cfcd04e15a179acab080bd3c69658c9fbefd0e1ccd950a07fc6
+  languageName: node
+  linkType: hard
+
 "@effect/schema@npm:0.68.12":
   version: 0.68.12
   resolution: "@effect/schema@npm:0.68.12"
@@ -2020,7 +2029,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jridgewell/resolve-uri@npm:^3.1.0":
+"@jridgewell/resolve-uri@npm:^3.0.3, @jridgewell/resolve-uri@npm:^3.1.0":
   version: 3.1.2
   resolution: "@jridgewell/resolve-uri@npm:3.1.2"
   checksum: 10c0/d502e6fb516b35032331406d4e962c21fe77cdf1cbdb49c6142bcbd9e30507094b18972778a6e27cbad756209cfe34b1a27729e6fa08a2eb92b33943f680cf1e
@@ -2038,6 +2047,16 @@ __metadata:
   version: 1.5.0
   resolution: "@jridgewell/sourcemap-codec@npm:1.5.0"
   checksum: 10c0/2eb864f276eb1096c3c11da3e9bb518f6d9fc0023c78344cdc037abadc725172c70314bdb360f2d4b7bffec7f5d657ce006816bc5d4ecb35e61b66132db00c18
+  languageName: node
+  linkType: hard
+
+"@jridgewell/trace-mapping@npm:0.3.9":
+  version: 0.3.9
+  resolution: "@jridgewell/trace-mapping@npm:0.3.9"
+  dependencies:
+    "@jridgewell/resolve-uri": "npm:^3.0.3"
+    "@jridgewell/sourcemap-codec": "npm:^1.4.10"
+  checksum: 10c0/fa425b606d7c7ee5bfa6a31a7b050dd5814b4082f318e0e4190f991902181b4330f43f4805db1dd4f2433fd0ed9cc7a7b9c2683f1deeab1df1b0a98b1e24055b
   languageName: node
   linkType: hard
 
@@ -5116,6 +5135,34 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@tsconfig/node10@npm:^1.0.7":
+  version: 1.0.11
+  resolution: "@tsconfig/node10@npm:1.0.11"
+  checksum: 10c0/28a0710e5d039e0de484bdf85fee883bfd3f6a8980601f4d44066b0a6bcd821d31c4e231d1117731c4e24268bd4cf2a788a6787c12fc7f8d11014c07d582783c
+  languageName: node
+  linkType: hard
+
+"@tsconfig/node12@npm:^1.0.7":
+  version: 1.0.11
+  resolution: "@tsconfig/node12@npm:1.0.11"
+  checksum: 10c0/dddca2b553e2bee1308a056705103fc8304e42bb2d2cbd797b84403a223b25c78f2c683ec3e24a095e82cd435387c877239bffcb15a590ba817cd3f6b9a99fd9
+  languageName: node
+  linkType: hard
+
+"@tsconfig/node14@npm:^1.0.0":
+  version: 1.0.3
+  resolution: "@tsconfig/node14@npm:1.0.3"
+  checksum: 10c0/67c1316d065fdaa32525bc9449ff82c197c4c19092b9663b23213c8cbbf8d88b6ed6a17898e0cbc2711950fbfaf40388938c1c748a2ee89f7234fc9e7fe2bf44
+  languageName: node
+  linkType: hard
+
+"@tsconfig/node16@npm:^1.0.2":
+  version: 1.0.4
+  resolution: "@tsconfig/node16@npm:1.0.4"
+  checksum: 10c0/05f8f2734e266fb1839eb1d57290df1664fe2aa3b0fdd685a9035806daa635f7519bf6d5d9b33f6e69dd545b8c46bd6e2b5c79acb2b1f146e885f7f11a42a5bb
+  languageName: node
+  linkType: hard
+
 "@tweenjs/tween.js@npm:~23.1.1":
   version: 23.1.3
   resolution: "@tweenjs/tween.js@npm:23.1.3"
@@ -6304,12 +6351,30 @@ __metadata:
   languageName: node
   linkType: hard
 
+"acorn-walk@npm:^8.1.1":
+  version: 8.3.4
+  resolution: "acorn-walk@npm:8.3.4"
+  dependencies:
+    acorn: "npm:^8.11.0"
+  checksum: 10c0/76537ac5fb2c37a64560feaf3342023dadc086c46da57da363e64c6148dc21b57d49ace26f949e225063acb6fb441eabffd89f7a3066de5ad37ab3e328927c62
+  languageName: node
+  linkType: hard
+
 "acorn@npm:^7.1.1":
   version: 7.4.1
   resolution: "acorn@npm:7.4.1"
   bin:
     acorn: bin/acorn
   checksum: 10c0/bd0b2c2b0f334bbee48828ff897c12bd2eb5898d03bf556dcc8942022cec795ac5bb5b6b585e2de687db6231faf07e096b59a361231dd8c9344d5df5f7f0e526
+  languageName: node
+  linkType: hard
+
+"acorn@npm:^8.11.0, acorn@npm:^8.4.1":
+  version: 8.15.0
+  resolution: "acorn@npm:8.15.0"
+  bin:
+    acorn: bin/acorn
+  checksum: 10c0/dec73ff59b7d6628a01eebaece7f2bdb8bb62b9b5926dcad0f8931f2b8b79c2be21f6c68ac095592adb5adb15831a3635d9343e6a91d028bbe85d564875ec3ec
   languageName: node
   linkType: hard
 
@@ -6488,6 +6553,13 @@ __metadata:
     normalize-path: "npm:^3.0.0"
     picomatch: "npm:^2.0.4"
   checksum: 10c0/57b06ae984bc32a0d22592c87384cd88fe4511b1dd7581497831c56d41939c8a001b28e7b853e1450f2bf61992dfcaa8ae2d0d161a0a90c4fb631ef07098fbac
+  languageName: node
+  linkType: hard
+
+"arg@npm:^4.1.0":
+  version: 4.1.3
+  resolution: "arg@npm:4.1.3"
+  checksum: 10c0/070ff801a9d236a6caa647507bdcc7034530604844d64408149a26b9e87c2f97650055c0f049abd1efc024b334635c01f29e0b632b371ac3f26130f4cf65997a
   languageName: node
   linkType: hard
 
@@ -7487,6 +7559,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"create-require@npm:^1.1.0":
+  version: 1.1.1
+  resolution: "create-require@npm:1.1.1"
+  checksum: 10c0/157cbc59b2430ae9a90034a5f3a1b398b6738bf510f713edc4d4e45e169bc514d3d99dd34d8d01ca7ae7830b5b8b537e46ae8f3c8f932371b0875c0151d7ec91
+  languageName: node
+  linkType: hard
+
 "crelt@npm:^1.0.0":
   version: 1.0.6
   resolution: "crelt@npm:1.0.6"
@@ -7868,6 +7947,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"diff@npm:^4.0.1":
+  version: 4.0.2
+  resolution: "diff@npm:4.0.2"
+  checksum: 10c0/81b91f9d39c4eaca068eb0c1eb0e4afbdc5bb2941d197f513dd596b820b956fef43485876226d65d497bebc15666aa2aa82c679e84f65d5f2bfbf14ee46e32c1
+  languageName: node
+  linkType: hard
+
 "diff@npm:^5.1.0":
   version: 5.2.0
   resolution: "diff@npm:5.2.0"
@@ -8157,6 +8243,7 @@ __metadata:
     tldraw: "npm:^3.13.4"
     tone: "npm:^15.0.4"
     ts-jest: "npm:^29.4.0"
+    ts-node: "npm:^10.9.2"
     tsx: "npm:^4.16.5"
     typescript: "npm:^5.5.4"
     uploadthing: "npm:^6.13.2"
@@ -11763,7 +11850,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"make-error@npm:^1.3.6":
+"make-error@npm:^1.1.1, make-error@npm:^1.3.6":
   version: 1.3.6
   resolution: "make-error@npm:1.3.6"
   checksum: 10c0/171e458d86854c6b3fc46610cfacf0b45149ba043782558c6875d9f42f222124384ad0b468c92e996d815a8a2003817a710c0a160e49c1c394626f76fa45396f
@@ -16307,6 +16394,44 @@ __metadata:
   languageName: node
   linkType: hard
 
+"ts-node@npm:^10.9.2":
+  version: 10.9.2
+  resolution: "ts-node@npm:10.9.2"
+  dependencies:
+    "@cspotcode/source-map-support": "npm:^0.8.0"
+    "@tsconfig/node10": "npm:^1.0.7"
+    "@tsconfig/node12": "npm:^1.0.7"
+    "@tsconfig/node14": "npm:^1.0.0"
+    "@tsconfig/node16": "npm:^1.0.2"
+    acorn: "npm:^8.4.1"
+    acorn-walk: "npm:^8.1.1"
+    arg: "npm:^4.1.0"
+    create-require: "npm:^1.1.0"
+    diff: "npm:^4.0.1"
+    make-error: "npm:^1.1.1"
+    v8-compile-cache-lib: "npm:^3.0.1"
+    yn: "npm:3.1.1"
+  peerDependencies:
+    "@swc/core": ">=1.2.50"
+    "@swc/wasm": ">=1.2.50"
+    "@types/node": "*"
+    typescript: ">=2.7"
+  peerDependenciesMeta:
+    "@swc/core":
+      optional: true
+    "@swc/wasm":
+      optional: true
+  bin:
+    ts-node: dist/bin.js
+    ts-node-cwd: dist/bin-cwd.js
+    ts-node-esm: dist/bin-esm.js
+    ts-node-script: dist/bin-script.js
+    ts-node-transpile-only: dist/bin-transpile.js
+    ts-script: dist/bin-script-deprecated.js
+  checksum: 10c0/5f29938489f96982a25ba650b64218e83a3357d76f7bede80195c65ab44ad279c8357264639b7abdd5d7e75fc269a83daa0e9c62fd8637a3def67254ecc9ddc2
+  languageName: node
+  linkType: hard
+
 "tsconfig-paths@npm:^3.15.0":
   version: 3.15.0
   resolution: "tsconfig-paths@npm:3.15.0"
@@ -16883,6 +17008,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"v8-compile-cache-lib@npm:^3.0.1":
+  version: 3.0.1
+  resolution: "v8-compile-cache-lib@npm:3.0.1"
+  checksum: 10c0/bdc36fb8095d3b41df197f5fb6f11e3a26adf4059df3213e3baa93810d8f0cc76f9a74aaefc18b73e91fe7e19154ed6f134eda6fded2e0f1c8d2272ed2d2d391
+  languageName: node
+  linkType: hard
+
 "v8-to-istanbul@npm:^9.0.1":
   version: 9.3.0
   resolution: "v8-to-istanbul@npm:9.3.0"
@@ -17255,6 +17387,13 @@ __metadata:
     y18n: "npm:^5.0.5"
     yargs-parser: "npm:^21.1.1"
   checksum: 10c0/ccd7e723e61ad5965fffbb791366db689572b80cca80e0f96aad968dfff4156cd7cd1ad18607afe1046d8241e6fb2d6c08bf7fa7bfb5eaec818735d8feac8f05
+  languageName: node
+  linkType: hard
+
+"yn@npm:3.1.1":
+  version: 3.1.1
+  resolution: "yn@npm:3.1.1"
+  checksum: 10c0/0732468dd7622ed8a274f640f191f3eaf1f39d5349a1b72836df484998d7d9807fbea094e2f5486d6b0cd2414aad5775972df0e68f8604db89a239f0f4bf7443
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary
- add simple plug-in loader and state machine utilities
- write unit tests for plug-in loader and state machine
- create integration test chaining LLM nodes
- document manual LiveKit recording steps
- fix existing tests and add ts-node dependency

## Testing
- `npm run lint`
- `npx jest`

------
https://chatgpt.com/codex/tasks/task_e_6864ae23ca28832982102e2db259ee4a