### PR TITLE
Add template selection for new workflows

### DIFF
--- a/app/(root)/(standard)/workflows/new/page.tsx
+++ b/app/(root)/(standard)/workflows/new/page.tsx
@@ -1,10 +1,6 @@
-import WorkflowBuilder from "@/components/workflow/WorkflowBuilder";
+import NewWorkflowClient from "@/components/workflow/NewWorkflowClient";
 import { createWorkflow, WorkflowGraph } from "@/lib/actions/workflow.actions";
-import { ReactFlowProvider } from "@xyflow/react";
 import React from "react";
-import Modal from "@/components/modals/Modal";
-import IntegrationButtons from "@/components/workflow/IntegrationButtons";
-import analyticsTemplate from "@/templates/analytics-dashboard.json";
 
 export default function Page() {
   async function handleSave(graph: WorkflowGraph, name: string) {
@@ -13,26 +9,5 @@ export default function Page() {
     return { id: workflow.id.toString() };
   }
 
-  const initialGraph = analyticsTemplate.graph as WorkflowGraph;
-
-  return (
-    <div className="relative -top-12 space-y-4">
-      <IntegrationButtons />
-      <p className="mx-2 text-sm">
-        This builder loads the Analytics Dashboard template. The default flow
-        collects Shopify and social metrics, aggregates the data, generates a
-        report, then shares it through Gmail and Slack. Use it as a starting
-        point for the unified analytics dashboard described in the roadmap.
-      </p>
-      <div className="w-[100%] h-full border-2 border-blue overscroll-none">
-        <ReactFlowProvider>
-          <Modal />
-          <WorkflowBuilder
-            onSave={handleSave}
-            initialGraph={initialGraph}
-          />
-        </ReactFlowProvider>
-      </div>
-    </div>
-  );
+  return <NewWorkflowClient onSave={handleSave} />;
 }

--- a/components/workflow/NewWorkflowClient.tsx
+++ b/components/workflow/NewWorkflowClient.tsx
@@ -1,0 +1,44 @@
+"use client";
+
+import React, { useState } from "react";
+import WorkflowBuilder from "./WorkflowBuilder";
+import TemplatePicker from "./TemplatePicker";
+import IntegrationButtons from "./IntegrationButtons";
+import Modal from "@/components/modals/Modal";
+import { ReactFlowProvider } from "@xyflow/react";
+import { WorkflowGraph } from "@/lib/actions/workflow.actions";
+import analyticsTemplate from "@/templates/analytics-dashboard.json";
+
+export default function NewWorkflowClient({
+  onSave,
+}: {
+  onSave: (graph: WorkflowGraph, name: string) => Promise<{ id: string }>;
+}) {
+  const [graph, setGraph] = useState<WorkflowGraph>(
+    analyticsTemplate.graph as WorkflowGraph
+  );
+  const [template, setTemplate] = useState<string>(analyticsTemplate.name);
+
+  const handleTemplateSelect = (g: WorkflowGraph, name: string) => {
+    setGraph(g);
+    setTemplate(name);
+  };
+
+  return (
+    <div className="relative -top-12 space-y-4">
+      <IntegrationButtons />
+      <TemplatePicker selected={template} onSelect={handleTemplateSelect} />
+      <p className="mx-2 text-sm">
+        Select a starter template or build from scratch. The analytics template
+        collects Shopify and social metrics, aggregates the data, generates a
+        report, then shares it through Gmail and Slack.
+      </p>
+      <div className="w-[100%] h-full border-2 border-blue overscroll-none">
+        <ReactFlowProvider>
+          <Modal />
+          <WorkflowBuilder onSave={onSave} initialGraph={graph} />
+        </ReactFlowProvider>
+      </div>
+    </div>
+  );
+}

--- a/components/workflow/TemplatePicker.tsx
+++ b/components/workflow/TemplatePicker.tsx
@@ -1,0 +1,41 @@
+import React from "react";
+import { WorkflowGraph } from "@/lib/actions/workflow.actions";
+import analyticsTemplate from "@/templates/analytics-dashboard.json";
+import clickCounter from "@/templates/click-counter.json";
+import conditionalBranch from "@/templates/conditional-branch.json";
+
+interface Template {
+  name: string;
+  description: string;
+  graph: WorkflowGraph;
+}
+
+const templates: Template[] = [
+  analyticsTemplate as Template,
+  clickCounter as Template,
+  conditionalBranch as Template,
+];
+
+export default function TemplatePicker({
+  onSelect,
+  selected,
+}: {
+  onSelect: (graph: WorkflowGraph, name: string) => void;
+  selected: string;
+}) {
+  return (
+    <div className="space-x-2 mb-4">
+      {templates.map((t) => (
+        <button
+          key={t.name}
+          className={`border px-2 py-1 rounded ${
+            selected === t.name ? "bg-blue-500 text-white" : ""
+          }`}
+          onClick={() => onSelect(t.graph, t.name)}
+        >
+          {t.name}
+        </button>
+      ))}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add `TemplatePicker` and `NewWorkflowClient` components
- use them on `/workflows/new` to let users pick a starter workflow

## Testing
- `yarn lint`


------
https://chatgpt.com/codex/tasks/task_e_686d8cd7541c8329bc6f3613ffc15d95