### PR TITLE
Fix Gmail account modal

### DIFF
--- a/components/modals/ConnectAccountModal.tsx
+++ b/components/modals/ConnectAccountModal.tsx
@@ -14,16 +14,16 @@ import { saveIntegration } from "@/lib/actions/integration.actions";
 export default function ConnectAccountModal() {
   const [service, setService] = useState("");
   const [email, setEmail] = useState("");
-  const [username, setUsername] = useState("");
+  const [accessToken, setAccessToken] = useState("");
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     if (!service) return;
-    const credential = JSON.stringify({ email, username });
+    const credential = JSON.stringify({ email, accessToken });
     await saveIntegration({ service, credential });
     setService("");
     setEmail("");
-    setUsername("");
+    setAccessToken("");
   };
 
   return (
@@ -43,9 +43,9 @@ export default function ConnectAccountModal() {
           onChange={(e) => setEmail(e.target.value)}
         />
         <Input
-          placeholder="Username"
-          value={username}
-          onChange={(e) => setUsername(e.target.value)}
+          placeholder="Access Token"
+          value={accessToken}
+          onChange={(e) => setAccessToken(e.target.value)}
         />
         <div className="flex gap-2 mt-2">
           <Button type="submit">Save</Button>


### PR DESCRIPTION
## Summary
- capture Gmail access token instead of username in ConnectAccountModal

## Testing
- `npx next lint --quiet`

------
https://chatgpt.com/codex/tasks/task_e_68684df1de348329ad45d665da7f696d