### PR TITLE
Improve PDF viewer plugin

### DIFF
--- a/components/nodes/BaseNode.tsx
+++ b/components/nodes/BaseNode.tsx
@@ -4,7 +4,7 @@ import {
   
 } from "@/lib/actions/realtimepost.actions";
 import useStore from "@/lib/reactflow/store";
-import { AppNodeType, AppState, AuthorOrAuthorId } from "@/lib/reactflow/types";
+import { AppState, AuthorOrAuthorId } from "@/lib/reactflow/types";
 import { Handle, Panel, Position } from "@xyflow/react";
 import { usePathname } from "next/navigation";
 import { useShallow } from "zustand/react/shallow";
@@ -19,7 +19,7 @@ interface Props {
   isLocked: boolean;
   id: string;
   author: AuthorOrAuthorId;
-  type: AppNodeType;
+  type: string;
   children: React.ReactNode;
   generateOnClick?: (evt: React.MouseEvent<HTMLButtonElement>) => void;
 }

--- a/plugins/PdfViewerNode.tsx
+++ b/plugins/PdfViewerNode.tsx
@@ -1,13 +1,34 @@
+"use client";
+
 import { NodeProps } from "@xyflow/react";
 import { PluginDescriptor } from "@/lib/pluginLoader";
+import BaseNode from "@/components/nodes/BaseNode";
+import { AuthorOrAuthorId } from "@/lib/reactflow/types";
+import { useAuth } from "@/lib/AuthContext";
+import { fetchUser } from "@/lib/actions/user.actions";
+import { useEffect, useState } from "react";
 
-function PdfViewerNode({ data }: NodeProps<{ url?: string }>) {
+export interface PdfViewerData {
+  url: string;
+  author: AuthorOrAuthorId;
+  locked: boolean;
+}
+
+function PdfViewerNode({ id, data }: NodeProps<PdfViewerData>) {
+  const currentUser = useAuth().user;
+  const [author, setAuthor] = useState(data.author);
+
+  useEffect(() => {
+    if ("username" in author) return;
+    fetchUser(data.author.id).then((user) => user && setAuthor(user));
+  }, [author, data.author.id]);
+
+  const isOwned = currentUser ? Number(currentUser.userId) === Number(data.author.id) : false;
+
   return (
-    <iframe
-      src={data?.url}
-      className="w-full h-full border-none"
-      title="PDF Viewer"
-    />
+    <BaseNode id={id} author={author} isOwned={isOwned} type="PDF_VIEWER" isLocked={data.locked}>
+      <iframe src={data.url} className="w-full h-[400px] border-none" title="PDF Viewer" />
+    </BaseNode>
   );
 }
 


### PR DESCRIPTION
## Summary
- allow BaseNode to handle plugin node types
- flesh out `PdfViewerNode` plugin using `BaseNode`

## Testing
- `npm run lint`
- `npm test` *(fails: Cannot read properties of undefined in workflowActions.integration.test.ts)*

------
https://chatgpt.com/codex/tasks/task_e_6869890fd10c832989efd6ca1e048418