### PR TITLE
Enable PDF viewer posts

### DIFF
--- a/app/(root)/(realtime)/post/[id]/page.tsx
+++ b/app/(root)/(realtime)/post/[id]/page.tsx
@@ -35,6 +35,8 @@ const Page = async ({ params }: { params: { id: string } }) => {
               : undefined
           }
           video_url={post.type === "VIDEO" ? post.video_url! : undefined}
+          pluginType={(post as any).pluginType ?? null}
+          pluginData={(post as any).pluginData ?? null}
           type={post.type}
           author={post.author!}
           createdAt={post.created_at.toDateString()}

--- a/app/(root)/(standard)/page.tsx
+++ b/app/(root)/(standard)/page.tsx
@@ -23,6 +23,7 @@ export default async function Home() {
       "GALLERY",
       "DRAW",
       "LIVECHAT",
+      "PLUGIN",
     ],
   });
   const user = await getUserFromCookies();
@@ -53,6 +54,8 @@ export default async function Home() {
                 video_url={
                   realtimePost.video_url ? realtimePost.video_url : undefined
                 }
+                pluginType={(realtimePost as any).pluginType ?? null}
+                pluginData={(realtimePost as any).pluginData ?? null}
                 type={realtimePost.type}
                 author={realtimePost.author!}
                 createdAt={realtimePost.created_at.toDateString()}

--- a/components/cards/PostCard.tsx
+++ b/components/cards/PostCard.tsx
@@ -42,6 +42,8 @@ interface Props {
   commentCount?: number;
   expirationDate?: string | null;
   embedPost?: React.ReactNode;
+  pluginType?: string | null;
+  pluginData?: Record<string, any> | null;
 }
 
 const PostCard = async ({
@@ -58,6 +60,8 @@ const PostCard = async ({
   commentCount = 0,
   expirationDate = null,
   embedPost,
+  pluginType = null,
+  pluginData = null,
   }: Props) => {
   let currentUserLike: Like | RealtimeLike | null = null;
   if (currentUserId) {
@@ -169,6 +173,20 @@ const PostCard = async ({
             {type === "DRAW" && (
               <div className="mt-2 mb-2 flex justify-center items-center">
                 <DrawCanvas id={id.toString()} content={content} />
+              </div>
+            )}
+            {type === "PLUGIN" && pluginType === "PDF_VIEWER" && pluginData && (
+              <div className="mt-2 mb-2 flex justify-center items-center">
+                <object
+                  data={(pluginData as any).pdfUrl}
+                  type="application/pdf"
+                  width="100%"
+                  height="400"
+                >
+                  <p>
+                    <a href={(pluginData as any).pdfUrl}>Download PDF</a>
+                  </p>
+                </object>
               </div>
             )}
             {embedPost && <div className="mt-4 scale-90">{embedPost}</div>}

--- a/components/cards/ThreadCard.tsx
+++ b/components/cards/ThreadCard.tsx
@@ -41,6 +41,8 @@ interface Props {
   likeCount: number;
   commentCount?: number;
   expirationDate?: string | null;
+  pluginType?: string | null;
+  pluginData?: Record<string, any> | null;
 }
 
 const ThreadCard = async ({
@@ -55,6 +57,8 @@ const ThreadCard = async ({
   likeCount,
   commentCount = 0,
   expirationDate = null,
+  pluginType = null,
+  pluginData = null,
 }: Props) => {
   let currentUserLike: Like | null = null;
   if (currentUserId) {
@@ -95,7 +99,21 @@ const ThreadCard = async ({
             <p className="text-xs text-gray-500 mt-1">Posted at {createdAt}</p>
 
             <hr className="mt-3 mb-4 w-[200%] h-px border-t-0 bg-transparent bg-gradient-to-r from-transparent via-slate-100 to-transparent opacity-75" />
-              <p className="mt-2  text-[1.08rem] text-black tracking-[.05rem]">{content}</p>
+            <p className="mt-2  text-[1.08rem] text-black tracking-[.05rem]">{content}</p>
+            {pluginType === "PDF_VIEWER" && pluginData && (
+              <div className="mt-2 mb-2 flex justify-center items-center">
+                <object
+                  data={(pluginData as any).pdfUrl}
+                  type="application/pdf"
+                  width="100%"
+                  height="400"
+                >
+                  <p>
+                    <a href={(pluginData as any).pdfUrl}>Download PDF</a>
+                  </p>
+                </object>
+              </div>
+            )}
            
               <hr className="mt-3 mb-4 w-[200%] h-px border-t-0 bg-transparent bg-gradient-to-r from-transparent via-slate-100 to-transparent opacity-75" />
 

--- a/components/forms/CreateFeedPost.tsx
+++ b/components/forms/CreateFeedPost.tsx
@@ -18,6 +18,7 @@ import CollageCreationModal from "@/components/modals/CollageCreationModal";
 import GalleryNodeModal from "@/components/modals/GalleryNodeModal";
 import PortalNodeModal from "@/components/modals/PortalNodeModal";
 import LivechatNodeModal from "@/components/modals/LivechatNodeModal";
+import PdfViewerNodeModal from "@/components/modals/PdfViewerNodeModal";
 import { uploadFileToSupabase } from "@/lib/utils";
 import { createRealtimePost } from "@/lib/actions/realtimepost.actions";
 import { fetchUserByUsername } from "@/lib/actions/user.actions";
@@ -29,10 +30,11 @@ import {
   YoutubePostValidation,
   GalleryPostValidation,
   PortalNodeValidation,
+  PdfViewerPostValidation,
 } from "@/lib/validations/thread";
 import { AppNodeType, DEFAULT_NODE_VALUES } from "@/lib/reactflow/types";
 
-const nodeOptions: { label: string; nodeType: AppNodeType }[] = [
+const nodeOptions: { label: string; nodeType: string }[] = [
   { label: "TEXT", nodeType: "TEXT" },
   { label: "IMAGE", nodeType: "IMAGE" },
   { label: "VIDEO", nodeType: "VIDEO" },
@@ -43,11 +45,12 @@ const nodeOptions: { label: string; nodeType: AppNodeType }[] = [
   { label: "PORTAL", nodeType: "PORTAL" },
   { label: "DRAW", nodeType: "DRAW" },
   { label: "LIVECHAT", nodeType: "LIVECHAT" },
+  { label: "PDF Viewer", nodeType: "PDF_VIEWER" },
 ];
 
 const CreateFeedPost = () => {
   const [open, setOpen] = useState(false);
-  const [selectedType, setSelectedType] = useState<AppNodeType | "">("");
+  const [selectedType, setSelectedType] = useState<string>("");
   const router = useRouter();
 
   function reset() {
@@ -126,12 +129,12 @@ const CreateFeedPost = () => {
     router.refresh();
   }
 
-  const handleSelect = async (value: AppNodeType) => {
+  const handleSelect = async (value: string) => {
     if (value === "LIVESTREAM" || value === "DRAW") {
       await createRealtimePost({
         path: "/",
         coordinates: { x: 0, y: 0 },
-        type: value,
+        type: value as AppNodeType,
         realtimeRoomId: "global",
       });
       reset();
@@ -214,10 +217,29 @@ const CreateFeedPost = () => {
             }}
           />
         );
+      case "PDF_VIEWER":
+        return (
+          <PdfViewerNodeModal
+            isOwned={true}
+            currentUrl=""
+            onSubmit={async (vals) => {
+              await createRealtimePost({
+                path: "/",
+                coordinates: { x: 0, y: 0 },
+                type: "PLUGIN",
+                realtimeRoomId: "global",
+                pluginType: "PDF_VIEWER",
+                pluginData: { pdfUrl: vals.pdfUrl },
+              });
+              reset();
+              router.refresh();
+            }}
+          />
+        );
       default:
         return (
           <DialogContent className="p-8  max-w-[34rem] max-h-[20rem]">
-            <Select onValueChange={(v) => handleSelect(v as AppNodeType)}>
+            <Select onValueChange={(v) => handleSelect(v)}>
               <SelectTrigger>
                 <SelectValue placeholder="Select post type" className="px-4" />
               </SelectTrigger> 

--- a/components/shared/RealtimePostsTab.tsx
+++ b/components/shared/RealtimePostsTab.tsx
@@ -33,6 +33,8 @@ const RealtimePostsTab = async ({ currentUserId, accountId }: Props) => {
               content={post.content ? post.content : undefined}
               image_url={post.image_url ? post.image_url : undefined}
               video_url={post.video_url ? post.video_url : undefined}
+              pluginType={(post as any).pluginType ?? null}
+              pluginData={(post as any).pluginData ?? null}
               type={post.type}
               author={post.author!}
               createdAt={post.created_at.toDateString()}


### PR DESCRIPTION
## Summary
- add PDF Viewer option to `CreateFeedPost`
- render PDF Viewer plugin posts in `PostCard` and `ThreadCard`
- pass plugin data to post cards
- fetch plugin posts on the standard feed

## Testing
- `yarn install`
- `npm run lint`
- `npm test` *(fails: Cannot read properties of undefined (reading 'create'))*

------
https://chatgpt.com/codex/tasks/task_e_68699762f7008329994d6b568bab52e4