### PR TITLE
Enable action names in workflow executor

### DIFF
--- a/components/workflow/WorkflowRunner.tsx
+++ b/components/workflow/WorkflowRunner.tsx
@@ -2,6 +2,7 @@
 
 import { Button } from "@/components/ui/button";
 import { WorkflowGraph } from "@/lib/workflowExecutor";
+import { getWorkflowAction } from "@/lib/workflowActions";
 import {
   WorkflowExecutionProvider,
   useWorkflowExecution,
@@ -16,9 +17,11 @@ function Runner({ graph }: Props) {
   const { run, pause, resume, paused, running, logs } = useWorkflowExecution();
 
   const handleRun = () => {
-    const actions: Record<string, () => Promise<string>> = {};
+    const actions: Record<string, () => Promise<string | void>> = {};
     for (const node of graph.nodes) {
-      actions[node.id] = async () => `Executed ${node.id}`;
+      const act = node.action ? getWorkflowAction(node.action) : undefined;
+      actions[node.action ?? node.id] =
+        act ?? (async () => `Executed ${node.id}`);
     }
     run(graph, actions);
   };

--- a/lib/workflowActions.ts
+++ b/lib/workflowActions.ts
@@ -1,0 +1,11 @@
+export type WorkflowAction = () => Promise<string | void>;
+
+const registry: Record<string, WorkflowAction> = {};
+
+export function registerWorkflowAction(name: string, action: WorkflowAction) {
+  registry[name] = action;
+}
+
+export function getWorkflowAction(name: string): WorkflowAction | undefined {
+  return registry[name];
+}

--- a/lib/workflowExecutor.ts
+++ b/lib/workflowExecutor.ts
@@ -1,6 +1,7 @@
 export interface WorkflowNode {
   id: string;
   type: string;
+  action?: string;
 }
 
 export interface WorkflowEdge {
@@ -37,7 +38,7 @@ export type ConditionEvaluator = (
 
 export async function executeWorkflow(
   graph: WorkflowGraph,
-  actions: Record<string, () => Promise<void>>,
+  actions: Record<string, () => Promise<any>>,
   evaluate: ConditionEvaluator = () => true,
   context: Record<string, any> = {}
 ): Promise<string[]> {
@@ -45,7 +46,8 @@ export async function executeWorkflow(
   const nodeMap = new Map(graph.nodes.map((n) => [n.id, n]));
   let current = graph.nodes[0];
   while (current) {
-    const act = actions[current.id];
+    const actionKey = current.action ?? current.id;
+    const act = actions[actionKey];
     if (act) {
       await act();
     }

--- a/tests/workflowExecution.test.ts
+++ b/tests/workflowExecution.test.ts
@@ -119,3 +119,20 @@ it("takes alternate path when condition fails", async () => {
   expect(result).toEqual(["A", "C"]);
   expect(order).toEqual(["A", "C"]);
 });
+it("executes actions by name", async () => {
+  const graph: WorkflowGraph = {
+    nodes: [
+      { id: "n1", type: "x", action: "first" },
+      { id: "n2", type: "y", action: "second" },
+    ],
+    edges: [{ id: "e1", source: "n1", target: "n2" }],
+  };
+  const order: string[] = [];
+  const actions = {
+    first: async () => order.push("A"),
+    second: async () => order.push("B"),
+  };
+  const result = await executeWorkflow(graph, actions);
+  expect(result).toEqual(["n1", "n2"]);
+  expect(order).toEqual(["A", "B"]);
+});


### PR DESCRIPTION
## Summary
- support `action` property on `WorkflowNode`
- lookup actions by name when executing workflows
- expose a registry for workflow actions
- test state machine execution by action name
- update WorkflowRunner to call registered actions

## Testing
- `npm run lint` *(fails: next lint reports warnings)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6866df20d1e08329b76fe82beb3310d9