### PR TITLE
Add multiselect components for new media

### DIFF
--- a/app/(root)/(standard)/profile/[id]/customize/customize-components.tsx
+++ b/app/(root)/(standard)/profile/[id]/customize/customize-components.tsx
@@ -19,6 +19,9 @@ import {
   addInterest,
   fetchMovies,
   fetchBooks,
+  fetchEvents,
+  fetchTVShows,
+  fetchPodcasts,
   fetchTracks,
   submitEdits,
 } from "@/lib/MultiSelectFunctions";
@@ -349,7 +352,13 @@ export default function CustomButtons({ userAttributes, initialOpen }: Props) {
             <hr />
 
             <div className="bg-black border border-white rounded-md px-3 pt-6  pb-16  mt-3 mb-3 ">
-              {/* <FancyMultiSelect /> */}
+              <FancyMultiSelect
+                fetchMultiselectData={fetchEvents}
+                initialSelected={convertListToSelectables((userAttributes as any).events)}
+                submitEdits={(selectables) =>
+                  submitEdits("EVENTS", selectables, userAttributes, path)
+                }
+              />
             </div>
             <hr />
             <div className="flex gap-4 mb-2 mt-2">
@@ -367,9 +376,6 @@ export default function CustomButtons({ userAttributes, initialOpen }: Props) {
               >
                 Close
               </DialogClose>
-            </div>
-            <div className="overlay w-full bg-white h-full text-center align-middle	 font-bold text-black">
-              {"UNDER CONSTRUCTION"}
             </div>
           </DialogContent>
         </Dialog>
@@ -437,7 +443,13 @@ export default function CustomButtons({ userAttributes, initialOpen }: Props) {
             <hr />
 
             <div className="bg-black border border-white rounded-md px-3 pt-6  pb-16  mt-3 mb-3 ">
-              {/* <FancyMultiSelect /> */}
+              <FancyMultiSelect
+                fetchMultiselectData={fetchTVShows}
+                initialSelected={convertListToSelectables((userAttributes as any).tv_shows)}
+                submitEdits={(selectables) =>
+                  submitEdits("TV_SHOWS", selectables, userAttributes, path)
+                }
+              />
             </div>
             <hr />
             <div className="flex gap-4 mb-2 mt-2">
@@ -448,16 +460,12 @@ export default function CustomButtons({ userAttributes, initialOpen }: Props) {
               >
                 Enter
               </DialogClose>
-
               <DialogClose
                 id="close"
                 className={`form-submit-button pl-4 py-1 pr-[1rem]`}
               >
                 Close
               </DialogClose>
-            </div>
-            <div className="overlay w-full bg-white h-full text-center align-middle	 font-bold text-black">
-              {"UNDER CONSTRUCTION"}
             </div>
           </DialogContent>
         </Dialog>
@@ -520,7 +528,13 @@ export default function CustomButtons({ userAttributes, initialOpen }: Props) {
             <hr />
 
             <div className="bg-black border border-white rounded-md px-3 pt-6  pb-16  mt-3 mb-3 ">
-              {/* <FancyMultiSelect /> */}
+              <FancyMultiSelect
+                fetchMultiselectData={fetchPodcasts}
+                initialSelected={convertListToSelectables((userAttributes as any).podcasts)}
+                submitEdits={(selectables) =>
+                  submitEdits("PODCASTS", selectables, userAttributes, path)
+                }
+              />
             </div>
             <hr />
             <div className="flex gap-4 mb-2 mt-2">
@@ -531,16 +545,12 @@ export default function CustomButtons({ userAttributes, initialOpen }: Props) {
               >
                 Enter
               </DialogClose>
-
               <DialogClose
                 id="close"
                 className={`form-submit-button pl-4 py-1 pr-[1rem]`}
               >
                 Close
               </DialogClose>
-            </div>
-            <div className="overlay w-full bg-white h-full text-center align-middle	 font-bold text-black">
-              {"UNDER CONSTRUCTION"}
             </div>
           </DialogContent>
         </Dialog>

--- a/lib/MultiSelectFunctions.ts
+++ b/lib/MultiSelectFunctions.ts
@@ -242,6 +242,51 @@ export async function fetchTracks(query: string): Promise<OptionType[]> {
   }
 }
 
+export async function fetchEvents(query: string): Promise<OptionType[]> {
+  const stub = [
+    { value: "festival", label: "Local Festival" },
+    { value: "meetup", label: "Community Meetup" },
+    { value: "conference", label: "Tech Conference" },
+  ];
+  return stub.filter((e) =>
+    e.label.toLowerCase().includes(query.toLowerCase())
+  );
+}
+
+export async function fetchTVShows(query: string): Promise<OptionType[]> {
+  try {
+    const response = await fetch(
+      `https://api.tvmaze.com/search/shows?q=${encodeURIComponent(query)}`
+    );
+    const data = await response.json();
+    if (Array.isArray(data)) {
+      const shows = data.map((item: any) => ({
+        value: item.show.id.toString(),
+        label: item.show.name,
+      }));
+      return shows.filter(
+        (show: any, idx: number, self: any) =>
+          idx === self.findIndex((s: any) => s.label === show.label)
+      );
+    }
+    return [];
+  } catch (error) {
+    console.error("Error fetching tv shows:", error);
+    return [];
+  }
+}
+
+export async function fetchPodcasts(query: string): Promise<OptionType[]> {
+  const stub = [
+    { value: "tech_talk", label: "Tech Talk" },
+    { value: "daily_news", label: "Daily News" },
+    { value: "comedy_hour", label: "Comedy Hour" },
+  ];
+  return stub.filter((p) =>
+    p.label.toLowerCase().includes(query.toLowerCase())
+  );
+}
+
 export async function fetchInterests(query: string): Promise<OptionType[]> {
   return interestList.filter((interest) =>
     interest.label.toLowerCase().includes(query.toLowerCase())
@@ -280,7 +325,10 @@ export function submitEdits(
     | "TRACKS"
     | "ARTISTS"
     | "BOOKS"
-    | "COMMUNITIES",
+    | "COMMUNITIES"
+    | "EVENTS"
+    | "TV_SHOWS"
+    | "PODCASTS",
   selectables: OptionType[],
   userAttributes: UserAttributes,
   path: string
@@ -347,6 +395,30 @@ export function submitEdits(
         userAttributes: {
           ...userAttributes,
           communities: convertSelectablesToList(selectables),
+        },
+        path,
+      });
+    case "EVENTS":
+      return upsertUserAttributes({
+        userAttributes: {
+          ...(userAttributes as any),
+          events: convertSelectablesToList(selectables),
+        },
+        path,
+      });
+    case "TV_SHOWS":
+      return upsertUserAttributes({
+        userAttributes: {
+          ...(userAttributes as any),
+          tv_shows: convertSelectablesToList(selectables),
+        },
+        path,
+      });
+    case "PODCASTS":
+      return upsertUserAttributes({
+        userAttributes: {
+          ...(userAttributes as any),
+          podcasts: convertSelectablesToList(selectables),
         },
         path,
       });


### PR DESCRIPTION
## Summary
- use `FancyMultiSelect` for events, TV, and podcast dialogs
- add stub fetchers for events, TV shows, and podcasts
- allow `submitEdits` to handle `EVENTS`, `TV_SHOWS`, and `PODCASTS`

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_686512a0d2f883299056216805555075