### PR TITLE
Allow jpg uploads

### DIFF
--- a/lib/validations/thread.ts
+++ b/lib/validations/thread.ts
@@ -7,6 +7,17 @@ const ACCEPTED_IMAGE_TYPES = [
   "image/png",
   "image/webp",
 ];
+const ACCEPTED_IMAGE_EXTENSIONS = [".jpeg", ".jpg", ".png", ".webp"];
+
+function isAcceptedImage(file: File) {
+  if (!file) return false;
+  const type = file.type?.toLowerCase();
+  const ext = file.name?.split(".").pop()?.toLowerCase();
+  return (
+    (type && ACCEPTED_IMAGE_TYPES.includes(type)) ||
+    (ext && ACCEPTED_IMAGE_EXTENSIONS.includes(`.${ext}`))
+  );
+}
 
 export const ThreadValidation = z.object({
   thread: z.string().min(3, { message: "Minimum of 3 characters" }),
@@ -20,7 +31,7 @@ export const RoomValidation = z.object({
     .any()
     .refine((file) => file?.size <= MAX_FILE_SIZE, `Max image size is 5MB.`)
     .refine(
-      (file) => ACCEPTED_IMAGE_TYPES.includes(file?.type),
+      (file) => isAcceptedImage(file),
       "Only .jpg, .jpeg, .png and .webp formats are supported."
     ),
 });
@@ -38,7 +49,7 @@ export const ImagePostValidation = z.object({
     .any()
     .refine((file) => file?.size <= MAX_FILE_SIZE, `Max image size is 5MB.`)
     .refine(
-      (file) => ACCEPTED_IMAGE_TYPES.includes(file?.type),
+      (file) => isAcceptedImage(file),
       "Only .jpg, .jpeg, .png and .webp formats are supported."
     ),
 });
@@ -50,7 +61,7 @@ export const GalleryPostValidation = z.object({
         .any()
         .refine((file) => file?.size <= MAX_FILE_SIZE, `Max image size is 5MB.`)
         .refine(
-          (file) => ACCEPTED_IMAGE_TYPES.includes(file?.type),
+          (file) => isAcceptedImage(file),
           "Only .jpg, .jpeg, .png and .webp formats are supported."
         )
     )
@@ -65,7 +76,7 @@ export const GalleryEditValidation = z.object({
         .any()
         .refine((file) => file?.size <= MAX_FILE_SIZE, `Max image size is 5MB.`)
         .refine(
-          (file) => ACCEPTED_IMAGE_TYPES.includes(file?.type),
+          (file) => isAcceptedImage(file),
           "Only .jpg, .jpeg, .png and .webp formats are supported."
         )
     )
@@ -87,7 +98,17 @@ export const LivechatInviteValidation = z.object({
 
 export const PortfolioNodeValidation = z.object({
   text: z.string().min(1),
-  images: z.array(z.any().refine((file) => file?.size <= MAX_FILE_SIZE, `Max image size is 5MB.`).refine((file) => ACCEPTED_IMAGE_TYPES.includes(file?.type), "Only .jpg, .jpeg, .png and .webp formats are supported.")).optional(),
+  images: z
+    .array(
+      z
+        .any()
+        .refine((file) => file?.size <= MAX_FILE_SIZE, `Max image size is 5MB.`)
+        .refine(
+          (file) => isAcceptedImage(file),
+          "Only .jpg, .jpeg, .png and .webp formats are supported."
+        )
+    )
+    .optional(),
   links: z.array(z.string().url()).optional(),
   layout: z.enum(["grid", "column"]).default("grid"),
   color: z.string().default("bg-white"),


### PR DESCRIPTION
## Summary
- add helper to support jpg extensions in validations

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_686ad1a94cf08329bb737608234b2955