### PR TITLE
Add circle backdrops for pivot letters

### DIFF
--- a/app/(root)/(standard)/pivot/page.tsx
+++ b/app/(root)/(standard)/pivot/page.tsx
@@ -59,16 +59,18 @@ function Ring({
         const x = radius * Math.sin(a);
         const y = -radius * Math.cos(a);
         return (
-          <text
-            key={i}
-            x={x}
-            y={y}
-            textAnchor="middle"
-            dominantBaseline="middle"
-            className="font-mono text-block  text-[1rem] text-gray-800 rounded-full"
-          >
-            {l}
-          </text>
+          <g key={i}>
+            <circle cx={x} cy={y} r={12} fill="white" />
+            <text
+              x={x}
+              y={y}
+              textAnchor="middle"
+              dominantBaseline="middle"
+              className="font-mono text-block text-[1rem] text-gray-800"
+            >
+              {l}
+            </text>
+          </g>
         );
       })}
     </g>


### PR DESCRIPTION
## Summary
- tweak `Ring` to draw white circle behind each letter for readability

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_686b26f462b08329a8abf90b9d7428f8