### PR TITLE
Add profile visibility and metrics logging

### DIFF
--- a/app/api/recommendations/click/route.ts
+++ b/app/api/recommendations/click/route.ts
@@ -1,0 +1,17 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getUserFromCookies } from "@/lib/serverutils";
+import { logRecommendationClick } from "@/lib/actions/recommendation.actions";
+
+export async function POST(req: NextRequest) {
+  const user = await getUserFromCookies();
+  if (!user?.userId) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 403 });
+  }
+  const { recommendedUserId, recommendedRoomId } = await req.json();
+  await logRecommendationClick({
+    userId: user.userId,
+    recommendedUserId: recommendedUserId ? BigInt(recommendedUserId) : undefined,
+    recommendedRoomId,
+  });
+  return NextResponse.json({ success: true });
+}

--- a/app/api/user-attributes/route.ts
+++ b/app/api/user-attributes/route.ts
@@ -1,5 +1,9 @@
 import { NextRequest, NextResponse } from "next/server";
-import { fetchUserAttributes, upsertUserAttributes } from "@/lib/actions/userattributes.actions";
+import {
+  fetchUserAttributes,
+  upsertUserAttributes,
+} from "@/lib/actions/userattributes.actions";
+import { visibility } from "@prisma/client";
 
 export async function GET(req: NextRequest) {
   const userId = req.nextUrl.searchParams.get("userId");
@@ -18,6 +22,15 @@ export async function POST(req: NextRequest) {
   const { userAttributes, path } = data;
   if (!userAttributes || !path) {
     return NextResponse.json({ error: "Missing payload" }, { status: 400 });
+  }
+  if (userAttributes.events_visibility) {
+    userAttributes.events_visibility = userAttributes.events_visibility as visibility;
+  }
+  if (userAttributes.tv_visibility) {
+    userAttributes.tv_visibility = userAttributes.tv_visibility as visibility;
+  }
+  if (userAttributes.podcasts_visibility) {
+    userAttributes.podcasts_visibility = userAttributes.podcasts_visibility as visibility;
   }
   await upsertUserAttributes({ userAttributes, path });
   return NextResponse.json({ success: true });

--- a/lib/actions/recommendation.actions.ts
+++ b/lib/actions/recommendation.actions.ts
@@ -108,3 +108,22 @@ export async function fetchRecommendations({
 
   return { users, rooms };
 }
+
+export async function logRecommendationClick({
+  userId,
+  recommendedUserId,
+  recommendedRoomId,
+}: {
+  userId: bigint;
+  recommendedUserId?: bigint;
+  recommendedRoomId?: string;
+}) {
+  await prisma.$connect();
+  await prisma.recommendationClick.create({
+    data: {
+      user_id: userId,
+      recommended_user_id: recommendedUserId,
+      recommended_room_id: recommendedRoomId,
+    },
+  });
+}

--- a/lib/actions/userattributes.actions.ts
+++ b/lib/actions/userattributes.actions.ts
@@ -1,6 +1,6 @@
 "use server";
 
-import { Prisma, realtime_post_type, UserAttributes } from "@prisma/client";
+import { Prisma, UserAttributes, visibility } from "@prisma/client";
 import { prisma } from "../prismaclient";
 import { revalidatePath } from "next/cache";
 import { getUserFromCookies } from "@/lib/serverutils";
@@ -36,6 +36,9 @@ export async function upsertUserAttributes({
       birthday = null,
       hobbies = [],
       communities = [],
+      events_visibility = visibility.PUBLIC,
+      tv_visibility = visibility.PUBLIC,
+      podcasts_visibility = visibility.PUBLIC,
     } = userAttributes as Partial<UserAttributes>;
 
     const sanitize = (arr: string[]) => arr.filter(Boolean);
@@ -71,6 +74,9 @@ export async function upsertUserAttributes({
         communities: {
           set: sanitize(communities),
         },
+        events_visibility,
+        tv_visibility,
+        podcasts_visibility,
       },
       create: {
         user_id: user.userId!,
@@ -100,7 +106,13 @@ export async function upsertUserAttributes({
         communities: {
           set: sanitize(communities),
         },
+        events_visibility,
+        tv_visibility,
+        podcasts_visibility,
       },
+    });
+    await prisma.userAttributeEdit.create({
+      data: { user_id: user.userId! },
     });
     await updateUserEmbedding(user.userId!);
     await generateFriendSuggestions(user.userId!);

--- a/lib/models/schema.prisma
+++ b/lib/models/schema.prisma
@@ -35,6 +35,8 @@ model User {
   userEmbedding            UserEmbedding?
   realtimerooms            UserRealtimeRoom[]
   workflows                Workflow[]
+  attributeEdits           UserAttributeEdit[]
+  recommendationClicks     RecommendationClick[]
 
   @@map("users")
 }
@@ -53,6 +55,10 @@ model UserAttributes {
   hobbies     String[]
   location    String?
   books       String[]
+  events_visibility   visibility @default(PUBLIC)
+  tv_visibility       visibility @default(PUBLIC)
+  podcasts_visibility visibility @default(PUBLIC)
+  updated_at DateTime @default(now()) @updatedAt @db.Timestamptz(6)
   user        User      @relation(fields: [user_id], references: [id], onDelete: Cascade)
 
   @@map("user_attributes")
@@ -274,4 +280,30 @@ enum realtime_post_type {
   CODE
   PORTFOLIO
   LLM_INSTRUCTION
+}
+
+enum visibility {
+  PUBLIC
+  FOLLOWERS
+  PRIVATE
+}
+
+model UserAttributeEdit {
+  id         BigInt   @id @default(autoincrement())
+  user_id    BigInt
+  created_at DateTime @default(now()) @db.Timestamptz(6)
+  user       User     @relation(fields: [user_id], references: [id], onDelete: Cascade)
+
+  @@map("user_attribute_edits")
+}
+
+model RecommendationClick {
+  id                  BigInt   @id @default(autoincrement())
+  user_id             BigInt
+  recommended_user_id BigInt?
+  recommended_room_id String?
+  created_at          DateTime @default(now()) @db.Timestamptz(6)
+  user                User     @relation(fields: [user_id], references: [id], onDelete: Cascade)
+
+  @@map("recommendation_clicks")
 }

--- a/tests/visibility-metrics.test.ts
+++ b/tests/visibility-metrics.test.ts
@@ -1,0 +1,14 @@
+import fs from "fs";
+
+const schema = fs.readFileSync("lib/models/schema.prisma", "utf8");
+const actions = fs.readFileSync("lib/actions/userattributes.actions.ts", "utf8");
+
+test("schema defines visibility fields", () => {
+  expect(schema.includes("events_visibility")).toBe(true);
+  expect(schema.includes("tv_visibility")).toBe(true);
+  expect(schema.includes("podcasts_visibility")).toBe(true);
+});
+
+test("upsertUserAttributes records edit metrics", () => {
+  expect(actions.includes("userAttributeEdit")).toBe(true);
+});


### PR DESCRIPTION
## Summary
- add visibility options and metrics tables to Prisma schema
- log edits when attributes are upserted
- save recommendation click events
- expose recommendation click API route
- handle visibility enums in user attributes API
- test visibility fields and metrics recording

## Testing
- `npm run lint`
- `npx jest`
- `npx prisma generate`

------
https://chatgpt.com/codex/tasks/task_e_686512a2401c8329bc0f0ba985a1a779