### PR TITLE
Fix portfolio color and export styles

### DIFF
--- a/components/nodes/PortfolioNode.tsx
+++ b/components/nodes/PortfolioNode.tsx
@@ -125,7 +125,7 @@ function PortfolioNode({ id, data }: NodeProps<PortfolioNodeData>) {
       generateOnClick={handleExport}
     >
       <div className="portfolio-container flex flex-col w-[34rem] max-h-[3000px] ">
-        <div  className={`${color}flex flex-col gap-2 rounded-lg p-4  mt-4  max-h-[3000px]`}>
+        <div  className={`${color} flex flex-col gap-2 rounded-lg p-4  mt-4  max-h-[3000px]`}>
           {text && (
             <div className="text-block flex flex-col max-h-[1000px] mb-1 mt-2 break-words">{text}</div>
           )}

--- a/lib/portfolio/export.ts
+++ b/lib/portfolio/export.ts
@@ -47,7 +47,7 @@ export function generatePortfolioTemplates(data: PortfolioExportData): {
 </body>
 </html>`;
 
-  const css = `@tailwind base;\n@tailwind components;\n@tailwind utilities;`;
+  const css = `@tailwind base;\n@tailwind components;\n@tailwind utilities;\n\n.portfolio-container {\n  display: flex;\n  padding: 50px;\n  width: 34rem;\n}\n\n.portfolio-img-frame {\n  background: transparent;\n  border: 1px solid #1a192b;\n  padding: 0px;\n}\n\n.text-block {\n  width: fit-content;\n  border: .5px solid #000000;\n  border-radius: 2px;\n  font-size: .7rem;\n  line-height: 1;\n  letter-spacing: normal;\n  margin: 0.3rem 0;\n  padding: 0.3rem;\n  max-height: 9.25rem;\n  overflow-y: auto;\n  scroll-behavior: smooth;\n}`;
 
   return { html, css };
 }

--- a/tests/__snapshots__/portfolio-export.test.ts.snap
+++ b/tests/__snapshots__/portfolio-export.test.ts.snap
@@ -23,5 +23,31 @@ exports[`portfolio export matches snapshot 1`] = `
 exports[`portfolio export matches snapshot 2`] = `
 "@tailwind base;
 @tailwind components;
-@tailwind utilities;"
+@tailwind utilities;
+
+.portfolio-container {
+  display: flex;
+  padding: 50px;
+  width: 34rem;
+}
+
+.portfolio-img-frame {
+  background: transparent;
+  border: 1px solid #1a192b;
+  padding: 0px;
+}
+
+.text-block {
+  width: fit-content;
+  border: .5px solid #000000;
+  border-radius: 2px;
+  font-size: .7rem;
+  line-height: 1;
+  letter-spacing: normal;
+  margin: 0.3rem 0;
+  padding: 0.3rem;
+  max-height: 9.25rem;
+  overflow-y: auto;
+  scroll-behavior: smooth;
+}"
 `;


### PR DESCRIPTION
## Summary
- fix portfolio background color by adding missing space in className
- include portfolio container and text styles in exported CSS
- update export CSS snapshot

## Testing
- `npm run lint` *(fails: warnings)*

------
https://chatgpt.com/codex/tasks/task_e_6865d0b2ef8c83299a5db0170c125e6d