### PR TITLE
Fix plugin loading under Next.js

### DIFF
--- a/components/reactflow/Room.tsx
+++ b/components/reactflow/Room.tsx
@@ -51,10 +51,12 @@ import { createRealtimeEdge } from "@/lib/actions/realtimeedge.actions";
 import { updateRealtimePost } from "@/lib/actions/realtimepost.actions";
 import { RealtimePost } from "@prisma/client";
 
-// Load plug-ins from the plugins directory
-const pluginModules = import.meta.glob<{
-  descriptor?: PluginDescriptor;
-}>("../../plugins/*.tsx", { eager: true });
+// Load plug-ins from the plugins directory using webpack's require.context
+const pluginContext = (require as any).context("../../plugins", false, /\\.tsx$/);
+const pluginModules: Record<string, { descriptor?: PluginDescriptor }> = {};
+pluginContext.keys().forEach((key: string) => {
+  pluginModules[key] = pluginContext(key);
+});
 const pluginDescriptors = loadPlugins(pluginModules);
 useStore.getState().registerPlugins(pluginDescriptors);
 


### PR DESCRIPTION
## Summary
- switch plugin loader to use `require.context`

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6865830889408329b2df8bce72862cdd