### PR TITLE
Integrate workflow actions

### DIFF
--- a/components/workflow/WorkflowRunner.tsx
+++ b/components/workflow/WorkflowRunner.tsx
@@ -4,6 +4,8 @@ import { Button } from "@/components/ui/button";
 import { WorkflowGraph } from "@/lib/workflowExecutor";
 import { getWorkflowAction } from "@/lib/workflowActions";
 import { registerDefaultWorkflowActions } from "@/lib/registerDefaultWorkflowActions";
+import { registerIntegrationActions } from "@/lib/registerIntegrationActions";
+import { IntegrationApp } from "@/lib/integrations/types";
 import { useEffect } from "react";
 import {
   WorkflowExecutionProvider,
@@ -20,6 +22,16 @@ function Runner({ graph }: Props) {
 
   useEffect(() => {
     registerDefaultWorkflowActions();
+    const integrationContext = (require as any).context(
+      "../../integrations",
+      false,
+      /\.ts$/
+    );
+    const modules: Record<string, { integration?: IntegrationApp }> = {};
+    integrationContext.keys().forEach((key: string) => {
+      modules[key] = integrationContext(key);
+    });
+    registerIntegrationActions(modules);
   }, []);
 
   const handleRun = () => {

--- a/components/workflow/WorkflowSidePanel.tsx
+++ b/components/workflow/WorkflowSidePanel.tsx
@@ -9,10 +9,18 @@ import {
 } from "@/components/ui/sheet";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 
 interface Props {
   node?: Node;
   edge?: Edge;
+  actions: string[];
   onUpdateNode: (node: Node) => void;
   onUpdateEdge: (edge: Edge) => void;
   onClose: () => void;
@@ -21,6 +29,7 @@ interface Props {
 export default function WorkflowSidePanel({
   node,
   edge,
+  actions,
   onUpdateNode,
   onUpdateEdge,
   onClose,
@@ -46,16 +55,26 @@ export default function WorkflowSidePanel({
               }
             />
             <Label htmlFor="node-action">Action</Label>
-            <Input
-              id="node-action"
+            <Select
               value={node.data?.action || ""}
-              onChange={(e) =>
+              onValueChange={(value) =>
                 onUpdateNode({
                   ...node,
-                  data: { ...node.data, action: e.target.value },
+                  data: { ...node.data, action: value },
                 })
               }
-            />
+            >
+              <SelectTrigger id="node-action">
+                <SelectValue placeholder="Select action" />
+              </SelectTrigger>
+              <SelectContent>
+                {actions.map((name) => (
+                  <SelectItem key={name} value={name}>
+                    {name}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
           </div>
         )}
         {edge && (

--- a/lib/workflowActions.ts
+++ b/lib/workflowActions.ts
@@ -9,3 +9,7 @@ export function registerWorkflowAction(name: string, action: WorkflowAction) {
 export function getWorkflowAction(name: string): WorkflowAction | undefined {
   return registry[name];
 }
+
+export function listWorkflowActions(): string[] {
+  return Object.keys(registry);
+}


### PR DESCRIPTION
## Summary
- expose `listWorkflowActions` helper
- load integration modules and registry actions in builder and runner
- show available actions in workflow side panel via dropdown

## Testing
- `yarn install`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6867033490008329bbdec981f2d8a6b0