### PR TITLE
Add random room suggestions

### DIFF
--- a/app/api/random-rooms/route.ts
+++ b/app/api/random-rooms/route.ts
@@ -1,0 +1,9 @@
+import { NextRequest, NextResponse } from "next/server";
+import { fetchRandomRooms } from "@/lib/actions/realtimeroom.actions";
+
+export async function GET(req: NextRequest) {
+  const countParam = req.nextUrl.searchParams.get("count");
+  const count = countParam ? parseInt(countParam, 10) : 4;
+  const rooms = await fetchRandomRooms(count);
+  return NextResponse.json(rooms);
+}

--- a/components/shared/RightSidebar.tsx
+++ b/components/shared/RightSidebar.tsx
@@ -13,8 +13,14 @@ interface SuggestedUser {
   overlap?: Record<string, string[]>;
 }
 
+interface RandomRoom {
+  id: string;
+  room_icon: string;
+}
+
 function RightSidebar() {
   const [users, setUsers] = useState<SuggestedUser[]>([]);
+  const [rooms, setRooms] = useState<RandomRoom[]>([]);
 
   useEffect(() => {
     async function load() {
@@ -31,6 +37,21 @@ function RightSidebar() {
     }
     load();
   }, []);
+
+  useEffect(() => {
+    async function loadRooms() {
+      try {
+        const res = await fetch("/api/random-rooms?count=4");
+        if (res.ok) {
+          const data = await res.json();
+          setRooms(data);
+        }
+      } catch (e) {
+        console.error(e);
+      }
+    }
+    loadRooms();
+  }, []);
     // return (
     // <section className="custom-scrollbar rightsidebar">
     //     <div className="flex flex-1 flex-col justify-start">
@@ -45,6 +66,22 @@ function RightSidebar() {
     <section className="sticky custom-scrollbar rightsidebar  bg-transparent">
       <div className="sticky flex w-full flex-1 flex-col gap-6 px-2">
         <h3 className="relative bottom-[4rem] text-[1.5rem] text-black">Find New Groups</h3>
+        <div className="relative bottom-[4rem] flex flex-col gap-y-4 items-center">
+          {rooms.length === 0 ? (
+            <p className="text-sm text-gray-500">No rooms</p>
+          ) : (
+            rooms.map((r) => (
+              <Link key={r.id} href={`/room/${r.id}`}>
+                <Button
+                  variant={"outline"}
+                  className="rounded-lg likebutton items-center justify-center bg-transparent outline-blue border-none"
+                >
+                  {r.id}
+                </Button>
+              </Link>
+            ))
+          )}
+        </div>
       </div>
       <div className="flex w-full flex-1 flex-col gap-2 px-2">
         <h3 className="relative bottom-[4rem] text-[1.5rem] text-black">Find New Users</h3>

--- a/lib/actions/realtimeroom.actions.ts
+++ b/lib/actions/realtimeroom.actions.ts
@@ -170,6 +170,32 @@ export async function getRoomsForUser({ userId }: { userId: bigint }) {
   }
 }
 
+export interface RandomRoom {
+  id: string;
+  room_icon: string;
+}
+
+export async function fetchRandomRooms(count = 4): Promise<RandomRoom[]> {
+  try {
+    await prisma.$connect();
+    const total = await prisma.realtimeRoom.count();
+    const take = Math.min(count, total);
+    if (take === 0) return [];
+    const skip = Math.max(
+      0,
+      Math.floor(Math.random() * Math.max(total - take + 1, 1))
+    );
+    const rooms = await prisma.realtimeRoom.findMany({
+      skip,
+      take,
+      select: { id: true, room_icon: true },
+    });
+    return rooms;
+  } catch (error: any) {
+    throw new Error(`Failed to fetch random rooms: ${error.message}`);
+  }
+}
+
 export async function findOrGenerateInviteToken({
   userId,
   roomId,


### PR DESCRIPTION
## Summary
- fetch random rooms from Prisma
- expose API route `/api/random-rooms`
- display random rooms in `RightSidebar`

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6868ce8376e883299b1d66c543aced42