### PR TITLE
Update Gmail modal

### DIFF
--- a/components/modals/SendEmailModal.tsx
+++ b/components/modals/SendEmailModal.tsx
@@ -18,20 +18,18 @@ interface Props {
 
 export default function SendEmailModal({ from, accessToken }: Props) {
   const [email, setEmail] = useState("");
-  const [message, setMessage] = useState("");
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    if (!email || !message) return;
+    if (!email) return;
     await sendEmail({
       from,
       to: email,
       subject: "",
-      message,
+      message: "hello",
       accessToken,
     });
     setEmail("");
-    setMessage("");
   };
 
   return (
@@ -44,11 +42,6 @@ export default function SendEmailModal({ from, accessToken }: Props) {
           placeholder="Recipient Email"
           value={email}
           onChange={(e) => setEmail(e.target.value)}
-        />
-        <Input
-          placeholder="Message"
-          value={message}
-          onChange={(e) => setMessage(e.target.value)}
         />
         <div className="flex gap-2 mt-2">
           <Button type="submit">Send</Button>

--- a/components/workflow/examples/GmailFlowExample.tsx
+++ b/components/workflow/examples/GmailFlowExample.tsx
@@ -84,6 +84,12 @@ function ExampleInner() {
     run(graph, actions);
   }, [run]);
 
+  useEffect(() => {
+    if (cred) {
+      handleTrigger();
+    }
+  }, [cred, handleTrigger]);
+
   const graph: WorkflowGraph = {
     nodes: [
       {


### PR DESCRIPTION
## Summary
- simplify SendEmailModal to only ask for recipient email
- automatically run Gmail example when credentials load

## Testing
- `yarn install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6868ad4e2c0c832983e9f5a74763bcae