### PR TITLE
Fix plugin loader dynamic import

### DIFF
--- a/lib/pluginImporters.ts
+++ b/lib/pluginImporters.ts
@@ -7,8 +7,7 @@ declare const require: any;
 if (typeof require !== "undefined" && require.context) {
   const ctx = require.context("../plugins", false, /\\.tsx$/);
   ctx.keys().forEach((key: string) => {
-    const path = `../plugins/${key.replace("./", "")}`;
-    importers[key] = () => import(path);
+    importers[key] = () => Promise.resolve(ctx(key));
   });
 } else if (typeof import.meta !== "undefined" && (import.meta as any).glob) {
   const modules = (import.meta as any).glob("../plugins/*.tsx");


### PR DESCRIPTION
## Summary
- fix plugin importer to avoid dynamic `import()` path and use webpack context

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_686972009fa883299ca2241fc1ccc3a7