### PR TITLE
Add workflow import/export

### DIFF
--- a/components/workflow/WorkflowBuilder.tsx
+++ b/components/workflow/WorkflowBuilder.tsx
@@ -37,7 +37,31 @@ export default function WorkflowBuilder({ initialGraph, onSave }: Props) {
   const [selectedNode, setSelectedNode] = useState<Node | null>(null);
   const [selectedEdge, setSelectedEdge] = useState<Edge | null>(null);
   const wrapperRef = useRef<HTMLDivElement>(null);
+  const importRef = useRef<HTMLInputElement>(null);
   const { screenToFlowPosition } = useReactFlow();
+
+  const exportJson = () => {
+    const data = JSON.stringify({ nodes, edges }, null, 2);
+    const blob = new Blob([data], { type: "application/json" });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = "workflow.json";
+    a.click();
+    URL.revokeObjectURL(url);
+  };
+
+  const importJson = async (files: FileList | null) => {
+    if (!files?.length) return;
+    try {
+      const text = await files[0].text();
+      const graph = JSON.parse(text) as WorkflowGraph;
+      setNodes(graph.nodes as Node[]);
+      setEdges(graph.edges as Edge[]);
+    } catch {
+      // ignore invalid file
+    }
+  };
 
 
   const onNodeClick: NodeMouseHandler = (_event, node) => {
@@ -123,6 +147,16 @@ export default function WorkflowBuilder({ initialGraph, onSave }: Props) {
           State
         </div>
         <Button onClick={addState}>Add State</Button>
+        <Button onClick={() => importRef.current?.click()}>Import</Button>
+        <input
+          type="file"
+          accept="application/json"
+          ref={importRef}
+          aria-label="Import Workflow"
+          className="hidden"
+          onChange={(e) => importJson(e.target.files)}
+        />
+        <Button onClick={exportJson}>Export</Button>
         <Button onClick={save}>Save</Button>
         {workflowId && (
           <a href={`/workflows/${workflowId}`}>Run Workflow</a>

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -9,6 +9,9 @@ jest.mock("@xyflow/react", () => {
     Background: () => React.createElement("div", null, "background"),
     Controls: () => React.createElement("div", null, "controls"),
     MiniMap: () => React.createElement("div", null, "minimap"),
-    addEdge: jest.fn(),
+    addEdge: jest.fn((edge: any, edges: any[]) => edges.concat(edge)),
+    useNodesState: (initial: any[]) => React.useState(initial),
+    useEdgesState: (initial: any[]) => React.useState(initial),
+    useReactFlow: () => ({ screenToFlowPosition: (pos: any) => pos }),
   };
 });

--- a/tests/workflowBuilder.test.tsx
+++ b/tests/workflowBuilder.test.tsx
@@ -1,14 +1,36 @@
 /** @jest-environment jsdom */
-import { render, screen, fireEvent } from "@testing-library/react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { act } from "react";
 import WorkflowBuilder from "@/components/workflow/WorkflowBuilder";
+
 
 it("adds a new state and triggers save", async () => {
   const onSave = jest.fn(async () => ({ id: "1" }));
   render(<WorkflowBuilder onSave={onSave} />);
   fireEvent.click(screen.getByText("Add State"));
-  fireEvent.click(screen.getByText("Save"));
+  await act(async () => {
+    fireEvent.click(screen.getByText("Save"));
+  });
   expect(onSave).toHaveBeenCalledWith({
     nodes: expect.arrayContaining([expect.objectContaining({ id: "state-1" })]),
     edges: [],
   });
+});
+
+it("imports workflow JSON", async () => {
+  const onSave = jest.fn(async () => ({ id: "1" }));
+  render(<WorkflowBuilder onSave={onSave} />);
+  const file = new File([
+    JSON.stringify({
+      nodes: [{ id: "n1", data: { label: "n1" }, position: { x: 0, y: 0 } }],
+      edges: [],
+    }),
+  ], "wf.json", { type: "application/json" });
+  const input = screen.getByLabelText("Import Workflow");
+  fireEvent.change(input, { target: { files: [file] } });
+  await act(async () => {});
+  await act(async () => {
+    fireEvent.click(screen.getByText("Save"));
+  });
+  expect(onSave).toHaveBeenCalled();
 });

--- a/tests/workflowRunner.test.tsx
+++ b/tests/workflowRunner.test.tsx
@@ -14,7 +14,7 @@ test("shows executed nodes when running", async () => {
   render(<WorkflowRunner graph={graph} />);
   fireEvent.click(screen.getByText("Run"));
   await waitFor(() => {
-    expect(screen.getByText("A")).toBeInTheDocument();
-    expect(screen.getByText("B")).toBeInTheDocument();
+    expect(screen.getByText("Executed A")).toBeInTheDocument();
+    expect(screen.getByText("Executed B")).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary
- enable JSON workflow import and export in `WorkflowBuilder`
- update Jest ReactFlow mock for new hooks
- adjust workflow builder and runner tests

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6866d4a5d42c83299d1f2a0df380a513