### PR TITLE
Fix portfolio node rendering

### DIFF
--- a/components/reactflow/Room.tsx
+++ b/components/reactflow/Room.tsx
@@ -48,6 +48,7 @@ import LLMInstructionNode from "../nodes/LLMInstructionNode";
 import DocumentNode from "../nodes/DocumentNode";
 import ThreadNode from "../nodes/ThreadNode";
 import CodeNode from "../nodes/CodeNode";
+import PortfolioNode from "../nodes/PortfolioNode";
 import HamburgerMenu from "../shared/HamburgerMenu";
 import NodeSidebar from "../shared/NodeSidebar";
 import { createRealtimeEdge } from "@/lib/actions/realtimeedge.actions";
@@ -339,6 +340,7 @@ function Room({ roomId, initialNodes, initialEdges }: Props) {
     DOCUMENT: DocumentNode,
     THREAD: ThreadNode,
     CODE: CodeNode,
+    PORTFOLIO: PortfolioNode,
   };
   pluginDescriptors.forEach((p) => {
     (nodeTypes as any)[p.type] = p.component as any;


### PR DESCRIPTION
## Summary
- register `PortfolioNode` in Room component

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6865b225b2f08329a31d213a48e9e9c4