### PR TITLE
Implement Product Review node

### DIFF
--- a/components/forms/ProductReviewNodeForm.tsx
+++ b/components/forms/ProductReviewNodeForm.tsx
@@ -1,0 +1,57 @@
+import { ProductReviewValidation } from "@/lib/validations/thread";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useForm } from "react-hook-form";
+import { z } from "zod";
+import { Button } from "../ui/button";
+import { Input } from "../ui/input";
+
+interface Props {
+  onSubmit: (values: z.infer<typeof ProductReviewValidation>) => void;
+  currentProductName: string;
+  currentRating: number;
+  currentSummary: string;
+}
+
+const ProductReviewNodeForm = ({
+  onSubmit,
+  currentProductName,
+  currentRating,
+  currentSummary,
+}: Props) => {
+  const form = useForm({
+    resolver: zodResolver(ProductReviewValidation),
+    defaultValues: {
+      productName: currentProductName,
+      rating: currentRating,
+      summary: currentSummary,
+    },
+  });
+
+  return (
+    <form method="post" className="ml-3 mr-3" onSubmit={form.handleSubmit(onSubmit)}>
+      <hr />
+      <div className="py-4 grid gap-2">
+        <label className="flex flex-col text-slate-500 gap-3 text-[14px]">
+          Product Name:
+          <Input type="text" {...form.register("productName")} defaultValue={currentProductName} />
+        </label>
+        <label className="flex flex-col text-slate-500 gap-3 text-[14px]">
+          Rating:
+          <Input type="number" min={1} max={5} {...form.register("rating", { valueAsNumber: true })} defaultValue={currentRating} />
+        </label>
+        <label className="flex flex-col text-slate-500 gap-3 text-[14px]">
+          Summary:
+          <Input type="text" {...form.register("summary")} defaultValue={currentSummary} />
+        </label>
+      </div>
+      <hr />
+      <div className="py-4 mb-4">
+        <Button type="submit" className="form-submit-button" size={"lg"}>
+          Save Changes
+        </Button>
+      </div>
+    </form>
+  );
+};
+
+export default ProductReviewNodeForm;

--- a/components/modals/ProductReviewNodeModal.tsx
+++ b/components/modals/ProductReviewNodeModal.tsx
@@ -1,0 +1,78 @@
+import { ProductReviewValidation } from "@/lib/validations/thread";
+import { z } from "zod";
+import ProductReviewNodeForm from "../forms/ProductReviewNodeForm";
+import {
+  DialogClose,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+
+interface Props {
+  id?: string;
+  isOwned: boolean;
+  onSubmit?: (values: z.infer<typeof ProductReviewValidation>) => void;
+  currentProductName: string;
+  currentRating: number;
+  currentSummary: string;
+}
+
+const renderCreate = ({ onSubmit, currentProductName, currentRating, currentSummary }: Omit<Props, "id" | "isOwned">) => (
+  <div>
+    <DialogHeader className="dialog-header text-white text-lg py-4 mt-[-4rem]">
+      <b>Create Review</b>
+    </DialogHeader>
+    <ProductReviewNodeForm
+      onSubmit={onSubmit!}
+      currentProductName={currentProductName}
+      currentRating={currentRating}
+      currentSummary={currentSummary}
+    />
+  </div>
+);
+
+const renderEdit = ({ onSubmit, currentProductName, currentRating, currentSummary }: Omit<Props, "id" | "isOwned">) => (
+  <div>
+    <DialogHeader className="dialog-header text-white text-lg py-4 mt-[-4rem]">
+      <b>Edit Review</b>
+    </DialogHeader>
+    <ProductReviewNodeForm
+      onSubmit={onSubmit!}
+      currentProductName={currentProductName}
+      currentRating={currentRating}
+      currentSummary={currentSummary}
+    />
+  </div>
+);
+
+const ProductReviewNodeModal = ({
+  id,
+  isOwned,
+  onSubmit,
+  currentProductName,
+  currentRating,
+  currentSummary,
+}: Props) => {
+  const isCreate = !id && isOwned;
+  const isEdit = id && isOwned;
+  return (
+    <div>
+      <DialogContent className="max-w-[40rem]">
+        <DialogTitle>ProductReviewNodeModal</DialogTitle>
+        <div className="grid rounded-md px-4 py-2">
+          {isCreate &&
+            renderCreate({ onSubmit, currentProductName, currentRating, currentSummary })}
+          {isEdit &&
+            renderEdit({ onSubmit, currentProductName, currentRating, currentSummary })}
+          {!isOwned && (
+            <DialogClose id="animateButton" className={`form-submit-button pl-2 py-2 pr-[1rem]`}>
+              <> Close </>
+            </DialogClose>
+          )}
+        </div>
+      </DialogContent>
+    </div>
+  );
+};
+
+export default ProductReviewNodeModal;

--- a/components/nodes/ProductReviewNode.tsx
+++ b/components/nodes/ProductReviewNode.tsx
@@ -1,0 +1,82 @@
+"use client";
+
+import { updateRealtimePost } from "@/lib/actions/realtimepost.actions";
+import { fetchUser } from "@/lib/actions/user.actions";
+import { useAuth } from "@/lib/AuthContext";
+import useStore from "@/lib/reactflow/store";
+import { AppState, ProductReviewNodeData } from "@/lib/reactflow/types";
+import { ProductReviewValidation } from "@/lib/validations/thread";
+import { NodeProps } from "@xyflow/react";
+import { useEffect, useState } from "react";
+import { usePathname } from "next/navigation";
+import { z } from "zod";
+import { useShallow } from "zustand/react/shallow";
+import BaseNode from "./BaseNode";
+import ProductReviewNodeModal from "../modals/ProductReviewNodeModal";
+
+function ProductReviewNode({ id, data }: NodeProps<ProductReviewNodeData>) {
+  const path = usePathname();
+  const currentUser = useAuth().user;
+  const store = useStore(
+    useShallow((state: AppState) => ({
+      closeModal: state.closeModal,
+    }))
+  );
+  const [author, setAuthor] = useState(data.author);
+  const [productName, setProductName] = useState(data.productName);
+  const [rating, setRating] = useState(data.rating);
+  const [summary, setSummary] = useState(data.summary);
+
+  useEffect(() => {
+    if ("username" in author) return;
+    fetchUser(data.author.id).then((user) => user && setAuthor(user));
+  }, [data.author.id, author]);
+
+  useEffect(() => {
+    setProductName(data.productName);
+    setRating(data.rating);
+    setSummary(data.summary);
+  }, [data]);
+
+  const isOwned = currentUser ? Number(currentUser.userId) === Number(data.author.id) : false;
+
+  async function onSubmit(values: z.infer<typeof ProductReviewValidation>) {
+    setProductName(values.productName);
+    setRating(values.rating);
+    setSummary(values.summary);
+    await updateRealtimePost({
+      id,
+      path,
+      content: JSON.stringify(values),
+    });
+    store.closeModal();
+  }
+
+  return (
+    <BaseNode
+      modalContent={
+        <ProductReviewNodeModal
+          id={id}
+          isOwned={isOwned}
+          currentProductName={productName}
+          currentRating={rating}
+          currentSummary={summary}
+          onSubmit={onSubmit}
+        />
+      }
+      id={id}
+      author={author}
+      isOwned={isOwned}
+      type={"PRODUCT_REVIEW"}
+      isLocked={data.locked}
+    >
+      <div className="flex flex-col p-2">
+        <div className="font-bold">{productName}</div>
+        <div>Rating: {rating}/5</div>
+        <div className="text-sm mt-1">{summary}</div>
+      </div>
+    </BaseNode>
+  );
+}
+
+export default ProductReviewNode;

--- a/components/reactflow/Room.tsx
+++ b/components/reactflow/Room.tsx
@@ -50,6 +50,7 @@ import DocumentNode from "../nodes/DocumentNode";
 import ThreadNode from "../nodes/ThreadNode";
 import CodeNode from "../nodes/CodeNode";
 import PortfolioNode from "../nodes/PortfolioNode";
+import ProductReviewNode from "../nodes/ProductReviewNode";
 import HamburgerMenu from "../shared/HamburgerMenu";
 import NodeSidebar from "../shared/NodeSidebar";
 import { createRealtimeEdge } from "@/lib/actions/realtimeedge.actions";
@@ -356,6 +357,7 @@ function Room({ roomId, initialNodes, initialEdges }: Props) {
     THREAD: ThreadNode,
     CODE: CodeNode,
     PORTFOLIO: PortfolioNode,
+    PRODUCT_REVIEW: ProductReviewNode,
   };
   pluginDescriptors.forEach((p) => {
     (nodeTypes as any)[p.type] = p.component as any;

--- a/components/shared/NodeSidebar.tsx
+++ b/components/shared/NodeSidebar.tsx
@@ -19,6 +19,7 @@ import {
   YoutubePostValidation,
   PortfolioNodeValidation,
   SplineViewerPostValidation,
+  ProductReviewValidation,
 
 } from "@/lib/validations/thread";
 import { usePathname, useParams } from "next/navigation";
@@ -47,6 +48,7 @@ import GalleryNodeModal from "@/components/modals/GalleryNodeModal";
 import LivechatNodeModal from "@/components/modals/LivechatNodeModal";
 import PortfolioNodeModal from "@/components/modals/PortfolioNodeModal";
 import SplineViewerNodeModal from "@/components/modals/SplineViewerNodeModal";
+import ProductReviewNodeModal from "@/components/modals/ProductReviewNodeModal";
 
 import { fetchUserByUsername } from "@/lib/actions/user.actions";
 
@@ -125,6 +127,7 @@ export default function NodeSidebar({
     { label: "AUDIO", nodeType: "AUDIO" },
     { label: "LLM", nodeType: "LLM_INSTRUCTION" },
     { label: "PORTFOLIO", nodeType: "PORTFOLIO" },
+    { label: "PRODUCT_REVIEW", nodeType: "PRODUCT_REVIEW" },
 
   ];
 
@@ -369,7 +372,26 @@ export default function NodeSidebar({
             />
           );
           break;
-  
+
+        case "PRODUCT_REVIEW":
+          store.openModal(
+            <ProductReviewNodeModal
+              isOwned={true}
+              currentProductName=""
+              currentRating={5}
+              currentSummary=""
+              onSubmit={(vals: z.infer<typeof ProductReviewValidation>) => {
+                createPostAndAddToCanvas({
+                  text: JSON.stringify(vals),
+                  path: pathname,
+                  coordinates: centerPosition,
+                  type: "PRODUCT_REVIEW",
+                  realtimeRoomId: roomId,
+                });
+              }}
+            />
+          );
+          break;
 
       case "AUDIO":
         createPostAndAddToCanvas({

--- a/lib/models/schema.prisma
+++ b/lib/models/schema.prisma
@@ -316,6 +316,7 @@ enum realtime_post_type {
   PORTFOLIO
   LLM_INSTRUCTION
   PLUGIN
+  PRODUCT_REVIEW
 }
 
 enum visibility {
@@ -368,4 +369,57 @@ model Integration {
   @@unique([user_id, service])
   @@index([user_id])
   @@map("integrations")
+}
+
+model ProductReview {
+  id          BigInt   @id @default(autoincrement())
+  realtime_post_id BigInt?
+  author_id   BigInt
+  product_name String
+  rating      Int
+  summary     String?
+  created_at  DateTime @default(now()) @db.Timestamptz(6)
+  updated_at  DateTime @default(now()) @updatedAt @db.Timestamptz(6)
+  author      User     @relation(fields: [author_id], references: [id], onDelete: Cascade)
+  realtime_post RealtimePost? @relation(fields: [realtime_post_id], references: [id])
+  claims      ProductReviewClaim[]
+
+  @@map("product_reviews")
+}
+
+model ProductReviewClaim {
+  id         BigInt   @id @default(autoincrement())
+  review_id  BigInt
+  text       String
+  created_at DateTime @default(now()) @db.Timestamptz(6)
+  review     ProductReview @relation(fields: [review_id], references: [id], onDelete: Cascade)
+  votes      ProductReviewVote[]
+  vouches    ProductReviewVouch[]
+
+  @@map("product_review_claims")
+}
+
+model ProductReviewVote {
+  id         BigInt   @id @default(autoincrement())
+  claim_id   BigInt
+  user_id    BigInt
+  type       String
+  created_at DateTime @default(now()) @db.Timestamptz(6)
+  claim      ProductReviewClaim @relation(fields: [claim_id], references: [id], onDelete: Cascade)
+  user       User     @relation(fields: [user_id], references: [id], onDelete: Cascade)
+
+  @@unique([claim_id, user_id, type])
+  @@map("product_review_votes")
+}
+
+model ProductReviewVouch {
+  id         BigInt   @id @default(autoincrement())
+  claim_id   BigInt
+  user_id    BigInt
+  amount     Int
+  created_at DateTime @default(now()) @db.Timestamptz(6)
+  claim      ProductReviewClaim @relation(fields: [claim_id], references: [id], onDelete: Cascade)
+  user       User     @relation(fields: [user_id], references: [id], onDelete: Cascade)
+
+  @@map("product_review_vouches")
 }

--- a/lib/reactflow/reactflowutils.ts
+++ b/lib/reactflow/reactflowutils.ts
@@ -273,7 +273,7 @@ export function convertPostToNode(
             y: realtimePost.y_coordinate,
           },
         } as CodeNode;
-        case "PORTFOLIO": {
+      case "PORTFOLIO": {
           let text = "";
           let images: string[] = [];
           let links: string[] = [];
@@ -316,6 +316,35 @@ export function convertPostToNode(
             y: realtimePost.y_coordinate,
           },
         } as PortfolioNodeData;
+      }
+
+      case "PRODUCT_REVIEW": {
+        let productName = "";
+        let rating = 5;
+        let summary = "";
+        if (realtimePost.content) {
+          try {
+            const parsed = JSON.parse(realtimePost.content);
+            productName = parsed.productName || "";
+            rating = parsed.rating || 5;
+            summary = parsed.summary || "";
+          } catch {}
+        }
+        return {
+          id: realtimePost.id.toString(),
+          type: realtimePost.type,
+          data: {
+            productName,
+            rating,
+            summary,
+            author: authorToSet,
+            locked: realtimePost.locked,
+          },
+          position: {
+            x: realtimePost.x_coordinate,
+            y: realtimePost.y_coordinate,
+          },
+        } as AppNode;
       }
 
       case "LLM_INSTRUCTION":

--- a/lib/reactflow/types.ts
+++ b/lib/reactflow/types.ts
@@ -12,6 +12,7 @@ import YoutubeNodeModal from "@/components/modals/YoutubeNodeModal";
 import CollageCreationModal from "@/components/modals/CollageCreationModal";
 import GalleryNodeModal from "@/components/modals/GalleryNodeModal";
 import PortfolioNodeModal from "@/components/modals/PortfolioNodeModal";
+import ProductReviewNodeModal from "@/components/modals/ProductReviewNodeModal";
 import ShareRoomModal from "@/components/modals/ShareRoomModal";
 import { PluginDescriptor } from "../pluginLoader";
 // there is currently no dedicated modal for portal nodes
@@ -180,6 +181,17 @@ export type LLMInstructionNode = Node<
   "LLM_INSTRUCTION"
 >;
 
+export type ProductReviewNodeData = Node<
+  {
+    productName: string;
+    rating: number;
+    summary: string;
+    author: AuthorOrAuthorId;
+    locked: boolean;
+  },
+  "PRODUCT_REVIEW"
+>;
+
 
 
 export type DefaultEdge = Edge<{}, "DEFAULT">;
@@ -201,6 +213,7 @@ export const NodeTypeMap = {
   CODE: {} as CodeNode,
   PORTFOLIO: {} as PortfolioNodeData,
   LLM_INSTRUCTION: {} as LLMInstructionNode,
+  PRODUCT_REVIEW: {} as ProductReviewNodeData,
   PLUGIN: {} as PluginDescriptor,
 };
 
@@ -218,6 +231,7 @@ export const NodeTypeToModalMap = {
   COLLAGE: CollageCreationModal,
   GALLERY: GalleryNodeModal,
   PORTFOLIO: PortfolioNodeModal,
+  PRODUCT_REVIEW: ProductReviewNodeModal,
   PORTAL: ShareRoomModal,
   LIVECHAT: ShareRoomModal,
 };
@@ -239,6 +253,7 @@ export type AppNode =
   | CodeNode
   | PortfolioNodeData
   | LLMInstructionNode
+  | ProductReviewNodeData
   | PluginDescriptor;
 
 export type AppEdgeType = keyof AppEdgeMapping;
@@ -263,6 +278,7 @@ export const DEFAULT_NODE_VALUES: Record<AppNodeType, string> = {
   ["CODE"]: "",
   ["PORTFOLIO"]: "",
   ["LLM_INSTRUCTION"]: "",
+  ["PRODUCT_REVIEW"]: "",
   ["PLUGIN"]: "",
 };
 

--- a/lib/validations/thread.ts
+++ b/lib/validations/thread.ts
@@ -118,6 +118,12 @@ export const PdfViewerPostValidation = z.object({
   pdfUrl: z.string().url(),
 });
 
+export const ProductReviewValidation = z.object({
+  productName: z.string().min(1),
+  rating: z.number().min(1).max(5),
+  summary: z.string().min(1),
+});
+
 export const SplineViewerPostValidation = z.object({
   sceneUrl: z.string().url(),
 });


### PR DESCRIPTION
## Summary
- add `PRODUCT_REVIEW` to realtime post enum and Prisma tables for reviews, claims, votes and vouches
- implement `ProductReviewNode` with modal and form
- register new node type in React Flow types and utilities
- enable creation in sidebar and rendering in room

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_686af685eae48329b5f494ad22f0f1d6