### PR TITLE
Add user cache for repeated lookups

### DIFF
--- a/lib/serverutils.ts
+++ b/lib/serverutils.ts
@@ -5,7 +5,11 @@ import { cookies } from "next/headers";
 import { User } from "./AuthContext";
 import { Tokens } from "next-firebase-auth-edge";
 import { filterStandardClaims } from "next-firebase-auth-edge/lib/auth/claims";
-import { fetchUserByAuthId, createDefaultUser } from "./actions/user.actions";
+import {
+  fetchUserByAuthId,
+  createDefaultUser,
+  clearUserCache,
+} from "./actions/user.actions";
 import { serverConfig } from "./firebase/config";
 
 export async function toUser({ decodedToken }: Tokens): Promise<User> {
@@ -49,6 +53,7 @@ export async function toUser({ decodedToken }: Tokens): Promise<User> {
 }
 
 export async function getUserFromCookies(): Promise<User | null> {
+  clearUserCache();
   const tokens = await getTokens(cookies(), serverConfig);
   const user = tokens ? await toUser(tokens) : null;
   return user;


### PR DESCRIPTION
## Summary
- cache user lookups in `lib/actions/user.actions.ts`
- clear the cache for each request in `getUserFromCookies`

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_686b0969b5c083298638463d48fe33cb