### PR TITLE
Handle extra realtime post types

### DIFF
--- a/components/nodes/CodeNode.tsx
+++ b/components/nodes/CodeNode.tsx
@@ -1,0 +1,28 @@
+"use client";
+
+import { useAuth } from "@/lib/AuthContext";
+import { fetchUser } from "@/lib/actions/user.actions";
+import { CodeNode as CodeNodeType } from "@/lib/reactflow/types";
+import { NodeProps } from "@xyflow/react";
+import { useEffect, useState } from "react";
+import BaseNode from "./BaseNode";
+
+function CodeNode({ id, data }: NodeProps<CodeNodeType>) {
+  const currentUser = useAuth().user;
+  const [author, setAuthor] = useState(data.author);
+
+  useEffect(() => {
+    if ("username" in author) return;
+    fetchUser(data.author.id).then((user) => user && setAuthor(user));
+  }, [data]);
+
+  const isOwned = currentUser ? Number(currentUser.userId) === Number(data.author.id) : false;
+
+  return (
+    <BaseNode id={id} author={author} isOwned={isOwned} type={"CODE"} isLocked={data.locked}>
+      <pre className="text-xs whitespace-pre-wrap">{data.code}</pre>
+    </BaseNode>
+  );
+}
+
+export default CodeNode;

--- a/components/nodes/DocumentNode.tsx
+++ b/components/nodes/DocumentNode.tsx
@@ -1,0 +1,30 @@
+"use client";
+
+import { useAuth } from "@/lib/AuthContext";
+import { fetchUser } from "@/lib/actions/user.actions";
+import { DocumentNode as DocumentNodeType } from "@/lib/reactflow/types";
+import { NodeProps } from "@xyflow/react";
+import { useEffect, useState } from "react";
+import BaseNode from "./BaseNode";
+
+function DocumentNode({ id, data }: NodeProps<DocumentNodeType>) {
+  const currentUser = useAuth().user;
+  const [author, setAuthor] = useState(data.author);
+
+  useEffect(() => {
+    if ("username" in author) return;
+    fetchUser(data.author.id).then((user) => user && setAuthor(user));
+  }, [data]);
+
+  const isOwned = currentUser ? Number(currentUser.userId) === Number(data.author.id) : false;
+
+  return (
+    <BaseNode id={id} author={author} isOwned={isOwned} type={"DOCUMENT"} isLocked={data.locked}>
+      <a href={data.documentUrl} target="_blank" rel="noreferrer" className="underline text-blue-500 break-all">
+        {data.documentUrl || "Document"}
+      </a>
+    </BaseNode>
+  );
+}
+
+export default DocumentNode;

--- a/components/nodes/ThreadNode.tsx
+++ b/components/nodes/ThreadNode.tsx
@@ -1,0 +1,28 @@
+"use client";
+
+import { useAuth } from "@/lib/AuthContext";
+import { fetchUser } from "@/lib/actions/user.actions";
+import { ThreadNode as ThreadNodeType } from "@/lib/reactflow/types";
+import { NodeProps } from "@xyflow/react";
+import { useEffect, useState } from "react";
+import BaseNode from "./BaseNode";
+
+function ThreadNode({ id, data }: NodeProps<ThreadNodeType>) {
+  const currentUser = useAuth().user;
+  const [author, setAuthor] = useState(data.author);
+
+  useEffect(() => {
+    if ("username" in author) return;
+    fetchUser(data.author.id).then((user) => user && setAuthor(user));
+  }, [data]);
+
+  const isOwned = currentUser ? Number(currentUser.userId) === Number(data.author.id) : false;
+
+  return (
+    <BaseNode id={id} author={author} isOwned={isOwned} type={"THREAD"} isLocked={data.locked}>
+      <div className="text-sm break-all">{data.threadId}</div>
+    </BaseNode>
+  );
+}
+
+export default ThreadNode;

--- a/components/reactflow/Room.tsx
+++ b/components/reactflow/Room.tsx
@@ -44,6 +44,9 @@ import DrawNode from "../nodes/DrawNode";
 import LivechatNode from "../nodes/LivechatNode";
 import AudioNode from "../nodes/AudioNode";
 import LLMInstructionNode from "../nodes/LLMInstructionNode";
+import DocumentNode from "../nodes/DocumentNode";
+import ThreadNode from "../nodes/ThreadNode";
+import CodeNode from "../nodes/CodeNode";
 import HamburgerMenu from "../shared/HamburgerMenu";
 import NodeSidebar from "../shared/NodeSidebar";
 import { createRealtimeEdge } from "@/lib/actions/realtimeedge.actions";
@@ -323,6 +326,9 @@ function Room({ roomId, initialNodes, initialEdges }: Props) {
     LIVECHAT: LivechatNode,
     AUDIO: AudioNode,
     LLM_INSTRUCTION: LLMInstructionNode,
+    DOCUMENT: DocumentNode,
+    THREAD: ThreadNode,
+    CODE: CodeNode,
   };
   const edgeTypes = {
     DEFAULT: DefaultEdge,

--- a/lib/reactflow/reactflowutils.ts
+++ b/lib/reactflow/reactflowutils.ts
@@ -12,6 +12,9 @@ import {
   DrawNode,
   LivechatNode,
   AudioNode,
+  DocumentNode,
+  ThreadNode,
+  CodeNode,
   PortfolioNodeData,
   LLMInstructionNode,
 
@@ -228,6 +231,48 @@ export function convertPostToNode(
             y: realtimePost.y_coordinate,
           },
         } as AudioNode;
+      case "DOCUMENT":
+        return {
+          id: realtimePost.id.toString(),
+          type: realtimePost.type,
+          data: {
+            documentUrl: realtimePost.video_url || realtimePost.image_url || "",
+            author: authorToSet,
+            locked: realtimePost.locked,
+          },
+          position: {
+            x: realtimePost.x_coordinate,
+            y: realtimePost.y_coordinate,
+          },
+        } as DocumentNode;
+      case "THREAD":
+        return {
+          id: realtimePost.id.toString(),
+          type: realtimePost.type,
+          data: {
+            threadId: realtimePost.content || realtimePost.id.toString(),
+            author: authorToSet,
+            locked: realtimePost.locked,
+          },
+          position: {
+            x: realtimePost.x_coordinate,
+            y: realtimePost.y_coordinate,
+          },
+        } as ThreadNode;
+      case "CODE":
+        return {
+          id: realtimePost.id.toString(),
+          type: realtimePost.type,
+          data: {
+            code: realtimePost.content || "",
+            author: authorToSet,
+            locked: realtimePost.locked,
+          },
+          position: {
+            x: realtimePost.x_coordinate,
+            y: realtimePost.y_coordinate,
+          },
+        } as CodeNode;
       case "PORTFOLIO":
         return {
           id: realtimePost.id.toString(),


### PR DESCRIPTION
## Summary
- support `DOCUMENT`, `THREAD`, and `CODE` realtime post types
- add simple node components for these types
- register the new nodes in the room renderer

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_686581d68600832988fa5b34ca236ff0