### PR TITLE
Fix Gmail example infinite loop

### DIFF
--- a/components/workflow/examples/GmailFlowExample.tsx
+++ b/components/workflow/examples/GmailFlowExample.tsx
@@ -88,7 +88,9 @@ function ExampleInner() {
     if (cred) {
       handleTrigger();
     }
-  }, [cred, handleTrigger]);
+    // intentionally omit handleTrigger from deps to avoid infinite loop
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [cred]);
 
   const graph: WorkflowGraph = {
     nodes: [


### PR DESCRIPTION
## Summary
- avoid re-triggering Gmail example workflow when internal run reference changes

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6868af438cd48329957872f3345fc2fb