### PR TITLE
Update replicate feature to embed original post

### DIFF
--- a/components/cards/PostCard.tsx
+++ b/components/cards/PostCard.tsx
@@ -41,6 +41,7 @@ interface Props {
   likeCount?: number;
   commentCount?: number;
   expirationDate?: string | null;
+  embedPost?: React.ReactNode;
 }
 
 const PostCard = async ({
@@ -56,6 +57,7 @@ const PostCard = async ({
   likeCount = 0,
   commentCount = 0,
   expirationDate = null,
+  embedPost,
   }: Props) => {
   let currentUserLike: Like | RealtimeLike | null = null;
   if (currentUserId) {
@@ -164,6 +166,7 @@ const PostCard = async ({
                 <DrawCanvas id={id.toString()} content={content} />
               </div>
             )}
+            {embedPost && <div className="mt-4 scale-90">{embedPost}</div>}
             <hr className="mt-4 mb-3 w-full h-px border-t-0 bg-transparent bg-gradient-to-r from-transparent via-slate-100 to-transparent opacity-75" />
 
             <div className="mt-4 flex flex-col gap-x-3 gap-y-4">

--- a/components/cards/ReplicatedPostCard.tsx
+++ b/components/cards/ReplicatedPostCard.tsx
@@ -28,18 +28,16 @@ const ReplicatedPostCard = async ({
   if (!original) return null;
 
   return (
-    <article className="flex flex-col gap-4">
-      <PostCard
-        id={id}
-        currentUserId={currentUserId}
-        content="Replicated"
-        type="TEXT"
-        author={author}
-        createdAt={createdAt}
-        likeCount={likeCount}
-        expirationDate={expirationDate ?? undefined}
-      />
-      <div className="ml-6">
+    <PostCard
+      id={id}
+      currentUserId={currentUserId}
+      content="Replicated"
+      type="TEXT"
+      author={author}
+      createdAt={createdAt}
+      likeCount={likeCount}
+      expirationDate={expirationDate ?? undefined}
+      embedPost={
         <PostCard
           id={original.id}
           currentUserId={currentUserId}
@@ -50,8 +48,8 @@ const ReplicatedPostCard = async ({
           likeCount={original.like_count}
           expirationDate={original.expiration_date?.toISOString() ?? null}
         />
-      </div>
-    </article>
+      }
+    />
   );
 };
 


### PR DESCRIPTION
## Summary
- show a nested original post when a post is replicated
- support optional `embedPost` children in `PostCard`

## Testing
- `yarn install`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6864ee0a85a48329814e615b978cd98e