### PR TITLE
Add workflow version history

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,9 @@ Mesh is deployed on Vercel: <https://vercel.com/18vijaybs-projects/ephemera>
 ### CRDT Prototype
 See [docs/realtime-crdt.md](docs/realtime-crdt.md) for notes on the experimental Yjs integration used for text nodes.
 
+### Workflow API
+Versioned workflows can be queried via [docs/workflows.md](docs/workflows.md).
+
 
 ## Faster setup in Codex
 See `Codex_Environment_Guide.md` for tips on caching dependencies and using a Docker image so the development server starts quickly.

--- a/app/api/workflows/[id]/route.ts
+++ b/app/api/workflows/[id]/route.ts
@@ -1,0 +1,18 @@
+import { fetchWorkflow } from "@/lib/actions/workflow.actions";
+import { NextRequest, NextResponse } from "next/server";
+
+export async function GET(
+  req: NextRequest,
+  { params }: { params: { id: string } }
+) {
+  const versionParam = req.nextUrl.searchParams.get("version");
+  const historyParam = req.nextUrl.searchParams.get("history");
+  const version = versionParam ? parseInt(versionParam, 10) : undefined;
+  const history = historyParam === "true";
+  const workflow = await fetchWorkflow({
+    id: BigInt(params.id),
+    version,
+    history,
+  });
+  return NextResponse.json(workflow);
+}

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -1,0 +1,15 @@
+# Workflow API
+
+## GET /api/workflows/[id]
+
+Returns a workflow by id.
+
+### Query Parameters
+- `version`: optional version number to fetch.
+- `history=true`: include all versions and transitions.
+
+If neither parameter is supplied, the latest workflow and all transitions are returned.
+
+## Database Changes
+
+`WorkflowTransition` now has a `version` column. See `lib/models/migrations/20250704000000_add_transition_version.sql` for the migration script.

--- a/lib/models/migrations/20250704000000_add_transition_version.sql
+++ b/lib/models/migrations/20250704000000_add_transition_version.sql
@@ -1,0 +1,7 @@
+ALTER TABLE "workflow_transitions" ADD COLUMN IF NOT EXISTS "version" INT;
+
+-- backfill existing rows using the to_state version if available
+UPDATE "workflow_transitions" wt
+SET "version" = ws.version
+FROM "workflow_states" ws
+WHERE wt."to_state_id" = ws."id" AND wt."version" IS NULL;

--- a/lib/models/schema.prisma
+++ b/lib/models/schema.prisma
@@ -280,6 +280,7 @@ model WorkflowTransition {
   workflow_id   BigInt
   from_state_id BigInt
   to_state_id   BigInt
+  version       Int
   created_at    DateTime      @default(now()) @db.Timestamptz(6)
   workflow      Workflow      @relation(fields: [workflow_id], references: [id], onDelete: Cascade)
   fromState     WorkflowState @relation("WorkflowTransitionFromState", fields: [from_state_id], references: [id])


### PR DESCRIPTION
## Summary
- add `version` column to `WorkflowTransition`
- track workflow transitions when creating or updating
- allow fetching a workflow by specific version or full history
- expose new `/api/workflows/[id]` route
- document workflow API and migration

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6867a26a203c8329878d3706beec51b0