### PR TITLE
Fix Gmail example modal

### DIFF
--- a/app/(root)/(standard)/workflows/example/page.tsx
+++ b/app/(root)/(standard)/workflows/example/page.tsx
@@ -2,6 +2,14 @@
 
 import CounterOutputExample from "@/components/workflow/examples/CounterOutputExample";
 import GmailFlowExample from "@/components/workflow/examples/GmailFlowExample";
+import { ReactFlowProvider } from "@xyflow/react";
+import Modal from "@/components/modals/Modal";
+
 export default function Page() {
-  return <GmailFlowExample />;
+  return (
+    <ReactFlowProvider>
+      <Modal />
+      <GmailFlowExample />
+    </ReactFlowProvider>
+  );
 }


### PR DESCRIPTION
## Summary
- wrap example workflow with `ReactFlowProvider` and include `<Modal />` so `openModal` works

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6868b0feb7ec83298b9881a28a6d8def