### PR TITLE
Fix portfolio export layout

### DIFF
--- a/lib/portfolio/export.ts
+++ b/lib/portfolio/export.ts
@@ -10,19 +10,24 @@ export function generatePortfolioTemplates(data: PortfolioExportData): {
   html: string;
   css: string;
 } {
-  const layoutClass =
-    data.layout === "grid" ? "grid grid-cols-3 gap-4" : "flex flex-col gap-4";
-  const colorClass = data.color || "bg-white";
+  const bgClass = data.color || "bg-white";
+
+  const textBlock = data.text
+    ? `<div class="text-block flex flex-col max-h-[1000px] mb-1 mt-2 break-words">${data.text}</div>`
+    : "";
 
   const images = data.images
-    .map((src) => `<img src="${src}" class="w-full" />`)
+    .map((src, idx) =>
+      `<img src="${src}" class="object-cover  portfolio-img-frame ${idx === 0 ? "flex flex-col max-h-[3000px] mb-1 mt-2 break-words" : ""}" />`
+    )
     .join("\n");
+
   const links = data.links
     .map(
       (href) =>
-        `<a href="${href}" class="text-blue-500 underline" target="_blank" rel="noopener">${href}</a>`
+        `<a href="${href}" class="text-blue-500 underline break-all" target="_blank" rel="noreferrer">${href}</a>`
     )
-    .join("<br/>\n");
+    .join("\n");
 
   const html = `<!DOCTYPE html>
 <html lang="en">
@@ -31,11 +36,13 @@ export function generatePortfolioTemplates(data: PortfolioExportData): {
   <title>Portfolio</title>
   <link href="tailwind.css" rel="stylesheet">
 </head>
-<body class="${colorClass} p-4">
-  <div class="${layoutClass}">
-    <div>${data.text}</div>
-    ${images}
-    <div>${links}</div>
+<body>
+  <div class="portfolio-container flex flex-col w-[34rem] max-h-[3000px]">
+    <div class="flex flex-col gap-2 rounded-lg p-4 ${bgClass} mt-4 max-h-[3000px]">
+      ${textBlock}
+      ${images}
+      ${links}
+    </div>
   </div>
 </body>
 </html>`;

--- a/tests/__snapshots__/portfolio-export.test.ts.snap
+++ b/tests/__snapshots__/portfolio-export.test.ts.snap
@@ -8,11 +8,13 @@ exports[`portfolio export matches snapshot 1`] = `
   <title>Portfolio</title>
   <link href="tailwind.css" rel="stylesheet">
 </head>
-<body class="bg-white p-4">
-  <div class="flex flex-col gap-4">
-    <div>Hello</div>
-    <img src="img.png" class="w-full" />
-    <div><a href="https://example.com" class="text-blue-500 underline" target="_blank" rel="noopener">https://example.com</a></div>
+<body>
+  <div class="portfolio-container flex flex-col w-[34rem] max-h-[3000px]">
+    <div class="flex flex-col gap-2 rounded-lg p-4 bg-white mt-4 max-h-[3000px]">
+      <div class="text-block flex flex-col max-h-[1000px] mb-1 mt-2 break-words">Hello</div>
+      <img src="img.png" class="object-cover  portfolio-img-frame flex flex-col max-h-[3000px] mb-1 mt-2 break-words" />
+      <a href="https://example.com" class="text-blue-500 underline break-all" target="_blank" rel="noreferrer">https://example.com</a>
+    </div>
   </div>
 </body>
 </html>"


### PR DESCRIPTION
## Summary
- mirror PortfolioNode layout in exported HTML
- update portfolio export snapshot

## Testing
- `npx jest -u tests/portfolio-export.test.ts`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6865c2189f688329a24f58f808029647