### PR TITLE
Add workflow execution page

### DIFF
--- a/app/(root)/(standard)/workflows/[id]/page.tsx
+++ b/app/(root)/(standard)/workflows/[id]/page.tsx
@@ -1,0 +1,10 @@
+import { fetchWorkflow } from "@/lib/actions/workflow.actions";
+import WorkflowRunner from "@/components/workflow/WorkflowRunner";
+import { notFound } from "next/navigation";
+
+export default async function Page({ params }: { params: { id: string } }) {
+  if (!params?.id) return notFound();
+  const workflow = await fetchWorkflow({ id: BigInt(params.id) });
+  if (!workflow) return notFound();
+  return <WorkflowRunner graph={workflow.graph} />;
+}

--- a/app/(root)/(standard)/workflows/new/page.tsx
+++ b/app/(root)/(standard)/workflows/new/page.tsx
@@ -6,7 +6,8 @@ export default function Page() {
     <WorkflowBuilder
       onSave={async (graph) => {
         "use server";
-        await createWorkflow({ name: "New Workflow", graph });
+        const workflow = await createWorkflow({ name: "New Workflow", graph });
+        return { id: workflow.id.toString() };
       }}
     />
   );

--- a/components/workflow/WorkflowBuilder.tsx
+++ b/components/workflow/WorkflowBuilder.tsx
@@ -17,12 +17,13 @@ import { WorkflowGraph } from "@/lib/actions/workflow.actions";
 
 interface Props {
   initialGraph?: WorkflowGraph;
-  onSave: (graph: WorkflowGraph) => void;
+  onSave: (graph: WorkflowGraph) => Promise<{ id: string }>;
 }
 
 export default function WorkflowBuilder({ initialGraph, onSave }: Props) {
   const [nodes, setNodes] = useState<Node[]>(initialGraph?.nodes || []);
   const [edges, setEdges] = useState<Edge[]>(initialGraph?.edges || []);
+  const [workflowId, setWorkflowId] = useState<string | null>(null);
 
   const onConnect = useCallback((connection: Connection) => {
     setEdges((eds) => addEdge(connection, eds));
@@ -40,14 +41,18 @@ export default function WorkflowBuilder({ initialGraph, onSave }: Props) {
     ]);
   };
 
-  const save = () => {
-    onSave({ nodes, edges });
+  const save = async () => {
+    const result = await onSave({ nodes, edges });
+    setWorkflowId(result.id);
   };
 
   return (
     <div style={{ height: 500 }}>
       <Button onClick={addState}>Add State</Button>
       <Button onClick={save}>Save</Button>
+      {workflowId && (
+        <a href={`/workflows/${workflowId}`}>Run Workflow</a>
+      )}
       <ReactFlow nodes={nodes} edges={edges} onConnect={onConnect}>
         <Background />
         <MiniMap />

--- a/components/workflow/WorkflowRunner.tsx
+++ b/components/workflow/WorkflowRunner.tsx
@@ -1,0 +1,39 @@
+"use client";
+import { useState } from "react";
+import { executeWorkflow, WorkflowGraph } from "@/lib/workflowExecutor";
+import { Button } from "@/components/ui/button";
+
+interface Props {
+  graph: WorkflowGraph;
+}
+
+export default function WorkflowRunner({ graph }: Props) {
+  const [executed, setExecuted] = useState<string[]>([]);
+  const [running, setRunning] = useState(false);
+
+  const run = async () => {
+    setRunning(true);
+    setExecuted([]);
+    const actions: Record<string, () => Promise<void>> = {};
+    for (const node of graph.nodes) {
+      actions[node.id] = async () => {
+        setExecuted((prev) => [...prev, node.id]);
+      };
+    }
+    await executeWorkflow(graph, actions);
+    setRunning(false);
+  };
+
+  return (
+    <div className="space-y-2">
+      <Button onClick={run} disabled={running}>
+        {running ? "Running..." : "Run"}
+      </Button>
+      <div>
+        {executed.map((id) => (
+          <div key={id}>{id}</div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/tests/workflowExecution.test.ts
+++ b/tests/workflowExecution.test.ts
@@ -45,3 +45,25 @@ it("handles conditional branches", async () => {
   expect(result).toEqual(["A", "B"]);
   expect(order).toEqual(["A", "B"]);
 });
+
+it("triggers actions in saved order", async () => {
+  const graph: WorkflowGraph = {
+    nodes: [
+      { id: "start", type: "x" },
+      { id: "mid", type: "y" },
+      { id: "end", type: "z" },
+    ],
+    edges: [
+      { id: "e1", source: "start", target: "mid" },
+      { id: "e2", source: "mid", target: "end" },
+    ],
+  };
+  const executed: string[] = [];
+  const actions = {
+    start: async () => executed.push("start"),
+    mid: async () => executed.push("mid"),
+    end: async () => executed.push("end"),
+  };
+  await executeWorkflow(graph, actions);
+  expect(executed).toEqual(["start", "mid", "end"]);
+});


### PR DESCRIPTION
## Summary
- create WorkflowRunner component and add dynamic workflow page
- allow WorkflowBuilder to return saved id and show Run Workflow button
- use saved workflow id when creating new workflows
- add test covering action execution order

## Testing
- `npm run lint`
- `npx jest`

------
https://chatgpt.com/codex/tasks/task_e_68657a378594832994289f1ebd0b2b2c