### PR TITLE
Add workflow state history

### DIFF
--- a/lib/actions/workflow.actions.ts
+++ b/lib/actions/workflow.actions.ts
@@ -26,6 +26,13 @@ export async function createWorkflow({
       graph,
     },
   });
+  await prisma.workflowState.create({
+    data: {
+      workflow_id: workflow.id,
+      version: 1,
+      graph,
+    },
+  });
   revalidatePath("/workflows");
   return workflow;
 }
@@ -37,14 +44,41 @@ export async function updateWorkflow({
   id: bigint;
   graph: WorkflowGraph;
 }) {
+  const user = await getUserFromCookies();
+  if (!user) throw new Error("User not authenticated");
   await prisma.$connect();
-  return await prisma.workflow.update({
-    where: { id },
-    data: { graph },
+  const workflow = await prisma.workflow.findUniqueOrThrow({ where: { id } });
+  if (workflow.owner_id !== user.userId) {
+    throw new Error("User not authorized");
+  }
+  const last = await prisma.workflowState.findFirst({
+    where: { workflow_id: id },
+    orderBy: { version: "desc" },
   });
+  const version = (last?.version ?? 0) + 1;
+  const [updatedWorkflow] = await prisma.$transaction([
+    prisma.workflow.update({
+      where: { id },
+      data: { graph },
+    }),
+    prisma.workflowState.create({
+      data: {
+        workflow_id: id,
+        version,
+        graph,
+      },
+    }),
+  ]);
+  return updatedWorkflow;
 }
 
 export async function fetchWorkflow({ id }: { id: bigint }) {
   await prisma.$connect();
-  return await prisma.workflow.findUniqueOrThrow({ where: { id } });
+  return await prisma.workflow.findUniqueOrThrow({
+    where: { id },
+    include: {
+      states: { orderBy: { version: "desc" }, take: 1 },
+      transitions: true,
+    },
+  });
 }

--- a/lib/models/schema.prisma
+++ b/lib/models/schema.prisma
@@ -254,8 +254,38 @@ model Workflow {
   graph      Json
   created_at DateTime @default(now()) @db.Timestamptz(6)
   owner      User     @relation(fields: [owner_id], references: [id], onDelete: Cascade)
+  states     WorkflowState[]
+  transitions WorkflowTransition[]
 
   @@map("workflows")
+}
+
+model WorkflowState {
+  id          BigInt   @id @default(autoincrement())
+  workflow_id BigInt
+  version     Int
+  graph       Json
+  created_at  DateTime  @default(now()) @db.Timestamptz(6)
+  updated_at  DateTime? @default(now()) @updatedAt @db.Timestamptz(6)
+  workflow    Workflow  @relation(fields: [workflow_id], references: [id], onDelete: Cascade)
+  fromTransitions WorkflowTransition[] @relation("WorkflowTransitionFromState")
+  toTransitions   WorkflowTransition[] @relation("WorkflowTransitionToState")
+
+  @@unique([workflow_id, version])
+  @@map("workflow_states")
+}
+
+model WorkflowTransition {
+  id            BigInt        @id @default(autoincrement())
+  workflow_id   BigInt
+  from_state_id BigInt
+  to_state_id   BigInt
+  created_at    DateTime      @default(now()) @db.Timestamptz(6)
+  workflow      Workflow      @relation(fields: [workflow_id], references: [id], onDelete: Cascade)
+  fromState     WorkflowState @relation("WorkflowTransitionFromState", fields: [from_state_id], references: [id])
+  toState       WorkflowState @relation("WorkflowTransitionToState", fields: [to_state_id], references: [id])
+
+  @@map("workflow_transitions")
 }
 
 enum like_type {


### PR DESCRIPTION
## Summary
- update Prisma schema to add `WorkflowState` and `WorkflowTransition`
- keep versions of workflow graphs using new tables
- enforce ownership checks when updating workflows
- include latest state when fetching workflows

## Testing
- `yarn install`
- `npm run lint` *(fails: warnings)*

------
https://chatgpt.com/codex/tasks/task_e_686619b699dc8329a7f3d00759a7269b