### PR TITLE
Add basic workflow builder

### DIFF
--- a/app/(root)/(standard)/workflows/new/page.tsx
+++ b/app/(root)/(standard)/workflows/new/page.tsx
@@ -1,0 +1,13 @@
+import WorkflowBuilder from "@/components/workflow/WorkflowBuilder";
+import { createWorkflow } from "@/lib/actions/workflow.actions";
+
+export default function Page() {
+  return (
+    <WorkflowBuilder
+      onSave={async (graph) => {
+        "use server";
+        await createWorkflow({ name: "New Workflow", graph });
+      }}
+    />
+  );
+}

--- a/components/workflow/WorkflowBuilder.tsx
+++ b/components/workflow/WorkflowBuilder.tsx
@@ -1,0 +1,58 @@
+"use client";
+
+import { useCallback, useState } from "react";
+import {
+  ReactFlow,
+  Background,
+  Controls,
+  MiniMap,
+  addEdge,
+  Connection,
+  Edge,
+  Node,
+} from "@xyflow/react";
+import "@xyflow/react/dist/style.css";
+import { Button } from "@/components/ui/button";
+import { WorkflowGraph } from "@/lib/actions/workflow.actions";
+
+interface Props {
+  initialGraph?: WorkflowGraph;
+  onSave: (graph: WorkflowGraph) => void;
+}
+
+export default function WorkflowBuilder({ initialGraph, onSave }: Props) {
+  const [nodes, setNodes] = useState<Node[]>(initialGraph?.nodes || []);
+  const [edges, setEdges] = useState<Edge[]>(initialGraph?.edges || []);
+
+  const onConnect = useCallback((connection: Connection) => {
+    setEdges((eds) => addEdge(connection, eds));
+  }, []);
+
+  const addState = () => {
+    const id = `state-${nodes.length + 1}`;
+    setNodes((nds) => [
+      ...nds,
+      {
+        id,
+        data: { label: id },
+        position: { x: 50 * nds.length, y: 50 * nds.length },
+      },
+    ]);
+  };
+
+  const save = () => {
+    onSave({ nodes, edges });
+  };
+
+  return (
+    <div style={{ height: 500 }}>
+      <Button onClick={addState}>Add State</Button>
+      <Button onClick={save}>Save</Button>
+      <ReactFlow nodes={nodes} edges={edges} onConnect={onConnect}>
+        <Background />
+        <MiniMap />
+        <Controls />
+      </ReactFlow>
+    </div>
+  );
+}

--- a/lib/actions/workflow.actions.ts
+++ b/lib/actions/workflow.actions.ts
@@ -1,0 +1,50 @@
+"use server";
+
+import { prisma } from "../prismaclient";
+import { revalidatePath } from "next/cache";
+import { getUserFromCookies } from "../serverutils";
+
+export interface WorkflowGraph {
+  nodes: any[];
+  edges: any[];
+}
+
+export async function createWorkflow({
+  name,
+  graph,
+}: {
+  name: string;
+  graph: WorkflowGraph;
+}) {
+  const user = await getUserFromCookies();
+  if (!user) throw new Error("User not authenticated");
+  await prisma.$connect();
+  const workflow = await prisma.workflow.create({
+    data: {
+      owner_id: user.userId!,
+      name,
+      graph,
+    },
+  });
+  revalidatePath("/workflows");
+  return workflow;
+}
+
+export async function updateWorkflow({
+  id,
+  graph,
+}: {
+  id: bigint;
+  graph: WorkflowGraph;
+}) {
+  await prisma.$connect();
+  return await prisma.workflow.update({
+    where: { id },
+    data: { graph },
+  });
+}
+
+export async function fetchWorkflow({ id }: { id: bigint }) {
+  await prisma.$connect();
+  return await prisma.workflow.findUniqueOrThrow({ where: { id } });
+}

--- a/lib/models/schema.prisma
+++ b/lib/models/schema.prisma
@@ -35,6 +35,7 @@ model User {
   userEmbedding            UserEmbedding?
   friendSuggestionsCreated FriendSuggestion[]        @relation("SuggestionsCreator")
   friendSuggestionsTarget  FriendSuggestion[]        @relation("SuggestionsTarget")
+  workflows               Workflow[]
 
   @@map("users")
 }
@@ -261,4 +262,15 @@ model FriendSuggestion {
 
   @@unique([user_id, suggested_user_id])
   @@map("friend_suggestions")
+}
+
+model Workflow {
+  id         BigInt   @id @default(autoincrement())
+  owner_id   BigInt
+  owner      User     @relation(fields: [owner_id], references: [id], onDelete: Cascade)
+  name       String
+  graph      Json
+  created_at DateTime @default(now()) @db.Timestamptz(6)
+
+  @@map("workflows")
 }

--- a/lib/workflowExecutor.ts
+++ b/lib/workflowExecutor.ts
@@ -1,0 +1,39 @@
+export interface WorkflowNode {
+  id: string;
+  type: string;
+}
+
+export interface WorkflowEdge {
+  id: string;
+  source: string;
+  target: string;
+  condition?: string;
+}
+
+export interface WorkflowGraph {
+  nodes: WorkflowNode[];
+  edges: WorkflowEdge[];
+}
+
+export async function executeWorkflow(
+  graph: WorkflowGraph,
+  actions: Record<string, () => Promise<void>>,
+  evaluate: (condition: string) => boolean = () => true
+): Promise<string[]> {
+  const executed: string[] = [];
+  const nodeMap = new Map(graph.nodes.map((n) => [n.id, n]));
+  let current = graph.nodes[0];
+  while (current) {
+    const act = actions[current.id];
+    if (act) {
+      await act();
+    }
+    executed.push(current.id);
+    const outgoing = graph.edges.filter((e) => e.source === current.id);
+    if (outgoing.length === 0) break;
+    const nextEdge = outgoing.find((e) => !e.condition || evaluate(e.condition));
+    if (!nextEdge) break;
+    current = nodeMap.get(nextEdge.target);
+  }
+  return executed;
+}

--- a/tests/workflowExecution.test.ts
+++ b/tests/workflowExecution.test.ts
@@ -1,0 +1,47 @@
+import { executeWorkflow, WorkflowGraph } from "@/lib/workflowExecutor";
+
+it("executes nodes in sequence", async () => {
+  const graph: WorkflowGraph = {
+    nodes: [
+      { id: "A", type: "start" },
+      { id: "B", type: "middle" },
+      { id: "C", type: "end" },
+    ],
+    edges: [
+      { id: "e1", source: "A", target: "B" },
+      { id: "e2", source: "B", target: "C" },
+    ],
+  };
+  const order: string[] = [];
+  const actions = {
+    A: async () => order.push("A"),
+    B: async () => order.push("B"),
+    C: async () => order.push("C"),
+  };
+  const result = await executeWorkflow(graph, actions);
+  expect(result).toEqual(["A", "B", "C"]);
+  expect(order).toEqual(["A", "B", "C"]);
+});
+
+it("handles conditional branches", async () => {
+  const graph: WorkflowGraph = {
+    nodes: [
+      { id: "A", type: "start" },
+      { id: "B", type: "branch" },
+      { id: "C", type: "alt" },
+    ],
+    edges: [
+      { id: "e1", source: "A", target: "B", condition: "t" },
+      { id: "e2", source: "A", target: "C", condition: "f" },
+    ],
+  };
+  const order: string[] = [];
+  const actions = {
+    A: async () => order.push("A"),
+    B: async () => order.push("B"),
+    C: async () => order.push("C"),
+  };
+  const result = await executeWorkflow(graph, actions, (c) => c === "t");
+  expect(result).toEqual(["A", "B"]);
+  expect(order).toEqual(["A", "B"]);
+});


### PR DESCRIPTION
## Summary
- implement Workflow model for storing graphs
- add workflow actions and executor utilities
- create WorkflowBuilder React component and new route
- test workflow execution logic

## Testing
- `npm run lint`
- `npx jest` *(fails: ts-node missing)*

------
https://chatgpt.com/codex/tasks/task_e_6864ae22aed883298ee2fd5c974756d5