### PR TITLE
Add analytics workflow starter

### DIFF
--- a/app/(root)/(standard)/workflows/new/page.tsx
+++ b/app/(root)/(standard)/workflows/new/page.tsx
@@ -4,6 +4,7 @@ import { ReactFlowProvider } from "@xyflow/react";
 import React from "react";
 import Modal from "@/components/modals/Modal";
 import IntegrationButtons from "@/components/workflow/IntegrationButtons";
+import analyticsTemplate from "@/templates/analytics-dashboard.json";
 
 export default function Page() {
   async function handleSave(graph: WorkflowGraph, name: string) {
@@ -12,13 +13,24 @@ export default function Page() {
     return { id: workflow.id.toString() };
   }
 
+  const initialGraph = analyticsTemplate.graph as WorkflowGraph;
+
   return (
-    <div className="relative -top-12">
+    <div className="relative -top-12 space-y-4">
       <IntegrationButtons />
+      <p className="mx-2 text-sm">
+        This builder starts with a sample analytics workflow fetching metrics,
+        generating a report, and sending it via email or Slack. It demonstrates
+        the unified analytics dashboard concept outlined in the product
+        roadmap.
+      </p>
       <div className="w-[100%] h-full border-2 border-blue overscroll-none">
         <ReactFlowProvider>
           <Modal />
-          <WorkflowBuilder onSave={handleSave} />
+          <WorkflowBuilder
+            onSave={handleSave}
+            initialGraph={initialGraph}
+          />
         </ReactFlowProvider>
       </div>
     </div>

--- a/integrations/AnalyticsIntegration.ts
+++ b/integrations/AnalyticsIntegration.ts
@@ -1,0 +1,28 @@
+import { IntegrationApp } from "@/lib/integrations/types";
+
+export const integration: IntegrationApp = {
+  name: "analytics",
+  description: "Aggregate analytics data and generate reports",
+  actions: [
+    {
+      name: "fetchData",
+      run: async () => {
+        console.log("Fetching analytics data");
+      },
+    },
+    {
+      name: "generateReport",
+      run: async () => {
+        console.log("Generating analytics report");
+      },
+    },
+    {
+      name: "sendReport",
+      run: async () => {
+        console.log("Sending analytics report");
+      },
+    },
+  ],
+};
+
+export default integration;

--- a/templates/analytics-dashboard.json
+++ b/templates/analytics-dashboard.json
@@ -1,0 +1,15 @@
+{
+  "name": "Analytics Dashboard",
+  "description": "Aggregates metrics and emails a weekly report",
+  "graph": {
+    "nodes": [
+      { "id": "fetch", "type": "trigger", "action": "analytics:fetchData" },
+      { "id": "report", "type": "action", "action": "analytics:generateReport" },
+      { "id": "notify", "type": "action", "action": "analytics:sendReport" }
+    ],
+    "edges": [
+      { "id": "e1", "source": "fetch", "target": "report" },
+      { "id": "e2", "source": "report", "target": "notify" }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- stub Analytics integration actions
- provide Analytics Dashboard workflow template
- prepopulate `/workflows/new` with the analytics template and explanation text

## Testing
- `npx next lint` *(fails: required packages not installed)*

------
https://chatgpt.com/codex/tasks/task_e_686c773682cc8329aec84848d4272809