### PR TITLE
Fix Word Rails scoring loop

### DIFF
--- a/app/(root)/(standard)/wordrails/page.tsx
+++ b/app/(root)/(standard)/wordrails/page.tsx
@@ -50,14 +50,16 @@ export default function Page() {
 
   useEffect(() => {
     if (!isComplete) return;
-    const updated = {
-      plays: stats.plays + 1,
-      wins: stats.wins + 1,
-      streak: stats.streak + 1,
-    };
-    localStorage.setItem("wordrails-stats", JSON.stringify(updated));
-    setStats(updated);
-  }, [isComplete, stats]);
+    setStats((prev) => {
+      const updated = {
+        plays: prev.plays + 1,
+        wins: prev.wins + 1,
+        streak: prev.streak + 1,
+      };
+      localStorage.setItem("wordrails-stats", JSON.stringify(updated));
+      return updated;
+    });
+  }, [isComplete]);
 
   const shareResult = () => {
     const index = puzzles.indexOf(puzzle) + 1;


### PR DESCRIPTION
## Summary
- stop Word Rails from repeatedly incrementing stats after completion

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_686b16a39414832997713c63f5dca3be