### PR TITLE
Fix portfolio node creation

### DIFF
--- a/components/nodes/PortfolioNode.tsx
+++ b/components/nodes/PortfolioNode.tsx
@@ -87,10 +87,10 @@ function PortfolioNode({ id, data }: NodeProps<PortfolioNodeData>) {
     await updateRealtimePost({
       id,
       path,
-      text: values.text,
       imageUrl: updatedImages[0],
       videoUrl: (values.links && values.links[0]) || links[0],
       content: JSON.stringify({
+        text: values.text,
         images: updatedImages,
         links: values.links || [],
         layout: values.layout,

--- a/components/shared/NodeSidebar.tsx
+++ b/components/shared/NodeSidebar.tsx
@@ -17,6 +17,7 @@ import {
   GalleryPostValidation,
   TextPostValidation,
   YoutubePostValidation,
+  PortfolioNodeValidation,
 } from "@/lib/validations/thread";
 import { usePathname, useParams } from "next/navigation";
 import {
@@ -57,6 +58,7 @@ import CollageCreationModal from "@/components/modals/CollageCreationModal";
 import PortalNodeModal from "@/components/modals/PortalNodeModal";
 import GalleryNodeModal from "@/components/modals/GalleryNodeModal";
 import LivechatNodeModal from "@/components/modals/LivechatNodeModal";
+import PortfolioNodeModal from "@/components/modals/PortfolioNodeModal";
 import { fetchUserByUsername } from "@/lib/actions/user.actions";
 
 export default function NodeSidebar({
@@ -332,12 +334,40 @@ export default function NodeSidebar({
         break;
 
       case "PORTFOLIO":
-        createPostAndAddToCanvas({
-          path: pathname,
-          coordinates: centerPosition,
-          type: "PORTFOLIO",
-          realtimeRoomId: roomId,
-        });
+        store.openModal(
+          <PortfolioNodeModal
+            isOwned={true}
+            currentText=""
+            currentImages={[]}
+            currentLinks={[]}
+            currentLayout="grid"
+            currentColor="bg-white"
+            onSubmit={async (vals) => {
+              const uploads = await Promise.all(
+                (vals.images || []).map((img) => uploadFileToSupabase(img))
+              );
+              const urls = uploads
+                .filter((r) => !r.error)
+                .map((r) => r.fileURL);
+              const payload = {
+                text: vals.text,
+                images: urls,
+                links: vals.links || [],
+                layout: vals.layout,
+                color: vals.color,
+              };
+              createPostAndAddToCanvas({
+                text: JSON.stringify(payload),
+                imageUrl: urls[0],
+                videoUrl: (vals.links && vals.links[0]) || undefined,
+                path: pathname,
+                coordinates: centerPosition,
+                type: "PORTFOLIO",
+                realtimeRoomId: roomId,
+              });
+            }}
+          />
+        );
         break;
 
       default:

--- a/lib/reactflow/reactflowutils.ts
+++ b/lib/reactflow/reactflowutils.ts
@@ -273,16 +273,42 @@ export function convertPostToNode(
             y: realtimePost.y_coordinate,
           },
         } as CodeNode;
-      case "PORTFOLIO":
+      case "PORTFOLIO": {
+        let text = "";
+        let images: string[] = [];
+        let links: string[] = [];
+        let layout: "grid" | "column" = "grid";
+        let color = "bg-white";
+
+        if (realtimePost.content) {
+          try {
+            const parsed = JSON.parse(realtimePost.content);
+            text = parsed.text || "";
+            images = parsed.images || [];
+            links = parsed.links || [];
+            layout = parsed.layout || "grid";
+            color = parsed.color || "bg-white";
+          } catch {
+            text = realtimePost.content || "";
+          }
+        }
+
+        if (images.length === 0 && realtimePost.image_url) {
+          images = [realtimePost.image_url];
+        }
+        if (links.length === 0 && realtimePost.video_url) {
+          links = [realtimePost.video_url];
+        }
+
         return {
           id: realtimePost.id.toString(),
           type: realtimePost.type,
           data: {
-            text: realtimePost.content || "",
-            images: realtimePost.image_url ? [realtimePost.image_url] : [],
-            links: realtimePost.video_url ? [realtimePost.video_url] : [],
-            layout: "grid",
-            color: "bg-white",
+            text,
+            images,
+            links,
+            layout,
+            color,
             author: authorToSet,
             locked: realtimePost.locked,
           },
@@ -291,6 +317,7 @@ export function convertPostToNode(
             y: realtimePost.y_coordinate,
           },
         } as PortfolioNodeData;
+      }
       case "LLM_INSTRUCTION":
         return {
           id: realtimePost.id.toString(),


### PR DESCRIPTION
## Summary
- add PortfolioNodeModal to NodeSidebar for new portfolio nodes
- parse portfolio data stored as JSON when converting realtime posts
- update portfolio node updates to store JSON payload

## Testing
- `yarn install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6865aa86beb88329b1918bc24ab0a671