### PR TITLE
Improve workflow editing UX

### DIFF
--- a/components/workflow/WorkflowSidePanel.tsx
+++ b/components/workflow/WorkflowSidePanel.tsx
@@ -1,0 +1,91 @@
+"use client";
+
+import { Node, Edge } from "@xyflow/react";
+import {
+  Sheet,
+  SheetContent,
+  SheetHeader,
+  SheetTitle,
+} from "@/components/ui/sheet";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+
+interface Props {
+  node?: Node;
+  edge?: Edge;
+  onUpdateNode: (node: Node) => void;
+  onUpdateEdge: (edge: Edge) => void;
+  onClose: () => void;
+}
+
+export default function WorkflowSidePanel({
+  node,
+  edge,
+  onUpdateNode,
+  onUpdateEdge,
+  onClose,
+}: Props) {
+  const open = !!node || !!edge;
+  return (
+    <Sheet open={open} onOpenChange={onClose}>
+      <SheetContent side="right" className="w-[250px] space-y-4">
+        {node && (
+          <div className="space-y-2">
+            <SheetHeader>
+              <SheetTitle>Edit State</SheetTitle>
+            </SheetHeader>
+            <Label htmlFor="node-label">Label</Label>
+            <Input
+              id="node-label"
+              value={node.data?.label || ""}
+              onChange={(e) =>
+                onUpdateNode({
+                  ...node,
+                  data: { ...node.data, label: e.target.value },
+                })
+              }
+            />
+            <Label htmlFor="node-action">Action</Label>
+            <Input
+              id="node-action"
+              value={node.data?.action || ""}
+              onChange={(e) =>
+                onUpdateNode({
+                  ...node,
+                  data: { ...node.data, action: e.target.value },
+                })
+              }
+            />
+          </div>
+        )}
+        {edge && (
+          <div className="space-y-2">
+            <SheetHeader>
+              <SheetTitle>Edit Transition</SheetTitle>
+            </SheetHeader>
+            <Label htmlFor="edge-label">Label</Label>
+            <Input
+              id="edge-label"
+              value={edge.label || ""}
+              onChange={(e) =>
+                onUpdateEdge({ ...edge, label: e.target.value })
+              }
+            />
+            <Label htmlFor="edge-condition">Condition</Label>
+            <Input
+              id="edge-condition"
+              value={(edge.data as any)?.condition || edge.condition || ""}
+              onChange={(e) =>
+                onUpdateEdge({
+                  ...edge,
+                  data: { ...(edge.data || {}), condition: e.target.value },
+                  condition: e.target.value,
+                })
+              }
+            />
+          </div>
+        )}
+      </SheetContent>
+    </Sheet>
+  );
+}


### PR DESCRIPTION
## Summary
- enable drag-and-drop state creation in `WorkflowBuilder`
- open a right panel to edit state and transition details
- persist edits via `useNodesState` and `useEdgesState`

## Testing
- `yarn install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_686619adf7a88329a70db7227eebbc8b