### PR TITLE
Add workflow run mode

### DIFF
--- a/components/workflow/NewWorkflowClient.tsx
+++ b/components/workflow/NewWorkflowClient.tsx
@@ -1,12 +1,18 @@
 "use client";
 
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import WorkflowBuilder from "./WorkflowBuilder";
 import TemplatePicker from "./TemplatePicker";
 import IntegrationButtons from "./IntegrationButtons";
 import Modal from "@/components/modals/Modal";
 import { ReactFlowProvider } from "@xyflow/react";
 import { WorkflowGraph } from "@/lib/actions/workflow.actions";
+import { WorkflowExecutionProvider } from "./WorkflowExecutionContext";
+import { registerWorkflowAction } from "@/lib/workflowActions";
+import { fetchIntegrations } from "@/lib/actions/integration.actions";
+import SendEmailModal from "@/components/modals/SendEmailModal";
+import useStore from "@/lib/reactflow/store";
+import { useShallow } from "zustand/react/shallow";
 import analyticsTemplate from "@/templates/analytics-dashboard.json";
 
 export default function NewWorkflowClient({
@@ -24,6 +30,30 @@ export default function NewWorkflowClient({
     setTemplate(name);
   };
 
+  const { openModal } = useStore(
+    useShallow((state) => ({ openModal: state.openModal }))
+  );
+
+  useEffect(() => {
+    fetchIntegrations().then((list) => {
+      const gmail = list.find((i) => i.service === "gmail");
+      if (gmail) {
+        try {
+          const cred = JSON.parse(gmail.credential);
+          if (cred.email && cred.accessToken) {
+            registerWorkflowAction("openEmailModal", async () => {
+              openModal(
+                <SendEmailModal from={cred.email} accessToken={cred.accessToken} />
+              );
+            });
+          }
+        } catch {
+          // ignore parse errors
+        }
+      }
+    });
+  }, [openModal]);
+
   return (
     <div className="relative -top-12 space-y-4">
       <IntegrationButtons />
@@ -34,10 +64,12 @@ export default function NewWorkflowClient({
         report, then shares it through Gmail and Slack.
       </p>
       <div className="w-[100%] h-full border-2 border-blue overscroll-none">
-        <ReactFlowProvider>
-          <Modal />
-          <WorkflowBuilder onSave={onSave} initialGraph={graph} />
-        </ReactFlowProvider>
+        <WorkflowExecutionProvider>
+          <ReactFlowProvider>
+            <Modal />
+            <WorkflowBuilder onSave={onSave} initialGraph={graph} />
+          </ReactFlowProvider>
+        </WorkflowExecutionProvider>
       </div>
     </div>
   );

--- a/components/workflow/WorkflowBuilder.tsx
+++ b/components/workflow/WorkflowBuilder.tsx
@@ -31,6 +31,7 @@ import { registerIntegrationTriggerTypes } from "@/lib/registerIntegrationTrigge
 import { listWorkflowTriggers } from "@/lib/workflowTriggers";
 import { IntegrationApp } from "@/lib/integrations/types";
 import ScheduleForm from "./ScheduleForm";
+import WorkflowRunner from "./WorkflowRunner";
 
 import { Input } from "@/components/ui/input";
 
@@ -56,6 +57,7 @@ export default function WorkflowBuilder({ initialGraph, onSave }: Props) {
   const [name, setName] = useState("New Workflow");
   const [selectedNode, setSelectedNode] = useState<Node | null>(null);
   const [selectedEdge, setSelectedEdge] = useState<Edge | null>(null);
+  const [showRunner, setShowRunner] = useState(false);
   const [actions, setActions] = useState<string[]>([]);
   const [triggers, setTriggers] = useState<string[]>([]);
   const wrapperRef = useRef<HTMLDivElement>(null);
@@ -216,6 +218,7 @@ export default function WorkflowBuilder({ initialGraph, onSave }: Props) {
           onChange={(e) => importJson(e.target.files)}
         />
         <Button onClick={exportJson}>Export</Button>
+        <Button onClick={() => setShowRunner((s) => !s)}>Run</Button>
         <Button onClick={save}>Save</Button>
         {workflowId && (
           <div className="space-y-2">
@@ -287,6 +290,12 @@ export default function WorkflowBuilder({ initialGraph, onSave }: Props) {
           setSelectedEdge(null);
         }}
       />
+      {showRunner && (
+        <div className="absolute inset-0 bg-white/90 z-20 overflow-auto p-4 space-y-2">
+          <Button onClick={() => setShowRunner(false)}>Close Runner</Button>
+          <WorkflowRunner graph={{ nodes, edges }} />
+        </div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- register Gmail send-email modal action in new workflow page
- wrap new workflow builder with execution context
- add Run button to WorkflowBuilder for quick testing

## Testing
- `npm run lint`
- `npm test --silent` *(fails: Can't reach database server)*

------
https://chatgpt.com/codex/tasks/task_e_686db76ee35c8329958a2cc696d4bd6c