### PR TITLE
Add integrations page

### DIFF
--- a/app/(root)/(standard)/integrations/integration-form.tsx
+++ b/app/(root)/(standard)/integrations/integration-form.tsx
@@ -1,0 +1,36 @@
+"use client";
+
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { saveIntegration } from "@/lib/actions/integration.actions";
+
+export default function IntegrationForm() {
+  const [service, setService] = useState("");
+  const [credential, setCredential] = useState("");
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!service || !credential) return;
+    await saveIntegration({ service, credential });
+    setService("");
+    setCredential("");
+    window.location.reload();
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-2">
+      <Input
+        placeholder="Service (e.g. gmail)"
+        value={service}
+        onChange={(e) => setService(e.target.value)}
+      />
+      <Input
+        placeholder="API Key or credential"
+        value={credential}
+        onChange={(e) => setCredential(e.target.value)}
+      />
+      <Button type="submit">Save</Button>
+    </form>
+  );
+}

--- a/app/(root)/(standard)/integrations/page.tsx
+++ b/app/(root)/(standard)/integrations/page.tsx
@@ -1,0 +1,19 @@
+import IntegrationForm from "./integration-form";
+import { fetchIntegrations } from "@/lib/actions/integration.actions";
+
+export default async function Page() {
+  const integrations = await fetchIntegrations();
+  return (
+    <main className="p-4 space-y-4">
+      <h1 className="text-2xl font-bold">Integrations</h1>
+      <IntegrationForm />
+      <ul className="space-y-2">
+        {integrations.map((i) => (
+          <li key={i.id} className="border p-2 rounded">
+            {i.service}: {i.credential}
+          </li>
+        ))}
+      </ul>
+    </main>
+  );
+}

--- a/app/api/integrations/route.ts
+++ b/app/api/integrations/route.ts
@@ -1,0 +1,16 @@
+import { NextRequest, NextResponse } from "next/server";
+import { fetchIntegrations, saveIntegration } from "@/lib/actions/integration.actions";
+
+export async function GET() {
+  const integrations = await fetchIntegrations();
+  return NextResponse.json(integrations);
+}
+
+export async function POST(req: NextRequest) {
+  const { service, credential } = await req.json();
+  if (!service || !credential) {
+    return NextResponse.json({ error: "Missing payload" }, { status: 400 });
+  }
+  await saveIntegration({ service, credential });
+  return NextResponse.json({ success: true });
+}

--- a/lib/actions/integration.actions.ts
+++ b/lib/actions/integration.actions.ts
@@ -1,0 +1,49 @@
+"use server";
+
+import { supabase } from "@/lib/supabaseclient";
+import { getUserFromCookies } from "@/lib/serverutils";
+
+export interface Integration {
+  id: string;
+  service: string;
+  credential: string;
+}
+
+export async function fetchIntegrations() {
+  const user = await getUserFromCookies();
+  if (!user) throw new Error("User not authenticated");
+  const { data, error } = await supabase
+    .from("integrations")
+    .select("id, service, credential")
+    .eq("user_id", user.userId);
+  if (error) throw new Error(error.message);
+  return data as Integration[];
+}
+
+export async function saveIntegration({
+  service,
+  credential,
+}: {
+  service: string;
+  credential: string;
+}) {
+  const user = await getUserFromCookies();
+  if (!user) throw new Error("User not authenticated");
+  const { error } = await supabase.from("integrations").upsert({
+    user_id: user.userId,
+    service,
+    credential,
+  });
+  if (error) throw new Error(error.message);
+}
+
+export async function deleteIntegration(id: string) {
+  const user = await getUserFromCookies();
+  if (!user) throw new Error("User not authenticated");
+  const { error } = await supabase
+    .from("integrations")
+    .delete()
+    .eq("id", id)
+    .eq("user_id", user.userId);
+  if (error) throw new Error(error.message);
+}


### PR DESCRIPTION
## Summary
- add actions for user integrations with Supabase backend
- create an API route for reading and saving integrations
- implement a new Integrations page with a client-side form

## Testing
- `yarn install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6866e60315808329b375cc1c1fce54c3