### PR TITLE
Fix React Flow builder error

### DIFF
--- a/app/(root)/(standard)/workflows/new/page.tsx
+++ b/app/(root)/(standard)/workflows/new/page.tsx
@@ -1,14 +1,17 @@
 import WorkflowBuilder from "@/components/workflow/WorkflowBuilder";
 import { createWorkflow } from "@/lib/actions/workflow.actions";
+import { ReactFlowProvider } from "@xyflow/react";
 
 export default function Page() {
   return (
-    <WorkflowBuilder
-      onSave={async (graph) => {
-        "use server";
-        const workflow = await createWorkflow({ name: "New Workflow", graph });
-        return { id: workflow.id.toString() };
-      }}
-    />
+    <ReactFlowProvider>
+      <WorkflowBuilder
+        onSave={async (graph) => {
+          "use server";
+          const workflow = await createWorkflow({ name: "New Workflow", graph });
+          return { id: workflow.id.toString() };
+        }}
+      />
+    </ReactFlowProvider>
   );
 }


### PR DESCRIPTION
## Summary
- wrap `WorkflowBuilder` usage in `ReactFlowProvider`

## Testing
- `npm run lint`
- `npx jest` *(fails: TypeError: (0 , react_2.useNodesState) is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_6866c5e61f6083299aa64c0abbc199e4