### PR TITLE
Add workflow action registration

### DIFF
--- a/components/workflow/WorkflowRunner.tsx
+++ b/components/workflow/WorkflowRunner.tsx
@@ -3,6 +3,8 @@
 import { Button } from "@/components/ui/button";
 import { WorkflowGraph } from "@/lib/workflowExecutor";
 import { getWorkflowAction } from "@/lib/workflowActions";
+import { registerDefaultWorkflowActions } from "@/lib/registerDefaultWorkflowActions";
+import { useEffect } from "react";
 import {
   WorkflowExecutionProvider,
   useWorkflowExecution,
@@ -15,6 +17,10 @@ interface Props {
 
 function Runner({ graph }: Props) {
   const { run, pause, resume, paused, running, logs } = useWorkflowExecution();
+
+  useEffect(() => {
+    registerDefaultWorkflowActions();
+  }, []);
 
   const handleRun = () => {
     const actions: Record<string, () => Promise<string | void>> = {};

--- a/lib/actions/github.actions.ts
+++ b/lib/actions/github.actions.ts
@@ -1,0 +1,18 @@
+"use server";
+
+export async function fetchLatestIssue({
+  repo,
+  token,
+}: {
+  repo: string;
+  token?: string;
+}) {
+  const url = `https://api.github.com/repos/${repo}/issues?per_page=1&state=open&sort=created&direction=desc`;
+  const res = await fetch(url, {
+    headers: token ? { Authorization: `Bearer ${token}` } : {},
+  });
+  if (!res.ok) throw new Error("Failed to fetch issues");
+  const data = await res.json();
+  const issue = data[0];
+  return `Latest issue: #${issue.number} ${issue.title}`;
+}

--- a/lib/actions/slack.actions.ts
+++ b/lib/actions/slack.actions.ts
@@ -1,0 +1,15 @@
+"use server";
+
+export async function sendSlackMessage({
+  webhookUrl,
+  text,
+}: {
+  webhookUrl: string;
+  text: string;
+}) {
+  await fetch(webhookUrl, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ text }),
+  });
+}

--- a/lib/registerDefaultWorkflowActions.ts
+++ b/lib/registerDefaultWorkflowActions.ts
@@ -1,0 +1,16 @@
+import { registerWorkflowAction } from "@/lib/workflowActions";
+import { fetchLatestIssue } from "@/lib/actions/github.actions";
+import { sendSlackMessage } from "@/lib/actions/slack.actions";
+
+export function registerDefaultWorkflowActions() {
+  registerWorkflowAction("github:latestIssue", async () => {
+    const repo = process.env.GITHUB_REPO ?? "";
+    const token = process.env.GITHUB_TOKEN;
+    return fetchLatestIssue({ repo, token });
+  });
+
+  registerWorkflowAction("slack:sendMessage", async () => {
+    const url = process.env.SLACK_WEBHOOK_URL ?? "";
+    await sendSlackMessage({ webhookUrl: url, text: "New issue created" });
+  });
+}

--- a/tests/registerDefaultWorkflowActions.test.ts
+++ b/tests/registerDefaultWorkflowActions.test.ts
@@ -1,0 +1,8 @@
+import { getWorkflowAction } from "@/lib/workflowActions";
+import { registerDefaultWorkflowActions } from "@/lib/registerDefaultWorkflowActions";
+
+test("registers default actions", () => {
+  registerDefaultWorkflowActions();
+  expect(getWorkflowAction("github:latestIssue")).toBeDefined();
+  expect(getWorkflowAction("slack:sendMessage")).toBeDefined();
+});


### PR DESCRIPTION
## Summary
- create GitHub and Slack workflow actions
- register default workflow actions and use them in WorkflowRunner
- add test for default action registration

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6866e35e3a6c8329bab9e96059926bfd