### PR TITLE
Add PDF viewer plugin

### DIFF
--- a/components/forms/PdfViewerNodeForm.tsx
+++ b/components/forms/PdfViewerNodeForm.tsx
@@ -1,0 +1,51 @@
+import { PdfViewerPostValidation } from "@/lib/validations/thread";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useForm } from "react-hook-form";
+import { z } from "zod";
+import { Button } from "../ui/button";
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "../ui/form";
+import { Input } from "../ui/input";
+
+interface Props {
+  onSubmit: (values: z.infer<typeof PdfViewerPostValidation>) => void;
+  currentUrl: string;
+}
+
+const PdfViewerNodeForm = ({ onSubmit, currentUrl }: Props) => {
+  const form = useForm({
+    resolver: zodResolver(PdfViewerPostValidation),
+    defaultValues: { pdfUrl: currentUrl },
+  });
+
+  return (
+    <Form {...form}>
+      <form onSubmit={form.handleSubmit(onSubmit)} className="grid gap-4 mt-4">
+        <FormField
+          control={form.control}
+          name="pdfUrl"
+          render={({ field }) => (
+            <FormItem className="grid gap-2">
+              <FormLabel className="text-xl">PDF URL</FormLabel>
+              <FormControl>
+                <Input type="text" defaultValue={currentUrl} {...field} />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+        <Button type="submit" className="form-submit-button">
+          Submit
+        </Button>
+      </form>
+    </Form>
+  );
+};
+
+export default PdfViewerNodeForm;

--- a/components/modals/PdfViewerNodeModal.tsx
+++ b/components/modals/PdfViewerNodeModal.tsx
@@ -1,0 +1,84 @@
+import { PdfViewerPostValidation } from "@/lib/validations/thread";
+import { z } from "zod";
+import {
+  DialogClose,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import PdfViewerNodeForm from "../forms/PdfViewerNodeForm";
+
+interface Props {
+  id?: string;
+  isOwned: boolean;
+  onSubmit?: (values: z.infer<typeof PdfViewerPostValidation>) => void;
+  currentUrl: string;
+}
+
+const renderCreate = ({
+  onSubmit,
+}: {
+  onSubmit?: (values: z.infer<typeof PdfViewerPostValidation>) => void;
+}) => (
+  <div>
+    <DialogHeader className="dialog-header text-white text-lg py-4 mt-[-4rem]">
+      <b>Create PDF Viewer</b>
+    </DialogHeader>
+    <PdfViewerNodeForm onSubmit={onSubmit!} currentUrl="" />
+  </div>
+);
+
+const renderEdit = ({
+  onSubmit,
+  currentUrl,
+}: {
+  onSubmit?: (values: z.infer<typeof PdfViewerPostValidation>) => void;
+  currentUrl: string;
+}) => (
+  <div>
+    <DialogHeader className="dialog-header text-white text-lg py-4 mt-[-4rem]">
+      <b>Edit PDF Viewer</b>
+    </DialogHeader>
+    <PdfViewerNodeForm onSubmit={onSubmit!} currentUrl={currentUrl} />
+  </div>
+);
+
+const renderView = (currentUrl: string) => (
+  <div>
+    <DialogHeader className="dialog-header text-white text-lg py-4 mt-[-3rem]">
+      <b>View PDF</b>
+    </DialogHeader>
+    <hr />
+    <div className="py-4">
+      <a href={currentUrl} target="_blank" rel="noreferrer" className="underline text-blue-500 break-all">
+        {currentUrl}
+      </a>
+    </div>
+    <hr />
+    <div className="py-4">
+      <DialogClose id="animateButton" className="form-submit-button pl-2 py-2 pr-[1rem]">
+        <div className="w-2" />
+        <> Close </>
+      </DialogClose>
+    </div>
+  </div>
+);
+
+const PdfViewerNodeModal = ({ id, isOwned, onSubmit, currentUrl }: Props) => {
+  const isCreate = !id && isOwned;
+  const isEdit = id && isOwned;
+  const isView = id && !isOwned;
+  return (
+    <div>
+      <DialogContent className="max-w-[50%]">
+        <div className="grid rounded-md px-4 py-2">
+          {isCreate && renderCreate({ onSubmit })}
+          {isEdit && renderEdit({ onSubmit, currentUrl })}
+          {isView && renderView(currentUrl)}
+        </div>
+      </DialogContent>
+    </div>
+  );
+};
+
+export default PdfViewerNodeModal;

--- a/lib/validations/thread.ts
+++ b/lib/validations/thread.ts
@@ -93,3 +93,7 @@ export const PortfolioNodeValidation = z.object({
   color: z.string().default("bg-white"),
 });
 
+export const PdfViewerPostValidation = z.object({
+  pdfUrl: z.string().url(),
+});
+

--- a/plugins/PdfViewerNode.tsx
+++ b/plugins/PdfViewerNode.tsx
@@ -1,13 +1,82 @@
-import { NodeProps } from "@xyflow/react";
+import { fetchUser } from "@/lib/actions/user.actions";
+import { updateRealtimePost } from "@/lib/actions/realtimepost.actions";
+import { useAuth } from "@/lib/AuthContext";
+import useStore from "@/lib/reactflow/store";
+import { AppState, AuthorOrAuthorId } from "@/lib/reactflow/types";
 import { PluginDescriptor } from "@/lib/pluginLoader";
+import { PdfViewerPostValidation } from "@/lib/validations/thread";
+import BaseNode from "@/components/nodes/BaseNode";
+import PdfViewerNodeModal from "@/components/modals/PdfViewerNodeModal";
+import { NodeProps } from "@xyflow/react";
+import { useEffect, useState } from "react";
+import { usePathname } from "next/navigation";
+import { z } from "zod";
+import { useShallow } from "zustand/react/shallow";
 
-function PdfViewerNode({ data }: NodeProps<{ url?: string }>) {
+interface PdfViewerNodeData {
+  pdfUrl?: string;
+  author: AuthorOrAuthorId;
+  locked: boolean;
+}
+
+function PdfViewerNode({ id, data }: NodeProps<PdfViewerNodeData>) {
+  const path = usePathname();
+  const currentUser = useAuth().user;
+  const store = useStore(
+    useShallow((state: AppState) => ({
+      closeModal: state.closeModal,
+    }))
+  );
+  const [author, setAuthor] = useState(data.author);
+  const [url, setUrl] = useState(data.pdfUrl || "");
+
+  useEffect(() => {
+    if ("username" in author) return;
+    fetchUser(data.author.id).then((user) => user && setAuthor(user));
+  }, [author, data.author.id]);
+
+  const isOwned = currentUser
+    ? Number(currentUser.userId) === Number(data.author.id)
+    : false;
+
+  const onSubmit = (values: z.infer<typeof PdfViewerPostValidation>) => {
+    setUrl(values.pdfUrl);
+    updateRealtimePost({
+      id,
+      path,
+      pluginType: "PDF_VIEWER",
+      pluginData: { pdfUrl: values.pdfUrl },
+    });
+    store.closeModal();
+  };
+
   return (
-    <iframe
-      src={data?.url}
-      className="w-full h-full border-none"
-      title="PDF Viewer"
-    />
+    <BaseNode
+      modalContent={
+        <PdfViewerNodeModal
+          id={id}
+          isOwned={isOwned}
+          currentUrl={url}
+          onSubmit={onSubmit}
+        />
+      }
+      id={id}
+      author={author}
+      isOwned={isOwned}
+      type="PLUGIN"
+      isLocked={data.locked}
+    >
+      <object
+        data={url}
+        type="application/pdf"
+        width="100%"
+        height="400"
+      >
+        <p>
+          <a href={url}>Download PDF</a>
+        </p>
+      </object>
+    </BaseNode>
   );
 }
 


### PR DESCRIPTION
## Summary
- implement new `PdfViewerNode` plugin with editing modal
- add form and modal components for configuring the PDF URL
- define `PdfViewerPostValidation`

## Testing
- `yarn install`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_686991a30f508329a0ac6941d90805db