### PR TITLE
Implement plugin node support

### DIFF
--- a/components/shared/NodeSidebar.tsx
+++ b/components/shared/NodeSidebar.tsx
@@ -373,6 +373,17 @@ export default function NodeSidebar({
           type: "LLM_INSTRUCTION",
           realtimeRoomId: roomId,
         });
+        break;
+      default:
+        if (pluginDescriptors.find((p) => p.type === nodeType)) {
+          createPostAndAddToCanvas({
+            path: pathname,
+            coordinates: centerPosition,
+            type: "PLUGIN",
+            pluginType: nodeType,
+            realtimeRoomId: roomId,
+          });
+        }
         break;  
   
         

--- a/lib/actions/realtimepost.actions.ts
+++ b/lib/actions/realtimepost.actions.ts
@@ -17,6 +17,8 @@ export interface CreateRealtimePostParams {
   collageLayoutStyle?: string;  // or some enum
   collageColumns?: number;
   collageGap?: number;
+  pluginType?: string;
+  pluginData?: Record<string, unknown>;
 }
 
 interface UpdateRealtimePostParams {
@@ -31,6 +33,8 @@ interface UpdateRealtimePostParams {
   collageColumns?: number;
   collageGap?: number;
   content?: string;
+  pluginType?: string;
+  pluginData?: Record<string, unknown>;
 }
 
 export async function createRealtimePost({
@@ -46,6 +50,8 @@ export async function createRealtimePost({
    collageLayoutStyle,
    collageColumns,
    collageGap,
+   pluginType,
+   pluginData,
 }: CreateRealtimePostParams) {
   const user = await getUserFromCookies();
   if (!user) {
@@ -66,6 +72,8 @@ export async function createRealtimePost({
         realtime_room_id: realtimeRoomId,
         locked: false,
         isPublic,
+        ...(pluginType && { pluginType }),
+        ...(pluginData && { pluginData }),
 
          // Collage fields
          ...(collageLayoutStyle && { collageLayoutStyle }),
@@ -111,6 +119,8 @@ export async function updateRealtimePost({
   collageColumns,
   collageGap,
   content,
+  pluginType,
+  pluginData,
 }: UpdateRealtimePostParams) {
   const user = await getUserFromCookies();
   try {
@@ -151,6 +161,8 @@ export async function updateRealtimePost({
       ...(collageColumns !== undefined && { collageColumns }),
       ...(collageGap !== undefined && { collageGap }),
       ...(isPublic !== undefined && { isPublic }),
+      ...(pluginType && { pluginType }),
+      ...(pluginData && { pluginData }),
     };
 
     if (coordinates && coordChanged) {

--- a/lib/models/schema.prisma
+++ b/lib/models/schema.prisma
@@ -144,6 +144,8 @@ model RealtimePost {
   collageColumns     Int?
   collageGap         Int?
   isPublic           Boolean            @default(false)
+  pluginType        String?
+  pluginData        Json?
   parent_id          BigInt?
   outgoing_edges     RealtimeEdge[]     @relation("RealtimeEdgeToSourceRealtimePost")
   incoming_edges     RealtimeEdge[]     @relation("RealtimeEdgeToTargetRealtimePost")
@@ -313,6 +315,7 @@ enum realtime_post_type {
   CODE
   PORTFOLIO
   LLM_INSTRUCTION
+  PLUGIN
 }
 
 enum visibility {

--- a/lib/reactflow/reactflowutils.ts
+++ b/lib/reactflow/reactflowutils.ts
@@ -334,7 +334,22 @@ export function convertPostToNode(
             y: realtimePost.y_coordinate,
           },
         } as LLMInstructionNode;
-      
+
+      case "PLUGIN": {
+        const data = realtimePost.pluginData ||
+          (realtimePost.content ? JSON.parse(realtimePost.content) : {});
+        const nodeType = (realtimePost as any).pluginType || "PLUGIN";
+        return {
+          id: realtimePost.id.toString(),
+          type: nodeType,
+          data: { ...data, author: authorToSet, locked: realtimePost.locked },
+          position: {
+            x: realtimePost.x_coordinate,
+            y: realtimePost.y_coordinate,
+          },
+        } as AppNode;
+      }
+
       default:
         throw new Error("Unsupported real-time post type");
       }

--- a/tests/pluginConvert.test.ts
+++ b/tests/pluginConvert.test.ts
@@ -1,0 +1,22 @@
+import { convertPostToNode } from "@/lib/reactflow/reactflowutils";
+import { realtime_post_type } from "@prisma/client";
+
+test("convertPostToNode handles plugin", () => {
+  const post: any = {
+    id: BigInt(1),
+    content: JSON.stringify({ foo: "bar" }),
+    image_url: null,
+    video_url: null,
+    author_id: BigInt(2),
+    x_coordinate: 10,
+    y_coordinate: 20,
+    type: "PLUGIN" as realtime_post_type,
+    pluginType: "HELLO",
+    pluginData: { foo: "bar" },
+    realtime_room_id: "r",
+    locked: false,
+  };
+  const node = convertPostToNode(post, { id: BigInt(2) } as any);
+  expect(node.type).toBe("HELLO");
+  expect((node as any).data.foo).toBe("bar");
+});


### PR DESCRIPTION
## Summary
- extend RealtimePost model with plugin fields
- add `PLUGIN` to realtime_post_type enum
- allow creating plugin nodes from sidebar
- load plugin node data in `convertPostToNode`
- expose plugin details in realtime post actions
- test plugin conversion logic

## Testing
- `npm run lint` *(fails: next not found)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6868f8438c9883298bdb78458aa033a8