### PR TITLE
Fix realtime room lookup

### DIFF
--- a/lib/actions/realtimeroom.actions.ts
+++ b/lib/actions/realtimeroom.actions.ts
@@ -14,7 +14,7 @@ export async function fetchRealtimeRoom({
   try {
     await prisma.$connect();
 
-    const realtimeRoom = await prisma.realtimeRoom.findUniqueOrThrow({
+    const realtimeRoom = await prisma.realtimeRoom.findUnique({
       where: {
         id: realtimeRoomId,
       },
@@ -36,6 +36,8 @@ export async function fetchRealtimeRoom({
         },
       },
     });
+
+    if (!realtimeRoom) return null;
 
     return {
       ...realtimeRoom,


### PR DESCRIPTION
## Summary
- avoid throwing when a realtime room is missing

## Testing
- `yarn install`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6868d14bbd988329acbffdbbf35bbe37