### PR TITLE
Fix node update sync

### DIFF
--- a/components/reactflow/Room.tsx
+++ b/components/reactflow/Room.tsx
@@ -248,15 +248,19 @@ function Room({ roomId, initialNodes, initialEdges }: Props) {
 
   const updateNodeFunction = useCallback(
     (updatedObject: RealtimePost) => {
-      updateNode(updatedObject.id.toString(), () =>
-        convertPostToNode({
-          ...updatedObject,
-          x_coordinate: Number(updatedObject.x_coordinate),
-          y_coordinate: Number(updatedObject.y_coordinate),
-        })
+      const newNode = convertPostToNode({
+        ...updatedObject,
+        x_coordinate: Number(updatedObject.x_coordinate),
+        y_coordinate: Number(updatedObject.y_coordinate),
+      });
+      updateNode(updatedObject.id.toString(), () => newNode);
+
+      const currentNodes = useStore.getState().nodes;
+      setNodes(
+        currentNodes.map((n) => (n.id === newNode.id ? { ...n, ...newNode } : n))
       );
     },
-    [updateNode]
+    [updateNode, setNodes]
   );
 
   const updateEdgeFunction = useCallback(


### PR DESCRIPTION
## Summary
- keep Zustand store in sync when realtime node updates are received

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_686615c377908329b00d18efc96d47d6