### PR TITLE
Add friend suggestion refresh based on interactions

### DIFF
--- a/lib/actions/like.actions.ts
+++ b/lib/actions/like.actions.ts
@@ -2,6 +2,7 @@
 
 import { like_type } from "@prisma/client";
 import { prisma } from "../prismaclient";
+import { generateFriendSuggestions } from "./friend-suggestions.actions";
 
 interface likePostParams {
   userId: string | number | bigint;
@@ -78,6 +79,7 @@ export async function likePost({ userId, postId }: likePostParams) {
         },
       }),
     ]);
+    await generateFriendSuggestions(uid);
   } catch (error: any) {
     throw new Error(`Failed to like post: ${error.message}`);
   }
@@ -263,6 +265,7 @@ export async function likeRealtimePost({
         data: { like_count: { increment: likeChangeAmount } },
       }),
     ]);
+    await generateFriendSuggestions(uid);
   } catch (error: any) {
     throw new Error(`Failed to like realtime post: ${error.message}`);
   }

--- a/lib/actions/realtimeroom.actions.ts
+++ b/lib/actions/realtimeroom.actions.ts
@@ -4,6 +4,7 @@ import { revalidatePath } from "next/cache";
 import { prisma } from "../prismaclient";
 import { getUserFromCookies } from "../serverutils";
 import { nanoid } from "nanoid";
+import { generateFriendSuggestions } from "./friend-suggestions.actions";
 
 export async function fetchRealtimeRoom({
   realtimeRoomId,
@@ -82,6 +83,7 @@ export async function joinRoom({ roomId }: { roomId: string }) {
         realtime_room_id: roomId,
       },
     });
+    await generateFriendSuggestions(user.userId!);
   } catch (error: any) {
     throw new Error(`Failed to join room: ${error.message}`);
   }
@@ -129,7 +131,7 @@ export async function createAndJoinRoom({
     if (!user) {
       throw new Error("User not authenticated");
     }
-    const [realtimeRoom, connection] = await prisma.$transaction([
+  const [realtimeRoom, connection] = await prisma.$transaction([
       prisma.realtimeRoom.create({
         data: {
           id: roomName,
@@ -143,6 +145,7 @@ export async function createAndJoinRoom({
         },
       }),
     ]);
+    await generateFriendSuggestions(user.userId!);
     revalidatePath(path);
     return realtimeRoom;
   } catch (error: any) {


### PR DESCRIPTION
## Summary
- improve friend suggestion scoring by factoring in common likes and rooms
- refresh suggestions when users like posts or join rooms
- update tests for new scoring logic

## Testing
- `npm run lint`
- `npx jest --runInBand`

------
https://chatgpt.com/codex/tasks/task_e_686512a3ace883298f0c4be148c07928