### PR TITLE
Implement editable portfolio node

### DIFF
--- a/components/forms/PortfolioNodeForm.tsx
+++ b/components/forms/PortfolioNodeForm.tsx
@@ -1,0 +1,191 @@
+import { PortfolioNodeValidation } from "@/lib/validations/thread";
+import { zodResolver } from "@hookform/resolvers/zod";
+import Image from "next/image";
+import { ChangeEvent, useState } from "react";
+import { useForm } from "react-hook-form";
+import { z } from "zod";
+import { Button } from "../ui/button";
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "../ui/form";
+import { Input } from "../ui/input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "../ui/select";
+
+interface Props {
+  onSubmit: (values: z.infer<typeof PortfolioNodeValidation>) => void;
+  currentText: string;
+  currentImages: string[];
+  currentLinks: string[];
+  currentLayout: "grid" | "column";
+  currentColor: string;
+}
+
+const PortfolioNodeForm = ({
+  onSubmit,
+  currentText,
+  currentImages,
+  currentLinks,
+  currentLayout,
+  currentColor,
+}: Props) => {
+  const [imageURLs, setImageURLs] = useState<string[]>(currentImages);
+  const [links, setLinks] = useState<string[]>(currentLinks);
+  const form = useForm({
+    resolver: zodResolver(PortfolioNodeValidation),
+    defaultValues: {
+      text: currentText,
+      images: [] as File[],
+      links: links,
+      layout: currentLayout,
+      color: currentColor,
+    },
+  });
+
+  const handleImages = (
+    e: ChangeEvent<HTMLInputElement>,
+    fieldChange: (value: File[]) => void,
+  ) => {
+    e.preventDefault();
+    const files = Array.from(e.target.files || []);
+    fieldChange(files);
+    Promise.all(
+      files.map(
+        (file) =>
+          new Promise<string>((resolve) => {
+            const reader = new FileReader();
+            reader.onload = (evt) => resolve(evt.target?.result?.toString() || "");
+            reader.readAsDataURL(file);
+          }),
+      ),
+    ).then((urls) => setImageURLs((prev) => [...prev, ...urls]));
+  };
+
+  return (
+    <Form {...form}>
+      <form
+        onSubmit={form.handleSubmit(onSubmit)}
+        className="flex flex-col justify-start gap-4 mt-4 mb-4"
+      >
+        <FormField
+          control={form.control}
+          name="text"
+          render={({ field }) => (
+            <FormItem className="flex flex-col gap-2 text-xl">
+              <FormLabel>Text</FormLabel>
+              <FormControl>
+                <Input type="text" {...field} className="text-black" />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+        <FormField
+          control={form.control}
+          name="images"
+          render={({ field }) => (
+            <FormItem className="flex flex-col gap-2 text-xl">
+              <FormLabel>Images</FormLabel>
+              <FormControl>
+                <Input
+                  hidden
+                  multiple
+                  type="file"
+                  accept="image/*"
+                  onChange={(e) => handleImages(e, field.onChange)}
+                />
+              </FormControl>
+              <div className="flex gap-2 flex-wrap">
+                {imageURLs.map((url, idx) => (
+                  <Image
+                    key={idx}
+                    src={url}
+                    alt={`img-${idx}`}
+                    width={80}
+                    height={80}
+                    className="object-cover"
+                  />
+                ))}
+              </div>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+        <FormField
+          control={form.control}
+          name="links"
+          render={({ field }) => (
+            <FormItem className="flex flex-col gap-2 text-xl">
+              <FormLabel>Links (comma separated)</FormLabel>
+              <FormControl>
+                <Input
+                  type="text"
+                  value={field.value?.join(",")}
+                  onChange={(e) => {
+                    const vals = e.target.value.split(",").map((v) => v.trim());
+                    setLinks(vals);
+                    field.onChange(vals);
+                  }}
+                  className="text-black"
+                />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+        <FormField
+          control={form.control}
+          name="layout"
+          render={({ field }) => (
+            <FormItem className="flex flex-col gap-2 text-xl">
+              <FormLabel>Layout</FormLabel>
+              <Select
+                onValueChange={field.onChange}
+                defaultValue={field.value}
+              >
+                <FormControl>
+                  <SelectTrigger>
+                    <SelectValue placeholder="Select layout" />
+                  </SelectTrigger>
+                </FormControl>
+                <SelectContent>
+                  <SelectItem value="grid">Grid</SelectItem>
+                  <SelectItem value="column">Column</SelectItem>
+                </SelectContent>
+              </Select>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+        <FormField
+          control={form.control}
+          name="color"
+          render={({ field }) => (
+            <FormItem className="flex flex-col gap-2 text-xl">
+              <FormLabel>Color</FormLabel>
+              <FormControl>
+                <Input type="text" {...field} className="text-black" />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+        <Button type="submit" className="w-full mt-4">
+          Submit
+        </Button>
+      </form>
+    </Form>
+  );
+};
+
+export default PortfolioNodeForm;

--- a/components/modals/PortfolioNodeModal.tsx
+++ b/components/modals/PortfolioNodeModal.tsx
@@ -1,0 +1,119 @@
+import { PortfolioNodeValidation } from "@/lib/validations/thread";
+import { z } from "zod";
+import PortfolioNodeForm from "../forms/PortfolioNodeForm";
+import {
+  DialogClose,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+
+interface Props {
+  id?: string;
+  isOwned: boolean;
+  onSubmit?: (values: z.infer<typeof PortfolioNodeValidation>) => void;
+  currentText: string;
+  currentImages: string[];
+  currentLinks: string[];
+  currentLayout: "grid" | "column";
+  currentColor: string;
+}
+
+const renderCreate = ({
+  onSubmit,
+  currentText,
+  currentImages,
+  currentLinks,
+  currentLayout,
+  currentColor,
+}: Omit<Props, "id" | "isOwned">) => (
+  <div>
+    <DialogHeader className="dialog-header text-white text-lg py-4 mt-[-4rem]">
+      <b>Create Portfolio</b>
+    </DialogHeader>
+    <hr />
+    <PortfolioNodeForm
+      onSubmit={onSubmit!}
+      currentText={currentText}
+      currentImages={currentImages}
+      currentLinks={currentLinks}
+      currentLayout={currentLayout}
+      currentColor={currentColor}
+    />
+  </div>
+);
+
+const renderEdit = ({
+  onSubmit,
+  currentText,
+  currentImages,
+  currentLinks,
+  currentLayout,
+  currentColor,
+}: Omit<Props, "id" | "isOwned">) => (
+  <div>
+    <DialogHeader className="dialog-header text-white text-lg py-4 mt-[-4rem]">
+      <b>Edit Portfolio</b>
+    </DialogHeader>
+    <hr />
+    <PortfolioNodeForm
+      onSubmit={onSubmit!}
+      currentText={currentText}
+      currentImages={currentImages}
+      currentLinks={currentLinks}
+      currentLayout={currentLayout}
+      currentColor={currentColor}
+    />
+  </div>
+);
+
+const PortfolioNodeModal = ({
+  id,
+  isOwned,
+  onSubmit,
+  currentText,
+  currentImages,
+  currentLinks,
+  currentLayout,
+  currentColor,
+}: Props) => {
+  const isCreate = !id && isOwned;
+  const isEdit = id && isOwned;
+  return (
+    <div>
+      <DialogContent className="max-w-[57rem]">
+        <DialogTitle>PortfolioNodeModal</DialogTitle>
+        <div className="grid rounded-md px-4 py-2">
+          {isCreate &&
+            renderCreate({
+              onSubmit,
+              currentText,
+              currentImages,
+              currentLinks,
+              currentLayout,
+              currentColor,
+            })}
+          {isEdit &&
+            renderEdit({
+              onSubmit,
+              currentText,
+              currentImages,
+              currentLinks,
+              currentLayout,
+              currentColor,
+            })}
+          {!isOwned && (
+            <DialogClose
+              id="animateButton"
+              className={`form-submit-button pl-2 py-2 pr-[1rem]`}
+            >
+              <> Close </>
+            </DialogClose>
+          )}
+        </div>
+      </DialogContent>
+    </div>
+  );
+};
+
+export default PortfolioNodeModal;

--- a/components/nodes/PortfolioNode.tsx
+++ b/components/nodes/PortfolioNode.tsx
@@ -3,20 +3,47 @@
 import { NodeProps } from "@xyflow/react";
 import { useAuth } from "@/lib/AuthContext";
 import { fetchUser } from "@/lib/actions/user.actions";
+import { updateRealtimePost } from "@/lib/actions/realtimepost.actions";
+import useStore from "@/lib/reactflow/store";
+import { PortfolioNodeValidation } from "@/lib/validations/thread";
+import { uploadFileToSupabase } from "@/lib/utils";
 import { useEffect, useState } from "react";
+import { usePathname } from "next/navigation";
+import { z } from "zod";
 import BaseNode from "./BaseNode";
-import { PortfolioNodeData } from "@/lib/reactflow/types";
+import { PortfolioNodeData, AppState } from "@/lib/reactflow/types";
+import { useShallow } from "zustand/react/shallow";
+import PortfolioNodeModal from "../modals/PortfolioNodeModal";
 
 import Image from "next/image";
 
 function PortfolioNode({ id, data }: NodeProps<PortfolioNodeData>) {
+  const path = usePathname();
   const currentUser = useAuth().user;
+  const store = useStore(
+    useShallow((state: AppState) => ({
+      closeModal: state.closeModal,
+    }))
+  );
   const [author, setAuthor] = useState(data.author);
+  const [text, setText] = useState(data.text);
+  const [images, setImages] = useState<string[]>(data.images || []);
+  const [links, setLinks] = useState<string[]>(data.links || []);
+  const [layout, setLayout] = useState<"grid" | "column">(data.layout);
+  const [color, setColor] = useState(data.color);
 
   useEffect(() => {
     if ("username" in author) return;
     fetchUser(data.author.id).then((user) => user && setAuthor(user));
   }, [data.author, author]);
+
+  useEffect(() => {
+    setText(data.text);
+    setImages(data.images || []);
+    setLinks(data.links || []);
+    setLayout(data.layout);
+    setColor(data.color);
+  }, [data]);
 
   const isOwned = currentUser
     ? Number(currentUser.userId) === Number(data.author.id)
@@ -44,8 +71,51 @@ function PortfolioNode({ id, data }: NodeProps<PortfolioNodeData>) {
     URL.revokeObjectURL(url);
   };
 
+  async function onSubmit(values: z.infer<typeof PortfolioNodeValidation>) {
+    const uploads = await Promise.all(
+      (values.images || []).map((img) => uploadFileToSupabase(img))
+    );
+    const urls = uploads.filter((r) => !r.error).map((r) => r.fileURL);
+    const updatedImages = urls.length > 0 ? [...images, ...urls] : images;
+
+    setText(values.text);
+    setImages(updatedImages);
+    setLinks(values.links || []);
+    setLayout(values.layout);
+    setColor(values.color);
+
+    await updateRealtimePost({
+      id,
+      path,
+      text: values.text,
+      imageUrl: updatedImages[0],
+      videoUrl: (values.links && values.links[0]) || links[0],
+      content: JSON.stringify({
+        images: updatedImages,
+        links: values.links || [],
+        layout: values.layout,
+        color: values.color,
+      }),
+    });
+    store.closeModal();
+  }
+
   return (
     <BaseNode
+      modalContent={
+        isOwned ? (
+          <PortfolioNodeModal
+            id={id}
+            isOwned={isOwned}
+            onSubmit={onSubmit}
+            currentText={text}
+            currentImages={images}
+            currentLinks={links}
+            currentLayout={layout}
+            currentColor={color}
+          />
+        ) : null
+      }
       id={id}
       author={author}
       isOwned={isOwned}
@@ -54,24 +124,24 @@ function PortfolioNode({ id, data }: NodeProps<PortfolioNodeData>) {
       generateOnClick={handleExport}
     >
       <div className="p-2">
-        <p className="mb-1">{data.text}</p>
-        {data.images[0] && (
+        <p className="mb-1">{text}</p>
+        {images[0] && (
           <Image
-            src={data.images[0]}
+            src={images[0]}
             alt="img"
             width={80}
             height={80}
             className="object-cover"
           />
         )}
-        {data.links[0] && (
+        {links[0] && (
           <a
-            href={data.links[0]}
+            href={links[0]}
             className="text-blue-500 underline"
             target="_blank"
             rel="noreferrer"
           >
-            {data.links[0]}
+            {links[0]}
           </a>
         )}
       </div>

--- a/lib/reactflow/types.ts
+++ b/lib/reactflow/types.ts
@@ -11,6 +11,7 @@ import ImageNodeModal from "@/components/modals/ImageNodeModal";
 import YoutubeNodeModal from "@/components/modals/YoutubeNodeModal";
 import CollageCreationModal from "@/components/modals/CollageCreationModal";
 import GalleryNodeModal from "@/components/modals/GalleryNodeModal";
+import PortfolioNodeModal from "@/components/modals/PortfolioNodeModal";
 import ShareRoomModal from "@/components/modals/ShareRoomModal";
 import { PluginDescriptor } from "../pluginLoader";
 // there is currently no dedicated modal for portal nodes
@@ -215,6 +216,7 @@ export const NodeTypeToModalMap = {
   VIDEO: YoutubeNodeModal,
   COLLAGE: CollageCreationModal,
   GALLERY: GalleryNodeModal,
+  PORTFOLIO: PortfolioNodeModal,
   PORTAL: ShareRoomModal,
   LIVECHAT: ShareRoomModal,
 };

--- a/lib/validations/thread.ts
+++ b/lib/validations/thread.ts
@@ -84,3 +84,12 @@ export const PortalNodeValidation = z.object({
 export const LivechatInviteValidation = z.object({
   invitee: z.string().min(1),
 });
+
+export const PortfolioNodeValidation = z.object({
+  text: z.string().min(1),
+  images: z.array(z.any().refine((file) => file?.size <= MAX_FILE_SIZE, `Max image size is 5MB.`).refine((file) => ACCEPTED_IMAGE_TYPES.includes(file?.type), "Only .jpg, .jpeg, .png and .webp formats are supported.")).optional(),
+  links: z.array(z.string().url()).optional(),
+  layout: z.enum(["grid", "column"]).default("grid"),
+  color: z.string().default("bg-white"),
+});
+


### PR DESCRIPTION
## Summary
- add PortfolioNodeForm for editing portfolio details
- create PortfolioNodeModal
- connect new modal in PortfolioNode component
- register PortfolioNodeModal in NodeType map
- add PortfolioNodeValidation schema

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6865a1e025f48329ba1c7db4291375ce