### PR TITLE
Centralize Prisma connection

### DIFF
--- a/lib/actions/follow.actions.ts
+++ b/lib/actions/follow.actions.ts
@@ -4,7 +4,6 @@ import { prisma } from "../prismaclient";
 
 export async function followUser({ followerId, followingId }: { followerId: bigint; followingId: bigint; }) {
   try {
-    await prisma.$connect();
     await prisma.follow.create({
       data: {
         follower_id: followerId,
@@ -18,7 +17,6 @@ export async function followUser({ followerId, followingId }: { followerId: bigi
 
 export async function unfollowUser({ followerId, followingId }: { followerId: bigint; followingId: bigint; }) {
   try {
-    await prisma.$connect();
     await prisma.follow.delete({
       where: {
         follower_id_following_id: {
@@ -33,7 +31,6 @@ export async function unfollowUser({ followerId, followingId }: { followerId: bi
 }
 
 export async function isFollowing({ followerId, followingId }: { followerId: bigint; followingId: bigint; }) {
-  await prisma.$connect();
   const follow = await prisma.follow.findUnique({
     where: {
       follower_id_following_id: { follower_id: followerId, following_id: followingId },
@@ -43,7 +40,6 @@ export async function isFollowing({ followerId, followingId }: { followerId: big
 }
 
 export async function areFriends({ userId, targetUserId }: { userId: bigint; targetUserId: bigint; }) {
-  await prisma.$connect();
   const [a, b] = await Promise.all([
     prisma.follow.findUnique({
       where: {
@@ -67,7 +63,6 @@ export interface FriendEntry {
 }
 
 export async function fetchFollowRelations({ userId }: { userId: bigint }) {
-  await prisma.$connect();
   const followings = await prisma.follow.findMany({
     where: { follower_id: userId },
     include: { following: true },

--- a/lib/actions/friend-suggestions.actions.ts
+++ b/lib/actions/friend-suggestions.actions.ts
@@ -12,7 +12,6 @@ function cosineSimilarity(a: number[], b: number[]) {
 }
 
 export async function updateUserEmbedding(userId: bigint) {
-  await prisma.$connect();
   const attrs = await prisma.userAttributes.findUnique({
     where: { user_id: userId },
   });
@@ -35,7 +34,6 @@ export async function updateUserEmbedding(userId: bigint) {
 }
 
 export async function generateFriendSuggestions(userId: bigint) {
-  await prisma.$connect();
   const base = await prisma.userEmbedding.findUnique({ where: { user_id: userId } });
   if (!base) return [];
   const others = await prisma.userEmbedding.findMany({ where: { user_id: { not: userId } } });
@@ -106,7 +104,6 @@ export async function generateFriendSuggestions(userId: bigint) {
 }
 
 export async function fetchFriendSuggestions(userId: bigint) {
-  await prisma.$connect();
   const suggestions = await prisma.friendSuggestion.findMany({
     where: { user_id: userId },
     include: { suggestedUser: true },

--- a/lib/actions/like.actions.ts
+++ b/lib/actions/like.actions.ts
@@ -16,7 +16,6 @@ interface realtimeLikeParams {
 
 export async function likePost({ userId, postId }: likePostParams) {
   try {
-    await prisma.$connect();
     const uid = BigInt(userId);
     const pid = BigInt(postId);
     const post = await prisma.post.findUnique({
@@ -87,7 +86,6 @@ export async function likePost({ userId, postId }: likePostParams) {
 
 export async function unlikePost({ userId, postId }: likePostParams) {
   try {
-    await prisma.$connect();
     const uid = BigInt(userId);
     const pid = BigInt(postId);
     const post = await prisma.post.findUnique({
@@ -135,7 +133,6 @@ export async function unlikePost({ userId, postId }: likePostParams) {
 
 export async function dislikePost({ userId, postId }: likePostParams) {
   try {
-    await prisma.$connect();
     const uid = BigInt(userId);
     const pid = BigInt(postId);
     const post = await prisma.post.findUnique({
@@ -208,7 +205,6 @@ export async function fetchLikeForCurrentUser({
   postId,
 }: likePostParams) {
   try {
-    await prisma.$connect();
     const uid = BigInt(userId);
     const pid = BigInt(postId);
     const like = await prisma.like.findUnique({
@@ -230,7 +226,6 @@ export async function likeRealtimePost({
   realtimePostId,
 }: realtimeLikeParams) {
   try {
-    await prisma.$connect();
     const uid = BigInt(userId);
     const pid = BigInt(realtimePostId);
     const post = await prisma.realtimePost.findUnique({
@@ -276,7 +271,6 @@ export async function unlikeRealtimePost({
   realtimePostId,
 }: realtimeLikeParams) {
   try {
-    await prisma.$connect();
     const uid = BigInt(userId);
     const pid = BigInt(realtimePostId);
     const post = await prisma.realtimePost.findUnique({ where: { id: pid } });
@@ -311,7 +305,6 @@ export async function dislikeRealtimePost({
   realtimePostId,
 }: realtimeLikeParams) {
   try {
-    await prisma.$connect();
     const uid = BigInt(userId);
     const pid = BigInt(realtimePostId);
     const post = await prisma.realtimePost.findUnique({ where: { id: pid } });
@@ -354,7 +347,6 @@ export async function fetchRealtimeLikeForCurrentUser({
   realtimePostId,
 }: realtimeLikeParams) {
   try {
-    await prisma.$connect();
     const uid = BigInt(userId);
     const pid = BigInt(realtimePostId);
     const like = await prisma.realtimeLike.findUnique({

--- a/lib/actions/realtimeedge.actions.ts
+++ b/lib/actions/realtimeedge.actions.ts
@@ -29,7 +29,6 @@ export async function createRealtimeEdge({
     throw new Error("User not authenticated");
   }
   try {
-    await prisma.$connect();
     const createdRealtimeEdge = await prisma.realtimeEdge.create({
       data: {
         source_node_id: sourceNodeId,
@@ -90,7 +89,6 @@ export async function updateRealtimeEdge({
 }: UpdateRealtimeEdgeParams) {
   const user = await getUserFromCookies();
   try {
-    await prisma.$connect();
     const originalEdge = await prisma.realtimeEdge.findUniqueOrThrow({
       where: {
         id: BigInt(id),
@@ -119,7 +117,6 @@ export async function fetchRealtimeEdges({
 }: {
   realtimeRoomId: string;
 }) {
-  await prisma.$connect();
 
   const realtimeEdges = await prisma.realtimeEdge.findMany({
     where: {
@@ -132,7 +129,6 @@ export async function fetchRealtimeEdges({
 
 export async function deleteRealtimeEdge({ id }: { id: string }) {
   const user = await getUserFromCookies();
-  await prisma.$connect();
   const originalEdge = await prisma.realtimeEdge.findUniqueOrThrow({
     where: {
       id: BigInt(id),

--- a/lib/actions/realtimepost.actions.ts
+++ b/lib/actions/realtimepost.actions.ts
@@ -58,7 +58,6 @@ export async function createRealtimePost({
     throw new Error("User not authenticated");
   }
   try {
-    await prisma.$connect();
     const createdRealtimePost = await prisma.realtimePost.create({
       data: {
         ...(text && { content: text }),
@@ -124,7 +123,6 @@ export async function updateRealtimePost({
 }: UpdateRealtimePostParams) {
   const user = await getUserFromCookies();
   try {
-    await prisma.$connect();
     const originalPost = await prisma.realtimePost.findUniqueOrThrow({
       where: {
         id: BigInt(id),
@@ -192,7 +190,6 @@ export async function lockRealtimePost({
 }) {
   const user = await getUserFromCookies();
   try {
-    await prisma.$connect();
     const originalPost = await prisma.realtimePost.findUniqueOrThrow({
       where: {
         id: BigInt(id),
@@ -223,7 +220,6 @@ export async function fetchRealtimePosts({
   realtimeRoomId: string;
   postTypes: realtime_post_type[];
 }) {
-  await prisma.$connect();
 
   const realtimePosts = await prisma.realtimePost.findMany({
     where: {
@@ -259,7 +255,6 @@ export async function deleteRealtimePost({
 }) {
   const user = await getUserFromCookies();
   try {
-    await prisma.$connect();
     const originalPost = await prisma.realtimePost.findUniqueOrThrow({
       where: {
         id: BigInt(id),
@@ -281,7 +276,6 @@ export async function deleteRealtimePost({
 
 export async function fetchRealtimePostById({ id }: { id: string }) {
   try {
-    await prisma.$connect();
     const post = await prisma.realtimePost.findUniqueOrThrow({
       where: {
         id: BigInt(id),
@@ -312,7 +306,6 @@ export async function fetchRealtimePostById({ id }: { id: string }) {
 }
 
 export async function fetchRealtimePostTreeById({ id }: { id: string }) {
-  await prisma.$connect();
   const post: any = await prisma.realtimePost.findUnique({
     where: { id: BigInt(id) },
     include: { author: true, _count: { select: { children: true } } },
@@ -360,7 +353,6 @@ export async function addCommentToRealtimePost({
   path: string;
 }) {
   try {
-    await prisma.$connect();
     const originalPost = await prisma.realtimePost.findUnique({
       where: { id: parentPostId },
     });
@@ -397,7 +389,6 @@ export async function fetchUserRealtimePosts({
   userId: bigint;
   postTypes: realtime_post_type[];
 }) {
-  await prisma.$connect();
   const realtimePosts = await prisma.realtimePost.findMany({
     where: {
       realtime_room_id: realtimeRoomId,
@@ -433,7 +424,6 @@ export async function replicateRealtimePost({
   path: string;
 }) {
   try {
-    await prisma.$connect();
     const oid = BigInt(originalPostId);
     const uid = BigInt(userId);
     const original = await prisma.realtimePost.findUnique({

--- a/lib/actions/realtimeroom.actions.ts
+++ b/lib/actions/realtimeroom.actions.ts
@@ -12,7 +12,6 @@ export async function fetchRealtimeRoom({
   realtimeRoomId: string;
 }) {
   try {
-    await prisma.$connect();
 
     const realtimeRoom = await prisma.realtimeRoom.findUnique({
       where: {
@@ -54,7 +53,6 @@ export async function fetchRealtimeRoom({
 
 export async function joinRoom({ roomId }: { roomId: string }) {
   try {
-    await prisma.$connect();
     const user = await getUserFromCookies();
     if (!user) {
       throw new Error("User not authenticated");
@@ -99,7 +97,6 @@ export async function leaveRoom({
   path: string;
 }) {
   try {
-    await prisma.$connect();
     const user = await getUserFromCookies();
     if (!user) {
       throw new Error("User not authenticated");
@@ -128,7 +125,6 @@ export async function createAndJoinRoom({
   path: string;
 }) {
   try {
-    await prisma.$connect();
     const user = await getUserFromCookies();
     if (!user) {
       throw new Error("User not authenticated");
@@ -157,7 +153,6 @@ export async function createAndJoinRoom({
 
 export async function getRoomsForUser({ userId }: { userId: bigint }) {
   try {
-    await prisma.$connect();
     const userRoomMemberships = await prisma.userRealtimeRoom.findMany({
       where: {
         user_id: userId,
@@ -179,7 +174,6 @@ export interface RandomRoom {
 
 export async function fetchRandomRooms(count = 4): Promise<RandomRoom[]> {
   try {
-    await prisma.$connect();
     const total = await prisma.realtimeRoom.count();
     const take = Math.min(count, total);
     if (take === 0) return [];
@@ -206,7 +200,6 @@ export async function findOrGenerateInviteToken({
   roomId: string;
 }) {
   try {
-    await prisma.$connect();
     const existingInviteToken = await prisma.realtimeRoomInviteToken.findFirst({
       where: { inviting_user_id: userId, realtime_room_id: roomId },
     });
@@ -228,7 +221,6 @@ export async function findOrGenerateInviteToken({
 
 export async function lookupInviteToken(inviteToken: string) {
   try {
-    await prisma.$connect();
     return await prisma.realtimeRoomInviteToken.findUnique({
       where: { token: inviteToken },
     });

--- a/lib/actions/recommendation.actions.ts
+++ b/lib/actions/recommendation.actions.ts
@@ -28,7 +28,6 @@ export async function fetchRecommendations({
   limitUsers = 7,
   limitRooms = 5,
 }: RecommendationParams) {
-  await prisma.$connect();
   const base = await prisma.userAttributes.findUnique({
     where: { user_id: userId },
   });
@@ -118,7 +117,6 @@ export async function logRecommendationClick({
   recommendedUserId?: bigint;
   recommendedRoomId?: string;
 }) {
-  await prisma.$connect();
   await prisma.recommendationClick.create({
     data: {
       user_id: userId,

--- a/lib/actions/scheduledWorkflow.actions.ts
+++ b/lib/actions/scheduledWorkflow.actions.ts
@@ -13,7 +13,6 @@ export async function createScheduledWorkflow({
   trigger?: string | null;
   metadata?: any;
 }) {
-  await prisma.$connect();
   const id = typeof workflowId === "string" ? BigInt(workflowId) : workflowId;
   return prisma.scheduledWorkflow.create({
     data: {
@@ -26,6 +25,5 @@ export async function createScheduledWorkflow({
 }
 
 export async function listScheduledWorkflows() {
-  await prisma.$connect();
   return prisma.scheduledWorkflow.findMany();
 }

--- a/lib/actions/thread.actions.ts
+++ b/lib/actions/thread.actions.ts
@@ -20,7 +20,6 @@ interface AddCommentToPostParams {
 
 export async function createPost({ text, authorId, path, expirationDate }: CreatePostParams) {
   try {
-    await prisma.$connect();
     const createdPost = await prisma.post.create({
       data: {
         content: text,
@@ -48,7 +47,6 @@ export async function createPost({ text, authorId, path, expirationDate }: Creat
 }
 
 export async function fetchPosts(pageNumber = 1, pageSize = 20) {
-  await prisma.$connect();
   await archiveExpiredPosts();
 
   const skipAmount = (pageNumber - 1) * pageSize;
@@ -114,7 +112,6 @@ export async function fetchPosts(pageNumber = 1, pageSize = 20) {
 
 export async function fetchPostById(id: bigint) {
   try {
-    await prisma.$connect();
     await archiveExpiredPosts();
     const post = await prisma.post.findUnique({
       where: {
@@ -155,7 +152,6 @@ export async function fetchPostById(id: bigint) {
 }
 
 export async function fetchPostTreeById(id: bigint) {
-  await prisma.$connect();
   await archiveExpiredPosts();
   const post = await prisma.post.findUnique({
     where: { id },
@@ -195,7 +191,6 @@ export async function addCommentToPost({
   path,
 }: AddCommentToPostParams) {
   try {
-    await prisma.$connect();
     const originalPost = await prisma.post.findUnique({
       where: {
         id: parentPostId,
@@ -239,7 +234,6 @@ export async function replicatePost({
   path: string;
 }) {
   try {
-    await prisma.$connect();
     const oid = BigInt(originalPostId);
     const uid = BigInt(userId);
     const original = await prisma.post.findUnique({
@@ -272,7 +266,6 @@ export async function updatePostExpiration({
   postId: bigint;
   duration: string;
 }) {
-  await prisma.$connect();
   const post = await prisma.post.findUnique({
     where: { id: postId },
   });
@@ -293,7 +286,6 @@ export async function updatePostExpiration({
 }
 
 export async function archiveExpiredPosts() {
-  await prisma.$connect();
   const now = new Date();
   const expired = await prisma.post.findMany({
     where: { expiration_date: { lte: now } },
@@ -339,7 +331,6 @@ export async function archiveExpiredPosts() {
 export async function deletePost({ id, path }: { id: bigint; path?: string }) {
   const user = await getUserFromCookies();
   try {
-    await prisma.$connect();
     const originalPost = await prisma.post.findUniqueOrThrow({
       where: {
         id: id,

--- a/lib/actions/user.actions.ts
+++ b/lib/actions/user.actions.ts
@@ -31,7 +31,6 @@ export async function updateUser({
   path,
 }: UpdateUserParams) {
   try {
-    await prisma.$connect();
     const result = await prisma.user.upsert({
       where: {
         auth_id: userAuthId,
@@ -63,7 +62,6 @@ export async function updateUser({
 
 export async function fetchUserByAuthId(userAuthId: string) {
   try {
-    await prisma.$connect();
     return await prisma.user.findUnique({
       where: {
         auth_id: userAuthId,
@@ -76,7 +74,6 @@ export async function fetchUserByAuthId(userAuthId: string) {
 
 export async function fetchUser(userId: bigint) {
   try {
-    await prisma.$connect();
     return await prisma.user.findUnique({
       where: {
         id: userId,
@@ -89,7 +86,6 @@ export async function fetchUser(userId: bigint) {
 
 export async function fetchUserByUsername(username: string) {
   try {
-    await prisma.$connect();
     return await prisma.user.findFirst({
       where: { username: username.toLowerCase() },
     });
@@ -100,7 +96,6 @@ export async function fetchUserByUsername(username: string) {
 
 export async function fetchUserThreads(userId: bigint) {
   try {
-    await prisma.$connect();
     const posts = await prisma.user.findUnique({
       where: {
         id: userId,
@@ -161,7 +156,6 @@ export async function fetchUsers({
   sortBy = Prisma.SortOrder.desc,
 }: FetchUsersParams) {
   try {
-    await prisma.$connect();
     const skipAmount = (pageNumber - 1) * pageSize;
     const query: Prisma.UserWhereInput[] = [
       {
@@ -211,7 +205,6 @@ export async function fetchUsers({
 
 export async function getActivity(userId: bigint) {
   try {
-    await prisma.$connect();
     const userThreads = await prisma.post.findMany({
       where: {
         author_id: userId,
@@ -259,7 +252,6 @@ export async function getActivity(userId: bigint) {
 
 export async function fetchRandomUsers(count = 3) {
   try {
-    await prisma.$connect();
     const total = await prisma.user.count({
       where: { onboarded: true },
     });
@@ -300,7 +292,6 @@ export async function createDefaultUser({
   image,
 }: CreateDefaultUserParams) {
   try {
-    await prisma.$connect();
     const usernameBase = email ? email.split("@")[0] : `user-${nanoid(6)}`;
     const user = await prisma.user.create({
       data: {

--- a/lib/actions/userattributes.actions.ts
+++ b/lib/actions/userattributes.actions.ts
@@ -23,7 +23,6 @@ export async function upsertUserAttributes({
     throw new Error("User not authenticated");
   }
   try {
-    await prisma.$connect();
 
     const {
       artists = [],
@@ -128,7 +127,6 @@ export async function fetchUserAttributes({
   userId: bigint | null;
 }) {
   if (!userId) return null;
-  await prisma.$connect();
 
   const userAttributes = await prisma.userAttributes.findUnique({
     where: {
@@ -156,7 +154,6 @@ export async function searchUsersByAttributes({
   base,
   limit = 10,
 }: SearchUsersByAttributesParams) {
-  await prisma.$connect();
 
   const others = await prisma.userAttributes.findMany({
     include: { user: true },

--- a/lib/actions/workflow.actions.ts
+++ b/lib/actions/workflow.actions.ts
@@ -18,7 +18,6 @@ export async function createWorkflow({
 }) {
   const user = await getUserFromCookies();
   if (!user) throw new Error("User not authenticated");
-  await prisma.$connect();
   const workflow = await prisma.workflow.create({
     data: {
       owner_id: user.userId!,
@@ -54,7 +53,6 @@ export async function updateWorkflow({
 }) {
   const user = await getUserFromCookies();
   if (!user) throw new Error("User not authenticated");
-  await prisma.$connect();
   const workflow = await prisma.workflow.findUniqueOrThrow({ where: { id } });
   if (workflow.owner_id !== user.userId) {
     throw new Error("User not authorized");
@@ -99,7 +97,6 @@ export async function fetchWorkflow({
   version?: number;
   history?: boolean;
 }) {
-  await prisma.$connect();
   const stateInclude = history
     ? { orderBy: { version: "asc" } }
     : version

--- a/lib/prismaclient.ts
+++ b/lib/prismaclient.ts
@@ -9,6 +9,8 @@ const datasourceUrl = process.env.DATABASE_URL
 export const prisma =
   globalForPrisma.prisma || new PrismaClient({ datasourceUrl });
 
+void prisma.$connect();
+
 if (process.env.NODE_ENV !== "production") {
   globalForPrisma.prisma = prisma;
 }

--- a/lib/workflowScheduler.ts
+++ b/lib/workflowScheduler.ts
@@ -32,7 +32,6 @@ async function runWorkflow(workflowId: bigint) {
 }
 
 export async function startWorkflowScheduler() {
-  await prisma.$connect();
   const schedules = await prisma.scheduledWorkflow.findMany();
   for (const sched of schedules) {
     if (sched.cron) {

--- a/tests/workflowActions.integration.test.ts
+++ b/tests/workflowActions.integration.test.ts
@@ -8,8 +8,11 @@ jest.mock("@/lib/prismaclient", () => {
   mockPrisma = {
     $connect: jest.fn(),
     $transaction: jest.fn(async (actions: any[]) => {
-      await Promise.all(actions.map((a) => a));
-      return [actions[0]?.data ? { id: BigInt(1), ...actions[0].data } : undefined];
+      const results = await Promise.all(actions);
+      return [
+        { id: BigInt(1), ...(results[0] ?? {}) },
+        { id: BigInt(2), ...(results[1] ?? {}) },
+      ];
     }),
     workflow: {
       create: jest.fn(async ({ data }: any) => ({ id: BigInt(1), ...data })),
@@ -17,8 +20,11 @@ jest.mock("@/lib/prismaclient", () => {
       findUniqueOrThrow: jest.fn(async ({ where }: any) => ({ id: where.id, owner_id: BigInt(2) })),
     },
     workflowState: {
-      create: jest.fn(),
+      create: jest.fn(async ({ data }: any) => ({ id: BigInt(1), ...data })),
       findFirst: jest.fn(),
+    },
+    workflowTransition: {
+      create: jest.fn(),
     },
   };
   return { prisma: mockPrisma };


### PR DESCRIPTION
## Summary
- initiate a single Prisma connection on module load
- rely on global Prisma client for all actions
- update workflow tests with richer Prisma mocks

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686b09dfa73c8329a085b16261605839