### PR TITLE
Add sidebar support for portfolio and LLM nodes

### DIFF
--- a/components/shared/NodeSidebar.tsx
+++ b/components/shared/NodeSidebar.tsx
@@ -43,6 +43,8 @@ const nodeTypes: { label: string; nodeType: AppNodeType }[] = [
   { label: "DRAW", nodeType: "DRAW" },
   { label: "LIVECHAT", nodeType: "LIVECHAT" },
   { label: "AUDIO", nodeType: "AUDIO" },
+  { label: "LLM_INSTRUCTION", nodeType: "LLM_INSTRUCTION" },
+  { label: "PORTFOLIO", nodeType: "PORTFOLIO" },
 ];
 
 // Import your modals
@@ -288,6 +290,24 @@ export default function NodeSidebar({
           path: pathname,
           coordinates: centerPosition,
           type: "AUDIO",
+          realtimeRoomId: roomId,
+        });
+        break;
+
+      case "LLM_INSTRUCTION":
+        createPostAndAddToCanvas({
+          path: pathname,
+          coordinates: centerPosition,
+          type: "LLM_INSTRUCTION",
+          realtimeRoomId: roomId,
+        });
+        break;
+
+      case "PORTFOLIO":
+        createPostAndAddToCanvas({
+          path: pathname,
+          coordinates: centerPosition,
+          type: "PORTFOLIO",
           realtimeRoomId: roomId,
         });
         break;

--- a/lib/reactflow/reactflowutils.ts
+++ b/lib/reactflow/reactflowutils.ts
@@ -11,6 +11,9 @@ import {
   PortalNode,
   DrawNode,
   LivechatNode,
+  AudioNode,
+  PortfolioNodeData,
+  LLMInstructionNode,
 
   AppEdge,
 } from "./types";
@@ -211,8 +214,56 @@ export function convertPostToNode(
           position: { x: realtimePost.x_coordinate, y: realtimePost.y_coordinate }
         } as LivechatNode;
       }
-    
-          default:
-            throw new Error("Unsupported real-time post type");
-        }
+      case "AUDIO":
+        return {
+          id: realtimePost.id.toString(),
+          type: realtimePost.type,
+          data: {
+            audioUrl: realtimePost.video_url || "",
+            author: authorToSet,
+            locked: realtimePost.locked,
+          },
+          position: {
+            x: realtimePost.x_coordinate,
+            y: realtimePost.y_coordinate,
+          },
+        } as AudioNode;
+      case "PORTFOLIO":
+        return {
+          id: realtimePost.id.toString(),
+          type: realtimePost.type,
+          data: {
+            text: realtimePost.content || "",
+            images: realtimePost.image_url ? [realtimePost.image_url] : [],
+            links: realtimePost.video_url ? [realtimePost.video_url] : [],
+            layout: "grid",
+            color: "bg-white",
+            author: authorToSet,
+            locked: realtimePost.locked,
+          },
+          position: {
+            x: realtimePost.x_coordinate,
+            y: realtimePost.y_coordinate,
+          },
+        } as PortfolioNodeData;
+      case "LLM_INSTRUCTION":
+        return {
+          id: realtimePost.id.toString(),
+          type: realtimePost.type,
+          data: {
+            prompt: realtimePost.content || "",
+            output: "",
+            status: "pending",
+            author: authorToSet,
+            locked: realtimePost.locked,
+          },
+          position: {
+            x: realtimePost.x_coordinate,
+            y: realtimePost.y_coordinate,
+          },
+        } as LLMInstructionNode;
+      
+      default:
+        throw new Error("Unsupported real-time post type");
+      }
     }


### PR DESCRIPTION
## Summary
- list new node options `LLM_INSTRUCTION` and `PORTFOLIO`
- allow creation of these node types in the sidebar
- support new node types when converting real-time posts

## Testing
- `npm run lint`
- `npx jest --runInBand`


------
https://chatgpt.com/codex/tasks/task_e_68657a3191808329b407bb0707d0e3b1