### PR TITLE
Add integrations table and Gmail token script

### DIFF
--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -24,6 +24,10 @@ export const integration: IntegrationApp = {
 ## Global Variables and Auth
 Integration actions receive a `credentials` object so implementations can pass API keys or tokens. Credentials may come from environment variables or the `integrations` table.
 
+## Database Table
+
+Run the migration script `lib/models/migrations/20250705000000_create_integrations.sql` on your Supabase database to create the `integrations` table used by these actions.
+
 ## Usage
 Actions are referenced in workflows as `<integration>:<action>`. Register modules with `registerIntegrationActions`.
 
@@ -60,12 +64,12 @@ Use `registerIntegrationTriggers` to subscribe to these events.
 The Gmail integration uses OAuth tokens to send mail on a user's behalf.
 
 1. Create an OAuth client in the [Google Cloud Console](https://console.cloud.google.com/apis/credentials).
-2. Set the `GMAIL_CLIENT_ID` and `GMAIL_CLIENT_SECRET` variables in `.env.local`.
-3. Generate an access token for the Gmail account and save it using the **Connect Account** modal with the JSON format:
+2. Set the `GMAIL_CLIENT_ID`, `GMAIL_CLIENT_SECRET`, and `GMAIL_REFRESH_TOKEN` variables in `.env`.
+3. Run `yarn gmail-token` to generate a fresh access token. Save the credentials using the **Connect Account** modal with the JSON format:
    ```json
    {
      "email": "user@gmail.com",
-     "accessToken": "ya29..."
+     "accessToken": "<token from script>"
    }
    ```
 

--- a/lib/models/migrations/20250705000000_create_integrations.sql
+++ b/lib/models/migrations/20250705000000_create_integrations.sql
@@ -1,0 +1,11 @@
+CREATE TABLE IF NOT EXISTS "integrations" (
+  "id" BIGSERIAL PRIMARY KEY,
+  "user_id" BIGINT NOT NULL,
+  "service" TEXT NOT NULL,
+  "credential" TEXT NOT NULL,
+  "created_at" TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  CONSTRAINT "integrations_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "users"("id") ON DELETE CASCADE,
+  CONSTRAINT "integrations_user_service_unique" UNIQUE ("user_id", "service")
+);
+
+CREATE INDEX IF NOT EXISTS "integrations_user_id_idx" ON "integrations"("user_id");

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "lint": "next lint",
     "test": "jest",
     "postinstall": "prisma generate",
-    "seed": "tsx --env-file=.env scripts/seed.ts"
+    "seed": "tsx --env-file=.env scripts/seed.ts",
+    "gmail-token": "tsx --env-file=.env scripts/gmail-token.ts"
   },
   "dependencies": {
     "@gsap/react": "^2.1.1",

--- a/scripts/gmail-token.ts
+++ b/scripts/gmail-token.ts
@@ -1,0 +1,26 @@
+import { google } from "googleapis";
+
+async function fetchAccessToken() {
+  const client = new google.auth.OAuth2(
+    process.env.GMAIL_CLIENT_ID,
+    process.env.GMAIL_CLIENT_SECRET,
+    process.env.GMAIL_REDIRECT_URI ?? "http://localhost"
+  );
+
+  const refreshToken = process.env.GMAIL_REFRESH_TOKEN;
+  if (!refreshToken) {
+    console.error("GMAIL_REFRESH_TOKEN is not set");
+    process.exit(1);
+  }
+
+  client.setCredentials({ refresh_token: refreshToken });
+  const { token } = await client.getAccessToken();
+  if (!token) {
+    console.error("Failed to retrieve access token");
+    process.exit(1);
+  }
+
+  console.log(token);
+}
+
+fetchAccessToken();


### PR DESCRIPTION
## Summary
- create SQL migration for `integrations` table
- add script to fetch Gmail access token using a refresh token
- document database setup and automated Gmail token retrieval
- expose script via `npm run gmail-token`

## Testing
- `yarn install`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68686517a0fc8329a8b6281f35ae4ec4