### PR TITLE
Improve loading for heavy nodes

### DIFF
--- a/components/reactflow/Room.tsx
+++ b/components/reactflow/Room.tsx
@@ -36,15 +36,19 @@ import EmojiReactions from "../reactions/EmojiReactions";
 import DefaultEdge from "../edges/DefaultEdge";
 import ImageComputeNode from "../nodes/ImageComputeNode";
 import ImageURLNode from "../nodes/ImageURLNode";
-import LiveStreamNode from "../nodes/LiveStreamNode";
+import dynamic from "next/dynamic";
+
+const LiveStreamNode = dynamic(() => import("../nodes/LiveStreamNode"), {
+  ssr: false,
+});
 import TextInputNode from "../nodes/TextInputNode";
 import PortalNode from "../nodes/PortalNode";
 import YoutubeNode from "../nodes/YoutubeNode";
 import CollageNode from "../nodes/CollageNode";
 import GalleryNode from "../nodes/GalleryNode";
-import DrawNode from "../nodes/DrawNode";
+const DrawNode = dynamic(() => import("../nodes/DrawNode"), { ssr: false });
 import LivechatNode from "../nodes/LivechatNode";
-import AudioNode from "../nodes/AudioNode";
+const AudioNode = dynamic(() => import("../nodes/AudioNode"), { ssr: false });
 import LLMInstructionNode from "../nodes/LLMInstructionNode";
 import DocumentNode from "../nodes/DocumentNode";
 import ThreadNode from "../nodes/ThreadNode";

--- a/plugins/SplineViewerNode.tsx
+++ b/plugins/SplineViewerNode.tsx
@@ -12,7 +12,11 @@ import { useEffect, useState, Suspense } from "react";
 import { usePathname } from "next/navigation";
 import { z } from "zod";
 import { useShallow } from "zustand/react/shallow";
-import Spline from "@splinetool/react-spline";
+import dynamic from "next/dynamic";
+
+const Spline = dynamic(() => import("@splinetool/react-spline"), {
+  ssr: false,
+});
 
 interface SplineViewerNodeData {
   sceneUrl?: string;


### PR DESCRIPTION
## Summary
- lazy load LiveStreamNode, DrawNode and AudioNode in Room
- lazy load Spline component in SplineViewerNode

## Testing
- `yarn install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_686b09f64e708329b3909df3c6122b87