### PR TITLE
Add counter workflow example

### DIFF
--- a/app/(root)/(standard)/workflows/example/page.tsx
+++ b/app/(root)/(standard)/workflows/example/page.tsx
@@ -1,0 +1,7 @@
+"use client";
+
+import CounterOutputExample from "@/components/workflow/examples/CounterOutputExample";
+
+export default function Page() {
+  return <CounterOutputExample />;
+}

--- a/components/workflow/WorkflowRunner.tsx
+++ b/components/workflow/WorkflowRunner.tsx
@@ -17,7 +17,7 @@ interface Props {
   graph: WorkflowGraph;
 }
 
-function Runner({ graph }: Props) {
+export function WorkflowRunnerInner({ graph }: Props) {
   const { run, pause, resume, paused, running, logs } = useWorkflowExecution();
 
   useEffect(() => {
@@ -69,7 +69,7 @@ function Runner({ graph }: Props) {
 export default function WorkflowRunner({ graph }: Props) {
   return (
     <WorkflowExecutionProvider>
-      <Runner graph={graph} />
+      <WorkflowRunnerInner graph={graph} />
     </WorkflowExecutionProvider>
   );
 }

--- a/components/workflow/WorkflowViewer.tsx
+++ b/components/workflow/WorkflowViewer.tsx
@@ -17,9 +17,16 @@ interface ViewerProps {
 }
 
 export default function WorkflowViewer({ graph }: ViewerProps) {
-  const { current } = useWorkflowExecution();
+  const { current, graph: execGraph } = useWorkflowExecution();
   const [nodes, setNodes] = useState<Node[]>(graph.nodes as Node[]);
-  const [edges] = useState<Edge[]>(graph.edges as Edge[]);
+  const [edges, setEdges] = useState<Edge[]>(graph.edges as Edge[]);
+
+  useEffect(() => {
+    if (execGraph) {
+      setNodes(execGraph.nodes as Node[]);
+      setEdges(execGraph.edges as Edge[]);
+    }
+  }, [execGraph]);
 
   useEffect(() => {
     setNodes((nds) =>

--- a/components/workflow/examples/CounterOutputExample.tsx
+++ b/components/workflow/examples/CounterOutputExample.tsx
@@ -1,0 +1,52 @@
+"use client";
+
+import { useEffect } from "react";
+import { Node } from "@xyflow/react";
+import { WorkflowGraph } from "@/lib/workflowExecutor";
+import { registerWorkflowAction } from "@/lib/workflowActions";
+import {
+  WorkflowExecutionProvider,
+  useWorkflowExecution,
+} from "../WorkflowExecutionContext";
+import { WorkflowRunnerInner } from "../WorkflowRunner";
+
+const sampleGraph: WorkflowGraph = {
+  nodes: [
+    { id: "counter", type: "trigger", action: "sample:counter" },
+    { id: "action", type: "action", action: "sample:createOutput" },
+  ],
+  edges: [{ id: "e1", source: "counter", target: "action" }],
+};
+
+function SampleRunner() {
+  const { addNode } = useWorkflowExecution();
+
+  useEffect(() => {
+    registerWorkflowAction("sample:counter", async () => {
+      for (let i = 0; i <= 100; i++) {
+        await new Promise((r) => setTimeout(r, 1000));
+      }
+      return "Counter reached 100";
+    });
+
+    registerWorkflowAction("sample:createOutput", async () => {
+      const node: Node = {
+        id: `output-${Date.now()}`,
+        data: { label: "output" },
+        position: { x: 150, y: 150 },
+      } as Node;
+      addNode(node);
+      return "Output node created";
+    });
+  }, [addNode]);
+
+  return <WorkflowRunnerInner graph={sampleGraph} />;
+}
+
+export default function CounterOutputExample() {
+  return (
+    <WorkflowExecutionProvider>
+      <SampleRunner />
+    </WorkflowExecutionProvider>
+  );
+}


### PR DESCRIPTION
## Summary
- extend `WorkflowExecutionContext` with graph state and `addNode`
- update `WorkflowViewer` to read graph from context
- export `WorkflowRunnerInner` for custom runners
- add `CounterOutputExample` with counter trigger and output node
- expose example page under `workflows/example`

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68670bcefed0832989d657127944a64b