### PR TITLE
Fix gmail token script

### DIFF
--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -64,7 +64,7 @@ Use `registerIntegrationTriggers` to subscribe to these events.
 The Gmail integration uses OAuth tokens to send mail on a user's behalf.
 
 1. Create an OAuth client in the [Google Cloud Console](https://console.cloud.google.com/apis/credentials).
-2. Set the `GMAIL_CLIENT_ID`, `GMAIL_CLIENT_SECRET`, and `GMAIL_REFRESH_TOKEN` variables in `.env`.
+2. Add the credentials to `.env` as `GMAIL_CLIENT_ID`, `GMAIL_CLIENT_SECRET`, and `GMAIL_REFRESH_TOKEN`. Optionally set `GMAIL_REDIRECT_URI` (defaults to `http://localhost`).
 3. Run `yarn gmail-token` to generate a fresh access token. Save the credentials using the **Connect Account** modal with the JSON format:
    ```json
    {

--- a/scripts/gmail-token.ts
+++ b/scripts/gmail-token.ts
@@ -1,9 +1,17 @@
 import { google } from "googleapis";
 
 async function fetchAccessToken() {
+  const clientId = process.env.GMAIL_CLIENT_ID;
+  const clientSecret = process.env.GMAIL_CLIENT_SECRET;
+
+  if (!clientId || !clientSecret) {
+    console.error("GMAIL_CLIENT_ID or GMAIL_CLIENT_SECRET is not set");
+    process.exit(1);
+  }
+
   const client = new google.auth.OAuth2(
-    process.env.GMAIL_CLIENT_ID,
-    process.env.GMAIL_CLIENT_SECRET,
+    clientId,
+    clientSecret,
     process.env.GMAIL_REDIRECT_URI ?? "http://localhost"
   );
 


### PR DESCRIPTION
## Summary
- add explicit checks for Gmail OAuth environment variables in `scripts/gmail-token.ts`
- update integration docs with instructions for setting Gmail variables

## Testing
- `yarn install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68686c6aee4483299b53294d095df9d1