### PR TITLE
Improve node locking and add timestamps

### DIFF
--- a/components/buttons/LockButton.tsx
+++ b/components/buttons/LockButton.tsx
@@ -13,8 +13,11 @@ interface Props {
 const LockButton = ({ lockOnClick, isLocked, isOwned }: Props) => {
   return (
     <div className="relative -bottom-1  ">
-      <button className="likebutton">
-   
+      <button
+        className="likebutton"
+        onClick={() => isOwned && lockOnClick(!isLocked)}
+        disabled={!isOwned}
+      >
         {isLocked ? (
           <Image src="/assets/locked.svg" width={24} height={24} alt="locked" />
         ) : (
@@ -23,10 +26,9 @@ const LockButton = ({ lockOnClick, isLocked, isOwned }: Props) => {
             width={24}
             height={24}
             alt="unlocked"
-
           />
         )}
-        </button>
+      </button>
     </div>
   );
 };

--- a/components/cards/PostCard.tsx
+++ b/components/cards/PostCard.tsx
@@ -106,11 +106,12 @@ const PostCard = async ({
           <div>
             <Link href={`/profile/${author.id}`} className="w-fit ">
               <div className={`${founders.className} `}>
-              <p className="cursor-pointer  text-[1.08rem] tracking-[.05rem] font-semibold text-black relative right-[.25rem] top-[.3rem]">
-                {author.name}
-              </p>
+                <p className="cursor-pointer  text-[1.08rem] tracking-[.05rem] font-semibold text-black relative right-[.25rem] top-[.3rem]">
+                  {author.name}
+                </p>
               </div>
             </Link>
+            <p className="text-xs text-gray-500 mt-1">Posted at {createdAt}</p>
             <hr className="mt-3 mb-4 w-full h-px border-t-0 bg-transparent bg-gradient-to-r from-transparent via-slate-100 to-transparent opacity-75" />
             {type === "TEXT" && content && (
               <p className="mt-2  text-[1.08rem] text-black tracking-[.05rem]">{content}</p>

--- a/components/cards/ThreadCard.tsx
+++ b/components/cards/ThreadCard.tsx
@@ -87,11 +87,12 @@ const ThreadCard = async ({
           <div>
             <Link href={`/profile/${author.id}`} className="w-fit ">
               <div className={`${founders.className} `}>
-              <p className="cursor-pointer  text-[1.08rem] tracking-[.05rem] font-semibold text-black relative right-[.25rem] top-[.3rem]">
-                {author.name}
-              </p>
+                <p className="cursor-pointer  text-[1.08rem] tracking-[.05rem] font-semibold text-black relative right-[.25rem] top-[.3rem]">
+                  {author.name}
+                </p>
               </div>
             </Link>
+            <p className="text-xs text-gray-500 mt-1">Posted at {createdAt}</p>
             <hr className="mt-3 mb-4 w-[200%] h-px border-t-0 bg-transparent bg-gradient-to-r from-transparent via-slate-100 to-transparent opacity-75" />
               <p className="mt-2  text-[1.08rem] text-black tracking-[.05rem]">{content}</p>
            

--- a/components/nodes/BaseNode.tsx
+++ b/components/nodes/BaseNode.tsx
@@ -51,9 +51,10 @@ function BaseNode({
 
   const lockOnClick = async (newLockState: boolean) => {
     await lockRealtimePost({ id, lockState: newLockState, path: pathname });
+    store.changePostLockState(id, newLockState);
   };
 
-  const canDrag = user && isOwned && !isLocked;
+  const canDrag = user && (!isLocked || isOwned);
 
   return (
     <div className={canDrag ? "" : "nodrag"}>

--- a/components/reactflow/Room.tsx
+++ b/components/reactflow/Room.tsx
@@ -192,6 +192,15 @@ function Room({ roomId, initialNodes, initialEdges }: Props) {
 
   const onNodeDragStop = useCallback(
     (_: any, node: AppNode) => {
+      const authorId = (node.data.author as any).id;
+      if (user && Number(authorId) === Number(user.userId)) {
+        updateRealtimePost({
+          id: node.id,
+          path: pathname,
+          coordinates: node.position,
+        });
+      }
+
       if (!PROXIMITY_CONNECT_ENABLED) return;
       const closeEdge = getClosestEdge(node);
 
@@ -203,7 +212,7 @@ function Room({ roomId, initialNodes, initialEdges }: Props) {
         onConnect({ source: closeEdge.source, target: closeEdge.target });
       }
     },
-    [edges, getClosestEdge, onConnect, setEdges]
+    [edges, getClosestEdge, onConnect, setEdges, user, pathname]
   );
 
   const reactFlowRef = useRef<HTMLDivElement>(null);


### PR DESCRIPTION
## Summary
- show "Posted at" timestamps on post cards
- allow locking nodes so only the owner can drag them
- update drag stop handler to persist node position

## Testing
- `yarn install`
- `npm run lint` *(fails: React hook dependency warnings)*

------
https://chatgpt.com/codex/tasks/task_e_6865a42d20b88329ac6cb015e5a532d0