### PR TITLE
Fix Television heading

### DIFF
--- a/app/(root)/(standard)/profile/[id]/customize/customize-components.tsx
+++ b/app/(root)/(standard)/profile/[id]/customize/customize-components.tsx
@@ -430,7 +430,7 @@ export default function CustomButtons({ userAttributes, initialOpen }: Props) {
             </Button>
           </DialogTrigger>
           <DialogContent className="grid bg-black  max-w-[50rem] max-h-[38rem]	">
-            <h2>Televisoin</h2>
+            <h2>Television</h2>
             <DialogHeader className="dialog-header mt-[-2rem] text-white tracking-wide	">
               <b> Choose Your Favorite TV Shows</b>
             </DialogHeader>


### PR DESCRIPTION
## Summary
- correct typo in `customize-components.tsx` for the television modal

## Testing
- `yarn install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6865129da604832993d34a7b7956f193