### PR TITLE
Add product link to review node

### DIFF
--- a/Product_Review_Node_SRS.md
+++ b/Product_Review_Node_SRS.md
@@ -17,7 +17,7 @@ Product Review Nodes capture opinions about a product in a standardized format. 
 
 ## 3. System Features
 ### 3.1 Structured Review Fields
-- **Description:** Forms for product name, rating (1–5), pros/cons, and claim text.
+- **Description:** Forms for product name, rating (1–5), a link to the product, pros/cons, and claim text.
 - **Storage:** Persisted in the database alongside other post types.
 - **UI:** Creation and edit modals validate required fields before saving.
 
@@ -58,7 +58,7 @@ Product Review Nodes capture opinions about a product in a standardized format. 
 - WebSocket or Supabase channels for real-time updates to votes and annotations.
 
 ## 5. Functional Requirements
-1. **FR1:** The system shall store product name, rating, summary, and an array of claims for each review.
+1. **FR1:** The system shall store product name, a product link, rating, summary, and an array of claims for each review.
 2. **FR2:** The system shall allow users to highlight claim text and create annotations linked to that claim.
 3. **FR3:** The system shall provide modular vote options on each claim and on the overall review.
 4. **FR4:** The system shall optionally let users attach micro vouch tokens to a claim and track totals per user.
@@ -95,3 +95,12 @@ The Product Review Node extends the existing node plug-in framework. A React com
 6. **Room & Feed Integration** – Render the node in rooms and the feed with real-time updates.
 7. **Testing & Linting** – Write tests and ensure `npm run lint` passes before merging.
 8. **Beta Feedback** – Deploy to a test environment and collect user feedback for refinements.
+
+## 11. Review Composition Guidelines
+To encourage useful and engaging reviews, posts should include:
+1. **Engaging introduction** with context, target audience, and quick verdict.
+2. **Product information** such as full name, manufacturer, price, availability, and model details.
+3. **Personal experience** covering setup, real-world usage, and specific examples.
+4. **Pros and cons** that focus on usability and performance.
+5. **Recommendations** for who should use the product and possible alternatives.
+6. **Visual elements** like photos, videos, or screenshots when applicable.

--- a/components/forms/ProductReviewNodeForm.tsx
+++ b/components/forms/ProductReviewNodeForm.tsx
@@ -10,6 +10,7 @@ interface Props {
   currentProductName: string;
   currentRating: number;
   currentSummary: string;
+  currentProductLink: string;
 }
 
 const ProductReviewNodeForm = ({
@@ -17,6 +18,7 @@ const ProductReviewNodeForm = ({
   currentProductName,
   currentRating,
   currentSummary,
+  currentProductLink,
 }: Props) => {
   const form = useForm({
     resolver: zodResolver(ProductReviewValidation),
@@ -24,6 +26,7 @@ const ProductReviewNodeForm = ({
       productName: currentProductName,
       rating: currentRating,
       summary: currentSummary,
+      productLink: currentProductLink,
     },
   });
 
@@ -42,6 +45,10 @@ const ProductReviewNodeForm = ({
         <label className="flex flex-col text-slate-500 gap-3 text-[14px]">
           Summary:
           <Input type="text" {...form.register("summary")} defaultValue={currentSummary} />
+        </label>
+        <label className="flex flex-col text-slate-500 gap-3 text-[14px]">
+          Product Link:
+          <Input type="url" {...form.register("productLink")} defaultValue={currentProductLink} />
         </label>
       </div>
       <hr />

--- a/components/modals/ProductReviewNodeModal.tsx
+++ b/components/modals/ProductReviewNodeModal.tsx
@@ -15,33 +15,36 @@ interface Props {
   currentProductName: string;
   currentRating: number;
   currentSummary: string;
+  currentProductLink: string;
 }
 
-const renderCreate = ({ onSubmit, currentProductName, currentRating, currentSummary }: Omit<Props, "id" | "isOwned">) => (
+const renderCreate = ({ onSubmit, currentProductName, currentRating, currentSummary, currentProductLink }: Omit<Props, "id" | "isOwned">) => (
   <div>
     <DialogHeader className="dialog-header text-white text-lg py-4 mt-[-4rem]">
       <b>Create Review</b>
     </DialogHeader>
-    <ProductReviewNodeForm
-      onSubmit={onSubmit!}
-      currentProductName={currentProductName}
-      currentRating={currentRating}
-      currentSummary={currentSummary}
-    />
+      <ProductReviewNodeForm
+        onSubmit={onSubmit!}
+        currentProductName={currentProductName}
+        currentRating={currentRating}
+        currentSummary={currentSummary}
+        currentProductLink={currentProductLink}
+      />
   </div>
 );
 
-const renderEdit = ({ onSubmit, currentProductName, currentRating, currentSummary }: Omit<Props, "id" | "isOwned">) => (
+const renderEdit = ({ onSubmit, currentProductName, currentRating, currentSummary, currentProductLink }: Omit<Props, "id" | "isOwned">) => (
   <div>
     <DialogHeader className="dialog-header text-white text-lg py-4 mt-[-4rem]">
       <b>Edit Review</b>
     </DialogHeader>
-    <ProductReviewNodeForm
-      onSubmit={onSubmit!}
-      currentProductName={currentProductName}
-      currentRating={currentRating}
-      currentSummary={currentSummary}
-    />
+      <ProductReviewNodeForm
+        onSubmit={onSubmit!}
+        currentProductName={currentProductName}
+        currentRating={currentRating}
+        currentSummary={currentSummary}
+        currentProductLink={currentProductLink}
+      />
   </div>
 );
 
@@ -52,6 +55,7 @@ const ProductReviewNodeModal = ({
   currentProductName,
   currentRating,
   currentSummary,
+  currentProductLink,
 }: Props) => {
   const isCreate = !id && isOwned;
   const isEdit = id && isOwned;
@@ -61,9 +65,9 @@ const ProductReviewNodeModal = ({
         <DialogTitle>ProductReviewNodeModal</DialogTitle>
         <div className="grid rounded-md px-4 py-2">
           {isCreate &&
-            renderCreate({ onSubmit, currentProductName, currentRating, currentSummary })}
+            renderCreate({ onSubmit, currentProductName, currentRating, currentSummary, currentProductLink })}
           {isEdit &&
-            renderEdit({ onSubmit, currentProductName, currentRating, currentSummary })}
+            renderEdit({ onSubmit, currentProductName, currentRating, currentSummary, currentProductLink })}
           {!isOwned && (
             <DialogClose id="animateButton" className={`form-submit-button pl-2 py-2 pr-[1rem]`}>
               <> Close </>

--- a/components/nodes/ProductReviewNode.tsx
+++ b/components/nodes/ProductReviewNode.tsx
@@ -26,6 +26,7 @@ function ProductReviewNode({ id, data }: NodeProps<ProductReviewNodeData>) {
   const [productName, setProductName] = useState(data.productName);
   const [rating, setRating] = useState(data.rating);
   const [summary, setSummary] = useState(data.summary);
+  const [productLink, setProductLink] = useState(data.productLink);
 
   useEffect(() => {
     if ("username" in author) return;
@@ -36,6 +37,7 @@ function ProductReviewNode({ id, data }: NodeProps<ProductReviewNodeData>) {
     setProductName(data.productName);
     setRating(data.rating);
     setSummary(data.summary);
+    setProductLink(data.productLink);
   }, [data]);
 
   const isOwned = currentUser ? Number(currentUser.userId) === Number(data.author.id) : false;
@@ -44,6 +46,7 @@ function ProductReviewNode({ id, data }: NodeProps<ProductReviewNodeData>) {
     setProductName(values.productName);
     setRating(values.rating);
     setSummary(values.summary);
+    setProductLink(values.productLink);
     await updateRealtimePost({
       id,
       path,
@@ -55,14 +58,15 @@ function ProductReviewNode({ id, data }: NodeProps<ProductReviewNodeData>) {
   return (
     <BaseNode
       modalContent={
-        <ProductReviewNodeModal
-          id={id}
-          isOwned={isOwned}
-          currentProductName={productName}
-          currentRating={rating}
-          currentSummary={summary}
-          onSubmit={onSubmit}
-        />
+      <ProductReviewNodeModal
+        id={id}
+        isOwned={isOwned}
+        currentProductName={productName}
+        currentRating={rating}
+        currentSummary={summary}
+        currentProductLink={productLink}
+        onSubmit={onSubmit}
+      />
       }
       id={id}
       author={author}
@@ -74,6 +78,9 @@ function ProductReviewNode({ id, data }: NodeProps<ProductReviewNodeData>) {
         <div className="font-bold">{productName}</div>
         <div>Rating: {rating}/5</div>
         <div className="text-sm mt-1">{summary}</div>
+        <a href={productLink} className="text-xs text-blue-500" target="_blank" rel="noopener noreferrer">
+          View Product
+        </a>
       </div>
     </BaseNode>
   );

--- a/components/shared/NodeSidebar.tsx
+++ b/components/shared/NodeSidebar.tsx
@@ -380,6 +380,7 @@ export default function NodeSidebar({
               currentProductName=""
               currentRating={5}
               currentSummary=""
+              currentProductLink=""
               onSubmit={(vals: z.infer<typeof ProductReviewValidation>) => {
                 createPostAndAddToCanvas({
                   text: JSON.stringify(vals),

--- a/lib/models/schema.prisma
+++ b/lib/models/schema.prisma
@@ -382,6 +382,7 @@ model ProductReview {
   product_name     String
   rating           Int
   summary          String?
+  product_link     String?
   created_at       DateTime             @default(now()) @db.Timestamptz(6)
   updated_at       DateTime             @default(now()) @updatedAt @db.Timestamptz(6)
   author           User                 @relation(fields: [author_id], references: [id], onDelete: Cascade)

--- a/lib/reactflow/reactflowutils.ts
+++ b/lib/reactflow/reactflowutils.ts
@@ -322,12 +322,14 @@ export function convertPostToNode(
         let productName = "";
         let rating = 5;
         let summary = "";
+        let productLink = "";
         if (realtimePost.content) {
           try {
             const parsed = JSON.parse(realtimePost.content);
             productName = parsed.productName || "";
             rating = parsed.rating || 5;
             summary = parsed.summary || "";
+            productLink = parsed.productLink || "";
           } catch {}
         }
         return {
@@ -337,6 +339,7 @@ export function convertPostToNode(
             productName,
             rating,
             summary,
+            productLink,
             author: authorToSet,
             locked: realtimePost.locked,
           },

--- a/lib/reactflow/types.ts
+++ b/lib/reactflow/types.ts
@@ -186,6 +186,7 @@ export type ProductReviewNodeData = Node<
     productName: string;
     rating: number;
     summary: string;
+    productLink: string;
     author: AuthorOrAuthorId;
     locked: boolean;
   },

--- a/lib/validations/thread.ts
+++ b/lib/validations/thread.ts
@@ -122,6 +122,7 @@ export const ProductReviewValidation = z.object({
   productName: z.string().min(1),
   rating: z.number().min(1).max(5),
   summary: z.string().min(1),
+  productLink: z.string().url(),
 });
 
 export const SplineViewerPostValidation = z.object({


### PR DESCRIPTION
## Summary
- include `productLink` in `ProductReviewNodeData`
- validate a product URL in ProductReviewValidation
- accept product link in creation forms and modal
- show product link in ProductReviewNode component
- parse product link from realtime post content
- save product link in database schema
- document review guidelines and updated requirements

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_686b023c67448329bf22d79067ef2fd9