### PR TITLE
Add trigger button workflow sample

### DIFF
--- a/app/(root)/(standard)/workflows/click-counter/page.tsx
+++ b/app/(root)/(standard)/workflows/click-counter/page.tsx
@@ -1,0 +1,7 @@
+"use client";
+
+import TriggerButtonExample from "@/components/workflow/examples/TriggerButtonExample";
+
+export default function Page() {
+  return <TriggerButtonExample />;
+}

--- a/components/workflow/WorkflowRunner.tsx
+++ b/components/workflow/WorkflowRunner.tsx
@@ -12,12 +12,14 @@ import {
   useWorkflowExecution,
 } from "./WorkflowExecutionContext";
 import WorkflowViewer from "./WorkflowViewer";
+import { NodeTypes } from "@xyflow/react";
 
 interface Props {
   graph: WorkflowGraph;
+  nodeTypes?: NodeTypes;
 }
 
-export function WorkflowRunnerInner({ graph }: Props) {
+export function WorkflowRunnerInner({ graph, nodeTypes }: Props) {
   const { run, pause, resume, paused, running, logs } = useWorkflowExecution();
 
   useEffect(() => {
@@ -56,7 +58,7 @@ export function WorkflowRunnerInner({ graph }: Props) {
           </Button>
         )}
       </div>
-      <WorkflowViewer graph={graph} />
+      <WorkflowViewer graph={graph} nodeTypes={nodeTypes} />
       <div className="border h-32 overflow-auto p-2 text-sm">
         {logs.map((log, i) => (
           <div key={i}>{log}</div>
@@ -66,10 +68,10 @@ export function WorkflowRunnerInner({ graph }: Props) {
   );
 }
 
-export default function WorkflowRunner({ graph }: Props) {
+export default function WorkflowRunner({ graph, nodeTypes }: Props) {
   return (
     <WorkflowExecutionProvider>
-      <WorkflowRunnerInner graph={graph} />
+      <WorkflowRunnerInner graph={graph} nodeTypes={nodeTypes} />
     </WorkflowExecutionProvider>
   );
 }

--- a/components/workflow/WorkflowViewer.tsx
+++ b/components/workflow/WorkflowViewer.tsx
@@ -7,6 +7,7 @@ import {
   Controls,
   Node,
   Edge,
+  NodeTypes,
 } from "@xyflow/react";
 import "@xyflow/react/dist/style.css";
 import { WorkflowGraph } from "@/lib/workflowExecutor";
@@ -14,9 +15,10 @@ import { useWorkflowExecution } from "./WorkflowExecutionContext";
 
 interface ViewerProps {
   graph: WorkflowGraph;
+  nodeTypes?: NodeTypes;
 }
 
-export default function WorkflowViewer({ graph }: ViewerProps) {
+export default function WorkflowViewer({ graph, nodeTypes }: ViewerProps) {
   const { current, graph: execGraph } = useWorkflowExecution();
   const [nodes, setNodes] = useState<Node[]>(graph.nodes as Node[]);
   const [edges, setEdges] = useState<Edge[]>(graph.edges as Edge[]);
@@ -40,7 +42,7 @@ export default function WorkflowViewer({ graph }: ViewerProps) {
 
   return (
     <div style={{ height: 300 }}>
-      <ReactFlow nodes={nodes} edges={edges}>
+      <ReactFlow nodes={nodes} edges={edges} nodeTypes={nodeTypes}>
         <Background />
         <Controls />
       </ReactFlow>

--- a/components/workflow/examples/TriggerButtonExample.tsx
+++ b/components/workflow/examples/TriggerButtonExample.tsx
@@ -1,0 +1,91 @@
+"use client";
+
+import { useState, useCallback } from "react";
+import { NodeProps, NodeTypes } from "@xyflow/react";
+import { WorkflowGraph } from "@/lib/workflowExecutor";
+import {
+  WorkflowExecutionProvider,
+  useWorkflowExecution,
+} from "../WorkflowExecutionContext";
+import { WorkflowRunnerInner } from "../WorkflowRunner";
+
+function TriggerNode({ data }: NodeProps) {
+  return (
+    <div className="p-2 bg-white border rounded">
+      <button className="nodrag" onClick={data.onTrigger}>
+        Trigger
+      </button>
+    </div>
+  );
+}
+
+function DisplayNode({ data }: NodeProps) {
+  return <div className="p-2 bg-white border rounded">Count: {data.count}</div>;
+}
+
+function ExampleInner() {
+  const { run } = useWorkflowExecution();
+  const [count, setCount] = useState(0);
+
+  const handleTrigger = useCallback(() => {
+    const newCount = count + 1;
+    const actions = {
+      increment: async () => {
+        setCount(newCount);
+      },
+      show: async () => {},
+    };
+    const graph: WorkflowGraph = {
+      nodes: [
+        {
+          id: "trigger",
+          type: "trigger",
+          action: "increment",
+          data: { onTrigger: handleTrigger },
+          position: { x: 0, y: 0 },
+        },
+        {
+          id: "display",
+          type: "display",
+          action: "show",
+          data: { count: newCount },
+          position: { x: 150, y: 0 },
+        },
+      ],
+      edges: [{ id: "e1", source: "trigger", target: "display" }],
+    };
+    run(graph, actions);
+  }, [count, run]);
+
+  const graph: WorkflowGraph = {
+    nodes: [
+      {
+        id: "trigger",
+        type: "trigger",
+        action: "increment",
+        data: { onTrigger: handleTrigger },
+        position: { x: 0, y: 0 },
+      },
+      {
+        id: "display",
+        type: "display",
+        action: "show",
+        data: { count },
+        position: { x: 150, y: 0 },
+      },
+    ],
+    edges: [{ id: "e1", source: "trigger", target: "display" }],
+  };
+
+  const nodeTypes: NodeTypes = { trigger: TriggerNode, display: DisplayNode };
+
+  return <WorkflowRunnerInner graph={graph} nodeTypes={nodeTypes} />;
+}
+
+export default function TriggerButtonExample() {
+  return (
+    <WorkflowExecutionProvider>
+      <ExampleInner />
+    </WorkflowExecutionProvider>
+  );
+}


### PR DESCRIPTION
## Summary
- support custom node types in `WorkflowViewer` and `WorkflowRunner`
- add `TriggerButtonExample` demonstrating click counter workflow
- expose example at `/workflows/click-counter`

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68672d88c60c83298df7e1d4f254ef2f