### PR TITLE
Enable plugin nodes from sidebar

### DIFF
--- a/components/reactflow/Room.tsx
+++ b/components/reactflow/Room.tsx
@@ -12,6 +12,7 @@ import { useReactFlow, useStoreApi } from "@xyflow/react";
 import useStore from "@/lib/reactflow/store";
 import { AppEdge, AppNode, AppState } from "@/lib/reactflow/types";
 import { loadPluginsAsync, PluginDescriptor } from "@/lib/pluginLoader";
+import pluginImporters from "@/lib/pluginImporters";
 import { subscribeToDatabaseUpdates, subscribeToRoom } from "@/lib/utils";
 import {
   convertPostToNode,
@@ -55,13 +56,7 @@ import { createRealtimeEdge } from "@/lib/actions/realtimeedge.actions";
 import { updateRealtimePost } from "@/lib/actions/realtimepost.actions";
 import { RealtimePost } from "@prisma/client";
 
-// Dynamically load plug-ins using import()
-const pluginContext = (require as any).context("../../plugins", false, /\\.tsx$/);
-const pluginImporters: Record<string, () => Promise<{ descriptor?: PluginDescriptor }>> = {};
-pluginContext.keys().forEach((key: string) => {
-  const path = `../../plugins/${key.replace("./", "")}`;
-  pluginImporters[key] = () => import(path);
-});
+// Plug-in modules are defined in lib/pluginImporters.ts
 
 const selector = (state: AppState) => ({
   nodes: state.nodes,

--- a/components/shared/NodeSidebar.tsx
+++ b/components/shared/NodeSidebar.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { Plus } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import {
@@ -9,7 +9,7 @@ import {
   SheetTitle,
   SheetTrigger,
 } from "@/components/ui/sheet";
-import { AppNodeType, AppState, DEFAULT_NODE_VALUES } from "@/lib/reactflow/types";
+import { AppState, DEFAULT_NODE_VALUES } from "@/lib/reactflow/types";
 import useStore from "@/lib/reactflow/store";
 import { z } from "zod";
 import {
@@ -32,23 +32,8 @@ import { useShallow } from "zustand/react/shallow";
 import { useAuth } from "@/lib/AuthContext";
 import { useRouter } from "next/navigation";
 import useMousePosition from "../hooks/MousePosition";
-
-// A simple static array of node types
-const nodeTypes: { label: string; nodeType: AppNodeType }[] = [
-  { label: "TEXT", nodeType: "TEXT" },
-  { label: "IMAGE", nodeType: "IMAGE" },
-  { label: "VIDEO", nodeType: "VIDEO" },
-  { label: "LIVESTREAM", nodeType: "LIVESTREAM" },
-  { label: "IMAGE_COMPUTE", nodeType: "IMAGE_COMPUTE" },
-  { label: "COLLAGE", nodeType: "COLLAGE" },
-  { label: "GALLERY", nodeType: "GALLERY" },
-  { label: "PORTAL", nodeType: "PORTAL" },
-  { label: "DRAW", nodeType: "DRAW" },
-  { label: "LIVECHAT", nodeType: "LIVECHAT" },
-  { label: "AUDIO", nodeType: "AUDIO" },
-  { label: "LLM_INSTRUCTION", nodeType: "LLM_INSTRUCTION" },
-  { label: "PORTFOLIO", nodeType: "PORTFOLIO" },
-];
+import pluginImporters from "@/lib/pluginImporters";
+import { loadPluginsAsync } from "@/lib/pluginLoader";
 
 
 // Import your modals
@@ -84,6 +69,14 @@ export default function NodeSidebar({
     }))
   );
   const { pluginDescriptors } = store;
+
+  useEffect(() => {
+    if (pluginDescriptors.length === 0) {
+      loadPluginsAsync(pluginImporters).then((descriptors) => {
+        useStore.getState().registerPlugins(descriptors);
+      });
+    }
+  }, [pluginDescriptors.length]);
   const params = useParams<{ id: string }>();
   const roomId = params.id;
 
@@ -130,7 +123,6 @@ export default function NodeSidebar({
     { label: "AUDIO", nodeType: "AUDIO" },
     { label: "LLM", nodeType: "LLM_INSTRUCTION" },
     { label: "PORTFOLIO", nodeType: "PORTFOLIO" },
-    { label: "PLUGIN", nodeType: "PLUGIN" },
 
   ];
 

--- a/lib/pluginImporters.ts
+++ b/lib/pluginImporters.ts
@@ -1,0 +1,13 @@
+import { PluginDescriptor } from "./pluginLoader";
+
+const importers: Record<string, () => Promise<{ descriptor?: PluginDescriptor }>> = {};
+
+if (typeof require !== "undefined" && (require as any).context) {
+  const ctx = (require as any).context("../plugins", false, /\\.tsx$/);
+  ctx.keys().forEach((key: string) => {
+    const path = `../plugins/${key.replace("./", "")}`;
+    importers[key] = () => import(path);
+  });
+}
+
+export default importers;


### PR DESCRIPTION
## Summary
- share plugin importers for client components
- register plugins in NodeSidebar if missing
- remove unused constant and placeholder entry

## Testing
- `npm run lint`
- `npm test` *(fails: Cannot read properties of undefined (reading 'create'))*

------
https://chatgpt.com/codex/tasks/task_e_686969d600348329bf08724340302826