### PR TITLE
Add plugin loader environment logging

### DIFF
--- a/lib/pluginImporters.ts
+++ b/lib/pluginImporters.ts
@@ -5,15 +5,21 @@ const importers: Record<string, () => Promise<{ descriptor?: PluginDescriptor }>
 declare const require: any;
 
 if (typeof require !== "undefined" && require.context) {
+  console.log("pluginImporters: using require.context");
   const ctx = require.context("../plugins", false, /\\.tsx$/);
   ctx.keys().forEach((key: string) => {
     importers[key] = () => Promise.resolve(ctx(key));
   });
+  console.log("pluginImporters: loaded", Object.keys(importers));
 } else if (typeof import.meta !== "undefined" && (import.meta as any).glob) {
+  console.log("pluginImporters: using import.meta.glob");
   const modules = (import.meta as any).glob("../plugins/*.tsx");
   Object.keys(modules).forEach((key) => {
     importers[key] = modules[key] as () => Promise<{ descriptor?: PluginDescriptor }>;
   });
+  console.log("pluginImporters: loaded", Object.keys(importers));
+} else {
+  console.log("pluginImporters: no loader api found");
 }
 
 export default importers;


### PR DESCRIPTION
## Summary
- log which API loads plugins in pluginImporters

## Testing
- `npm run lint`
- `node -r ts-node/register -e "require('./lib/pluginImporters.ts')"`

------
https://chatgpt.com/codex/tasks/task_e_68697cf12a748329b3ec7984f318cfc1