### PR TITLE
Add workflow runner context with pause and logs

### DIFF
--- a/components/workflow/WorkflowExecutionContext.tsx
+++ b/components/workflow/WorkflowExecutionContext.tsx
@@ -1,0 +1,87 @@
+"use client";
+
+import { createContext, useContext, useRef, useState, ReactNode } from "react";
+import { WorkflowGraph } from "@/lib/workflowExecutor";
+
+interface ExecutionContextValue {
+  current: string | null;
+  executed: string[];
+  logs: string[];
+  running: boolean;
+  paused: boolean;
+  run: (
+    graph: WorkflowGraph,
+    actions: Record<string, () => Promise<string | void>>,
+    evaluate?: (condition: string) => boolean
+  ) => Promise<void>;
+  pause: () => void;
+  resume: () => void;
+}
+
+const WorkflowExecutionContext = createContext<ExecutionContextValue | null>(null);
+
+export const useWorkflowExecution = () => {
+  const ctx = useContext(WorkflowExecutionContext);
+  if (!ctx) throw new Error("WorkflowExecutionContext not found");
+  return ctx;
+};
+
+export function WorkflowExecutionProvider({ children }: { children: ReactNode }) {
+  const [current, setCurrent] = useState<string | null>(null);
+  const [executed, setExecuted] = useState<string[]>([]);
+  const [logs, setLogs] = useState<string[]>([]);
+  const [running, setRunning] = useState(false);
+  const [paused, setPaused] = useState(false);
+  const resumeRef = useRef<() => void>();
+
+  const waitIfPaused = () =>
+    paused
+      ? new Promise<void>((resolve) => {
+          resumeRef.current = resolve;
+        })
+      : Promise.resolve();
+
+  const pause = () => setPaused(true);
+  const resume = () => {
+    setPaused(false);
+    resumeRef.current?.();
+  };
+
+  const run = async (
+    graph: WorkflowGraph,
+    actions: Record<string, () => Promise<string | void>>,
+    evaluate: (condition: string) => boolean = () => true
+  ) => {
+    setRunning(true);
+    setExecuted([]);
+    setLogs([]);
+    setCurrent(null);
+
+    const nodeMap = new Map(graph.nodes.map((n) => [n.id, n]));
+    let currentNode = graph.nodes[0];
+    while (currentNode) {
+      setCurrent(currentNode.id);
+      const result = await actions[currentNode.id]?.();
+      if (typeof result === "string") {
+        setLogs((prev) => [...prev, result]);
+      }
+      setExecuted((prev) => [...prev, currentNode.id]);
+      await waitIfPaused();
+      const outgoing = graph.edges.filter((e) => e.source === currentNode.id);
+      if (outgoing.length === 0) break;
+      const nextEdge = outgoing.find((e) => !e.condition || evaluate(e.condition));
+      if (!nextEdge) break;
+      currentNode = nodeMap.get(nextEdge.target)!;
+    }
+    setCurrent(null);
+    setRunning(false);
+  };
+
+  return (
+    <WorkflowExecutionContext.Provider
+      value={{ current, executed, logs, running, paused, run, pause, resume }}
+    >
+      {children}
+    </WorkflowExecutionContext.Provider>
+  );
+}

--- a/components/workflow/WorkflowViewer.tsx
+++ b/components/workflow/WorkflowViewer.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import {
+  ReactFlow,
+  Background,
+  Controls,
+  Node,
+  Edge,
+} from "@xyflow/react";
+import "@xyflow/react/dist/style.css";
+import { WorkflowGraph } from "@/lib/workflowExecutor";
+import { useWorkflowExecution } from "./WorkflowExecutionContext";
+
+interface ViewerProps {
+  graph: WorkflowGraph;
+}
+
+export default function WorkflowViewer({ graph }: ViewerProps) {
+  const { current } = useWorkflowExecution();
+  const [nodes, setNodes] = useState<Node[]>(graph.nodes as Node[]);
+  const [edges] = useState<Edge[]>(graph.edges as Edge[]);
+
+  useEffect(() => {
+    setNodes((nds) =>
+      nds.map((n) =>
+        n.id === current
+          ? { ...n, className: "bg-yellow-100 border-2 border-blue-500" }
+          : { ...n, className: "" }
+      )
+    );
+  }, [current]);
+
+  return (
+    <div style={{ height: 300 }}>
+      <ReactFlow nodes={nodes} edges={edges}>
+        <Background />
+        <Controls />
+      </ReactFlow>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- introduce `WorkflowExecutionContext` to share execution state
- highlight active node in new `WorkflowViewer`
- update `WorkflowRunner` to use context, viewer and pause/resume controls

## Testing
- `yarn install`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_686619b41400832989bfebd3842d9883