### PR TITLE
Add workflow name input

### DIFF
--- a/app/(root)/(standard)/workflows/new/page.tsx
+++ b/app/(root)/(standard)/workflows/new/page.tsx
@@ -1,27 +1,24 @@
 import WorkflowBuilder from "@/components/workflow/WorkflowBuilder";
-import { createWorkflow } from "@/lib/actions/workflow.actions";
+import { createWorkflow, WorkflowGraph } from "@/lib/actions/workflow.actions";
 import { ReactFlowProvider } from "@xyflow/react";
 import React from "react";
 import Modal from "@/components/modals/Modal";
 import IntegrationButtons from "@/components/workflow/IntegrationButtons";
 
 export default function Page() {
+  async function handleSave(graph: WorkflowGraph, name: string) {
+    "use server";
+    const workflow = await createWorkflow({ name, graph });
+    return { id: workflow.id.toString() };
+  }
+
   return (
     <div className="relative -top-12">
       <IntegrationButtons />
       <div className="w-[100%] h-full border-2 border-blue overscroll-none">
         <ReactFlowProvider>
           <Modal />
-          <WorkflowBuilder
-            onSave={async (graph) => {
-              "use server";
-              const workflow = await createWorkflow({
-                name: "New Workflow",
-                graph,
-              });
-              return { id: workflow.id.toString() };
-            }}
-          />
+          <WorkflowBuilder onSave={handleSave} />
         </ReactFlowProvider>
       </div>
     </div>

--- a/components/workflow/WorkflowBuilder.tsx
+++ b/components/workflow/WorkflowBuilder.tsx
@@ -27,9 +27,11 @@ import { registerIntegrationActions } from "@/lib/registerIntegrationActions";
 import { listWorkflowActions } from "@/lib/workflowActions";
 import { IntegrationApp } from "@/lib/integrations/types";
 
+import { Input } from "@/components/ui/input";
+
 interface Props {
   initialGraph?: WorkflowGraph;
-  onSave: (graph: WorkflowGraph) => Promise<{ id: string }>;
+  onSave: (graph: WorkflowGraph, name: string) => Promise<{ id: string }>;
 }
 const proOptions = { hideAttribution: true };
 
@@ -41,6 +43,7 @@ export default function WorkflowBuilder({ initialGraph, onSave }: Props) {
     initialGraph?.edges || []
   );
   const [workflowId, setWorkflowId] = useState<string | null>(null);
+  const [name, setName] = useState("New Workflow");
   const [selectedNode, setSelectedNode] = useState<Node | null>(null);
   const [selectedEdge, setSelectedEdge] = useState<Edge | null>(null);
   const [actions, setActions] = useState<string[]>([]);
@@ -150,7 +153,7 @@ export default function WorkflowBuilder({ initialGraph, onSave }: Props) {
   };
 
   const save = async () => {
-    const result = await onSave({ nodes, edges });
+    const result = await onSave({ nodes, edges }, name);
     setWorkflowId(result.id);
   };
 
@@ -168,6 +171,12 @@ export default function WorkflowBuilder({ initialGraph, onSave }: Props) {
           State
         </div>
         <Button onClick={addState}>Add State</Button>
+        <Input
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          className="border p-1"
+          aria-label="Workflow Name"
+        />
         <Button onClick={() => importRef.current?.click()}>Import</Button>
         <input
           type="file"

--- a/tests/workflowBuilder.test.tsx
+++ b/tests/workflowBuilder.test.tsx
@@ -18,10 +18,13 @@ it.skip("adds a new state and triggers save", async () => {
   await act(async () => {
     fireEvent.click(screen.getByText("Save"));
   });
-  expect(onSave).toHaveBeenCalledWith({
-    nodes: expect.arrayContaining([expect.objectContaining({ id: "state-1" })]),
-    edges: [],
-  });
+  expect(onSave).toHaveBeenCalledWith(
+    {
+      nodes: expect.arrayContaining([expect.objectContaining({ id: "state-1" })]),
+      edges: [],
+    },
+    expect.any(String)
+  );
 });
 
 it.skip("imports workflow JSON", async () => {
@@ -39,5 +42,5 @@ it.skip("imports workflow JSON", async () => {
   await act(async () => {
     fireEvent.click(screen.getByText("Save"));
   });
-  expect(onSave).toHaveBeenCalled();
+  expect(onSave).toHaveBeenCalledWith(expect.any(Object), expect.any(String));
 });


### PR DESCRIPTION
## Summary
- let users name a workflow in WorkflowBuilder
- pass workflow name to server action when saving a new workflow
- adjust page and tests for updated handler

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_686c726d08088329bb0b4aa3726efe9a