### PR TITLE
Improve integration error handling

### DIFF
--- a/components/modals/ConnectAccountModal.tsx
+++ b/components/modals/ConnectAccountModal.tsx
@@ -15,15 +15,22 @@ export default function ConnectAccountModal() {
   const [service, setService] = useState("");
   const [email, setEmail] = useState("");
   const [accessToken, setAccessToken] = useState("");
+  const [error, setError] = useState("");
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     if (!service) return;
     const credential = JSON.stringify({ email, accessToken });
-    await saveIntegration({ service, credential });
-    setService("");
-    setEmail("");
-    setAccessToken("");
+    try {
+      await saveIntegration({ service, credential });
+      setService("");
+      setEmail("");
+      setAccessToken("");
+      setError("");
+    } catch (err: any) {
+      console.error("Failed to save integration", err);
+      setError(err.message || "Failed to save integration");
+    }
   };
 
   return (
@@ -47,6 +54,9 @@ export default function ConnectAccountModal() {
           value={accessToken}
           onChange={(e) => setAccessToken(e.target.value)}
         />
+        {error && (
+          <p className="text-red-500 text-sm">{error}</p>
+        )}
         <div className="flex gap-2 mt-2">
           <Button type="submit">Save</Button>
           <DialogClose asChild>


### PR DESCRIPTION
## Summary
- handle errors when saving integration in ConnectAccountModal
- display any error messages to the user

## Testing
- `npm run lint`
- `npm test` *(fails: Cannot read properties of undefined)*

------
https://chatgpt.com/codex/tasks/task_e_6868579b249c83299da75eee56c29d86