### PR TITLE
Add fallback plugin importer

### DIFF
--- a/lib/pluginImporters.ts
+++ b/lib/pluginImporters.ts
@@ -2,11 +2,18 @@ import { PluginDescriptor } from "./pluginLoader";
 
 const importers: Record<string, () => Promise<{ descriptor?: PluginDescriptor }>> = {};
 
-if (typeof require !== "undefined" && (require as any).context) {
-  const ctx = (require as any).context("../plugins", false, /\\.tsx$/);
+declare const require: any;
+
+if (typeof require !== "undefined" && require.context) {
+  const ctx = require.context("../plugins", false, /\\.tsx$/);
   ctx.keys().forEach((key: string) => {
     const path = `../plugins/${key.replace("./", "")}`;
     importers[key] = () => import(path);
+  });
+} else if (typeof import.meta !== "undefined" && (import.meta as any).glob) {
+  const modules = (import.meta as any).glob("../plugins/*.tsx");
+  Object.keys(modules).forEach((key) => {
+    importers[key] = modules[key] as () => Promise<{ descriptor?: PluginDescriptor }>;
   });
 }
 


### PR DESCRIPTION
## Summary
- support dynamic plugin discovery with `import.meta.glob` when `require.context` is unavailable

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6869708ed26c8329b1079d47a6b52696