### PR TITLE
Fix missing relation in Prisma schema

### DIFF
--- a/lib/models/schema.prisma
+++ b/lib/models/schema.prisma
@@ -264,6 +264,7 @@ model Workflow {
   states             WorkflowState[]
   transitions        WorkflowTransition[]
   scheduledWorkflows ScheduledWorkflow[]
+  runs               WorkflowRun[]
 
   @@map("workflows")
 }


### PR DESCRIPTION
## Summary
- add `runs` field in `Workflow` model to satisfy Prisma relation requirements

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_686c6e9f95c083299239fadbd1ada5de