### PR TITLE
Show halfway results in card grid

### DIFF
--- a/app/(root)/(standard)/halfway/page.tsx
+++ b/app/(root)/(standard)/halfway/page.tsx
@@ -19,6 +19,13 @@ import {
   SelectItem,
 } from "@/components/ui/select";
 import { Slider } from "@/components/ui/slider";
+import {
+  Card,
+  CardHeader,
+  CardContent,
+  CardTitle,
+  CardDescription,
+} from "@/components/ui/card";
 
 const libraries: Libraries = ["places"];
 const mapContainerStyle = { width: "100%", height: "400px" };
@@ -33,6 +40,8 @@ type Venue = {
   address: string;
   location: LatLng;
   rating?: number;
+  openingHours?: string[];
+  types?: string[];
 };
 
 type CircleItemRef = React.MutableRefObject<
@@ -127,16 +136,20 @@ export default function HalfwayPage() {
 
       const data = await res.json();
       if (data && Array.isArray(data.results)) {
-        const newVenues: Venue[] = data.results.map((place: any) => ({
-          id: place.place_id,
-          name: place.name,
-          address: place.vicinity || place.formatted_address,
-          location: {
-            lat: place.geometry.location.lat,
-            lng: place.geometry.location.lng,
-          },
-          rating: place.rating,
-        }));
+        const newVenues: Venue[] = data.results
+          .map((place: any) => ({
+            id: place.place_id,
+            name: place.name,
+            address: place.vicinity || place.formatted_address,
+            location: {
+              lat: place.geometry.location.lat,
+              lng: place.geometry.location.lng,
+            },
+            rating: place.rating,
+            openingHours: place.opening_hours?.weekday_text,
+            types: place.types,
+          }))
+          .sort((a: Venue, b: Venue) => (b.rating ?? 0) - (a.rating ?? 0));
         setVenues(newVenues);
         console.log("Venues within radius:", newVenues);
       } else {
@@ -250,6 +263,30 @@ export default function HalfwayPage() {
             />
           ))}
         </GoogleMap>
+      )}
+
+      {venues.length > 0 && (
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4 pt-4">
+          {venues.map((venue) => (
+            <Card key={venue.id} className="likebutton">
+              <CardHeader>
+                <CardTitle>{venue.name}</CardTitle>
+                <CardDescription>{venue.address}</CardDescription>
+              </CardHeader>
+              <CardContent className="space-y-1">
+                {venue.rating && <p>Rating: {venue.rating}</p>}
+                {venue.types && <p>Type: {venue.types.join(", ")}</p>}
+                {venue.openingHours && (
+                  <div className="text-sm">
+                    {venue.openingHours.map((line, i) => (
+                      <p key={i}>{line}</p>
+                    ))}
+                  </div>
+                )}
+              </CardContent>
+            </Card>
+          ))}
+        </div>
       )}
 
       {/* Venue Type + Radius controls */}

--- a/app/api/nearbyPlaces/route.ts
+++ b/app/api/nearbyPlaces/route.ts
@@ -1,25 +1,53 @@
-import { NextRequest, NextResponse } from 'next/server';
+import { NextRequest, NextResponse } from "next/server";
 
 export async function GET(request: NextRequest) {
   const { searchParams } = new URL(request.url);
-  const lat = searchParams.get('lat');
-  const lng = searchParams.get('lng');
-  const radius = searchParams.get('radius');
-  const venueType = searchParams.get('type');
+  const lat = searchParams.get("lat");
+  const lng = searchParams.get("lng");
+  const radius = searchParams.get("radius") ?? "1500";
+  const venueType = searchParams.get("type") ?? "restaurant";
 
   if (!lat || !lng) {
-    return NextResponse.json({ error: "Latitude and longitude are required." }, { status: 400 });
+    return NextResponse.json(
+      { error: "Latitude and longitude are required." },
+      { status: 400 }
+    );
   }
 
   const apiKey = process.env.GOOGLE_MAPS_API_KEY;
 
-  const apiUrl = `https://maps.googleapis.com/maps/api/place/nearbysearch/json?location=${lat},${lng}&radius=${radius}&type=${venueType}&key=${apiKey}&libraries=drawing`;
+  const apiUrl =
+    `https://maps.googleapis.com/maps/api/place/nearbysearch/json?` +
+    `location=${lat},${lng}&radius=${radius}&type=${venueType}&key=${apiKey}`;
 
   const res = await fetch(apiUrl);
   if (!res.ok) {
-    return NextResponse.json({ error: "Failed to fetch places." }, { status: res.status });
+    return NextResponse.json(
+      { error: "Failed to fetch places." },
+      { status: res.status }
+    );
   }
 
   const data = await res.json();
-  return NextResponse.json(data);
+
+  if (!Array.isArray(data.results)) {
+    return NextResponse.json({ results: [] });
+  }
+
+  const detailResults = await Promise.all(
+    data.results.map(async (place: any) => {
+      const detailUrl =
+        `https://maps.googleapis.com/maps/api/place/details/json?place_id=${place.place_id}` +
+        `&fields=name,formatted_address,opening_hours,rating,types&key=${apiKey}`;
+
+      const detailRes = await fetch(detailUrl);
+      if (!detailRes.ok) {
+        return place;
+      }
+      const detailData = await detailRes.json();
+      return { ...place, ...detailData.result };
+    })
+  );
+
+  return NextResponse.json({ results: detailResults });
 }


### PR DESCRIPTION
## Summary
- enhance `/api/nearbyPlaces` to fetch place details and include opening hours, rating and types
- display halfway search results as cards below the map
- sort venues by rating

## Testing
- `yarn install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6868b7e774ac8329ae46aabcf8e58980