### PR TITLE
Implement dynamic plugin loader

### DIFF
--- a/lib/pluginLoader.ts
+++ b/lib/pluginLoader.ts
@@ -9,3 +9,12 @@ export function loadPlugins(modules: Record<string, { descriptor?: PluginDescrip
     .filter((m) => m && m.descriptor)
     .map((m) => m.descriptor!) as PluginDescriptor[];
 }
+
+export async function loadPluginsAsync(
+  importers: Record<string, () => Promise<{ descriptor?: PluginDescriptor }>>
+): Promise<PluginDescriptor[]> {
+  const modules = await Promise.all(Object.values(importers).map((fn) => fn()));
+  return modules
+    .filter((m) => m && m.descriptor)
+    .map((m) => m.descriptor!) as PluginDescriptor[];
+}

--- a/plugins/PdfViewerNode.tsx
+++ b/plugins/PdfViewerNode.tsx
@@ -1,0 +1,20 @@
+import { NodeProps } from "@xyflow/react";
+import { PluginDescriptor } from "@/lib/pluginLoader";
+
+function PdfViewerNode({ data }: NodeProps<{ url?: string }>) {
+  return (
+    <iframe
+      src={data?.url}
+      className="w-full h-full border-none"
+      title="PDF Viewer"
+    />
+  );
+}
+
+export const descriptor: PluginDescriptor = {
+  type: "PDF_VIEWER",
+  component: PdfViewerNode,
+  config: { label: "PDF Viewer" },
+};
+
+export default PdfViewerNode;

--- a/plugins/SplineViewerNode.tsx
+++ b/plugins/SplineViewerNode.tsx
@@ -1,0 +1,14 @@
+import { NodeProps } from "@xyflow/react";
+import { PluginDescriptor } from "@/lib/pluginLoader";
+
+function SplineViewerNode({ id }: NodeProps<any>) {
+  return <div className="bg-blue-200 p-2 rounded">Spline viewer {id}</div>;
+}
+
+export const descriptor: PluginDescriptor = {
+  type: "SPLINE_VIEWER",
+  component: SplineViewerNode,
+  config: { label: "Spline Viewer" },
+};
+
+export default SplineViewerNode;

--- a/tests/pluginLoader.test.ts
+++ b/tests/pluginLoader.test.ts
@@ -1,4 +1,8 @@
-import { loadPlugins, PluginDescriptor } from "@/lib/pluginLoader";
+import {
+  loadPlugins,
+  loadPluginsAsync,
+  PluginDescriptor,
+} from "@/lib/pluginLoader";
 
 test("loadPlugins collects descriptors", () => {
   const modules = {
@@ -10,4 +14,16 @@ test("loadPlugins collects descriptors", () => {
   expect(result).toHaveLength(2);
   expect(result[0].type).toBe("A");
   expect(result[1].type).toBe("B");
+});
+
+test("loadPluginsAsync resolves descriptors", async () => {
+  const modules = {
+    a: async () => ({ descriptor: { type: "X", component: {}, config: {} } as PluginDescriptor }),
+    b: async () => ({}),
+    c: async () => ({ descriptor: { type: "Y", component: {}, config: {} } as PluginDescriptor }),
+  };
+  const result = await loadPluginsAsync(modules);
+  expect(result).toHaveLength(2);
+  expect(result[0].type).toBe("X");
+  expect(result[1].type).toBe("Y");
 });


### PR DESCRIPTION
## Summary
- add asynchronous plugin loader helper
- load plugin descriptors with `import()` in Room
- register plugin descriptors via store hook
- include sample PDF and Spline viewer plugins
- test async loader

## Testing
- `npm run lint`
- `npm test` *(fails: workflowActions.integration.test.ts due to prisma undefined)*

------
https://chatgpt.com/codex/tasks/task_e_6868f5ba9ad88329b14ee462100ce153