### PR TITLE
Fix workflow example crash

### DIFF
--- a/components/workflow/examples/CounterOutputExample.tsx
+++ b/components/workflow/examples/CounterOutputExample.tsx
@@ -12,8 +12,20 @@ import { WorkflowRunnerInner } from "../WorkflowRunner";
 
 const sampleGraph: WorkflowGraph = {
   nodes: [
-    { id: "counter", type: "trigger", action: "sample:counter" },
-    { id: "action", type: "action", action: "sample:createOutput" },
+    {
+      id: "counter",
+      type: "trigger",
+      action: "sample:counter",
+      data: { label: "counter" },
+      position: { x: 0, y: 0 },
+    },
+    {
+      id: "action",
+      type: "action",
+      action: "sample:createOutput",
+      data: { label: "action" },
+      position: { x: 150, y: 0 },
+    },
   ],
   edges: [{ id: "e1", source: "counter", target: "action" }],
 };


### PR DESCRIPTION
## Summary
- set explicit positions for nodes in `CounterOutputExample` so React Flow can render

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6867112a91b483299263f23fb89e49f5