### PR TITLE
Fix __dirname error in Next.js config

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,4 +1,8 @@
 import path from "path";
+import { fileURLToPath } from "url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {


### PR DESCRIPTION
## Summary
- resolve `__dirname` in `next.config.mjs` for ESM

## Testing
- `yarn install`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_686994bcccb8832984936597fc1069e6