### PR TITLE
Add integration modals

### DIFF
--- a/app/(root)/(standard)/workflows/new/page.tsx
+++ b/app/(root)/(standard)/workflows/new/page.tsx
@@ -2,27 +2,28 @@ import WorkflowBuilder from "@/components/workflow/WorkflowBuilder";
 import { createWorkflow } from "@/lib/actions/workflow.actions";
 import { ReactFlowProvider } from "@xyflow/react";
 import React from "react";
-import { Button } from "@/components/ui/button";
+import Modal from "@/components/modals/Modal";
+import IntegrationButtons from "@/components/workflow/IntegrationButtons";
 
 export default function Page() {
   return (
     <div className="relative -top-12">
-      <div className="mb-3 flex ">
-      <Button className="p-4 mr-2">Connect Accounts </Button>
-      <Button className="p-4 ">Configure Integrations </Button>
+      <IntegrationButtons />
+      <div className="w-[100%] h-full border-2 border-blue overscroll-none">
+        <ReactFlowProvider>
+          <Modal />
+          <WorkflowBuilder
+            onSave={async (graph) => {
+              "use server";
+              const workflow = await createWorkflow({
+                name: "New Workflow",
+                graph,
+              });
+              return { id: workflow.id.toString() };
+            }}
+          />
+        </ReactFlowProvider>
       </div>
-    <div className="w-[100%] h-full border-2 border-blue overscroll-none">
-
-    <ReactFlowProvider>
-      <WorkflowBuilder
-        onSave={async (graph) => {
-          "use server";
-          const workflow = await createWorkflow({ name: "New Workflow", graph });
-          return { id: workflow.id.toString() };
-        }}
-      />
-    </ReactFlowProvider>
-    </div>
     </div>
   );
 }

--- a/components/modals/ConnectAccountModal.tsx
+++ b/components/modals/ConnectAccountModal.tsx
@@ -1,0 +1,61 @@
+"use client";
+
+import { useState } from "react";
+import {
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogClose,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import { saveIntegration } from "@/lib/actions/integration.actions";
+
+export default function ConnectAccountModal() {
+  const [service, setService] = useState("");
+  const [email, setEmail] = useState("");
+  const [username, setUsername] = useState("");
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!service) return;
+    const credential = JSON.stringify({ email, username });
+    await saveIntegration({ service, credential });
+    setService("");
+    setEmail("");
+    setUsername("");
+  };
+
+  return (
+    <DialogContent className="max-w-[40rem]">
+      <DialogHeader>
+        <DialogTitle>Connect Account</DialogTitle>
+      </DialogHeader>
+      <form onSubmit={handleSubmit} className="space-y-2">
+        <Input
+          placeholder="Service (e.g. gmail)"
+          value={service}
+          onChange={(e) => setService(e.target.value)}
+        />
+        <Input
+          placeholder="Email"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+        />
+        <Input
+          placeholder="Username"
+          value={username}
+          onChange={(e) => setUsername(e.target.value)}
+        />
+        <div className="flex gap-2 mt-2">
+          <Button type="submit">Save</Button>
+          <DialogClose asChild>
+            <Button variant="secondary" type="button">
+              Close
+            </Button>
+          </DialogClose>
+        </div>
+      </form>
+    </DialogContent>
+  );
+}

--- a/components/modals/IntegrationConfigModal.tsx
+++ b/components/modals/IntegrationConfigModal.tsx
@@ -1,0 +1,53 @@
+"use client";
+
+import { useState } from "react";
+import {
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogClose,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import { saveIntegration } from "@/lib/actions/integration.actions";
+
+export default function IntegrationConfigModal() {
+  const [service, setService] = useState("");
+  const [apiKey, setApiKey] = useState("");
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!service || !apiKey) return;
+    await saveIntegration({ service, credential: apiKey });
+    setService("");
+    setApiKey("");
+  };
+
+  return (
+    <DialogContent className="max-w-[40rem]">
+      <DialogHeader>
+        <DialogTitle>Configure Integration</DialogTitle>
+      </DialogHeader>
+      <form onSubmit={handleSubmit} className="space-y-2">
+        <Input
+          placeholder="Service (e.g. slack)"
+          value={service}
+          onChange={(e) => setService(e.target.value)}
+        />
+        <Input
+          placeholder="API Key or credential"
+          value={apiKey}
+          onChange={(e) => setApiKey(e.target.value)}
+        />
+        <div className="flex gap-2 mt-2">
+          <Button type="submit">Save</Button>
+          <DialogClose asChild>
+            <Button variant="secondary" type="button">
+              Close
+            </Button>
+          </DialogClose>
+        </div>
+      </form>
+    </DialogContent>
+  );
+}

--- a/components/workflow/IntegrationButtons.tsx
+++ b/components/workflow/IntegrationButtons.tsx
@@ -1,0 +1,33 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import useStore from "@/lib/reactflow/store";
+import { AppState } from "@/lib/reactflow/types";
+import { useShallow } from "zustand/react/shallow";
+import ConnectAccountModal from "@/components/modals/ConnectAccountModal";
+import IntegrationConfigModal from "@/components/modals/IntegrationConfigModal";
+
+export default function IntegrationButtons() {
+  const { openModal } = useStore(
+    useShallow((state: AppState) => ({
+      openModal: state.openModal,
+    }))
+  );
+
+  return (
+    <div className="mb-3 flex">
+      <Button
+        className="p-4 mr-2"
+        onClick={() => openModal(<ConnectAccountModal />)}
+      >
+        Connect Accounts
+      </Button>
+      <Button
+        className="p-4"
+        onClick={() => openModal(<IntegrationConfigModal />)}
+      >
+        Configure Integrations
+      </Button>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add ConnectAccountModal for entering service, email and username
- add IntegrationConfigModal for API key setup
- add IntegrationButtons component to open these modals
- hook IntegrationButtons and Modal into new workflow page

## Testing
- `yarn install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68674033f40883298424b45e4e6cfb61