### PR TITLE
Fix integration save logic

### DIFF
--- a/app/(root)/(standard)/integrations/integration-form.tsx
+++ b/app/(root)/(standard)/integrations/integration-form.tsx
@@ -3,7 +3,6 @@
 import { useState } from "react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
-import { saveIntegration } from "@/lib/actions/integration.actions";
 
 export default function IntegrationForm() {
   const [service, setService] = useState("");
@@ -12,7 +11,11 @@ export default function IntegrationForm() {
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     if (!service || !credential) return;
-    await saveIntegration({ service, credential });
+    await fetch("/api/integrations", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ service, credential }),
+    });
     setService("");
     setCredential("");
     window.location.reload();

--- a/components/modals/ConnectAccountModal.tsx
+++ b/components/modals/ConnectAccountModal.tsx
@@ -9,7 +9,6 @@ import {
 } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
-import { saveIntegration } from "@/lib/actions/integration.actions";
 
 export default function ConnectAccountModal() {
   const [service, setService] = useState("");
@@ -22,7 +21,11 @@ export default function ConnectAccountModal() {
     if (!service) return;
     const credential = JSON.stringify({ email, accessToken });
     try {
-      await saveIntegration({ service, credential });
+      await fetch("/api/integrations", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ service, credential }),
+      });
       setService("");
       setEmail("");
       setAccessToken("");

--- a/components/modals/IntegrationConfigModal.tsx
+++ b/components/modals/IntegrationConfigModal.tsx
@@ -9,7 +9,6 @@ import {
 } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
-import { saveIntegration } from "@/lib/actions/integration.actions";
 
 export default function IntegrationConfigModal() {
   const [service, setService] = useState("");
@@ -18,7 +17,11 @@ export default function IntegrationConfigModal() {
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     if (!service || !apiKey) return;
-    await saveIntegration({ service, credential: apiKey });
+    await fetch("/api/integrations", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ service, credential: apiKey }),
+    });
     setService("");
     setApiKey("");
   };


### PR DESCRIPTION
## Summary
- call the `/api/integrations` route using `fetch` from integration forms

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6868738295d08329ace5b0ea78bb0069