### PR TITLE
Improve RandomDataPlotExample

### DIFF
--- a/components/workflow/examples/RandomDataPlotExample.tsx
+++ b/components/workflow/examples/RandomDataPlotExample.tsx
@@ -1,122 +1,143 @@
 "use client";
 
-import { useCallback, useState } from "react";
-import { NodeProps, NodeTypes } from "@xyflow/react";
+import { useCallback, useEffect, useState } from "react";
+import {
+  ReactFlow,
+  Background,
+  MiniMap,
+  Controls,
+  BackgroundVariant,
+  useNodesState,
+  useEdgesState,
+  addEdge,
+  Connection,
+  NodeTypes,
+  Node,
+  Edge,
+} from "@xyflow/react";
+import { Button } from "@/components/ui/button";
 import { WorkflowGraph } from "@/lib/workflowExecutor";
 import {
   WorkflowExecutionProvider,
   useWorkflowExecution,
 } from "../WorkflowExecutionContext";
-import { WorkflowRunnerInner } from "../WorkflowRunner";
-import { ReactFlow } from "@xyflow/react";
-import { Background,MiniMap,BackgroundVariant } from "@xyflow/react";
-import WorkflowBuilder from "../WorkflowBuilder";
-import NewWorkflowClient from "../NewWorkflowClient";
-function TriggerNode({ data }: NodeProps) {
-  return (
-    <div className="p-2 bg-white border rounded">
-      <button className="nodrag" onClick={data.onTrigger}>
-        Generate Data
-      </button>
-    </div>
-  );
-}
-
-function GraphNode({ data }: NodeProps) {
-  const points: [number, number][] = data.points || [];
-  const width = 200;
-  const height = 100;
-  if (points.length === 0) {
-    return <div className="p-2 bg-white border rounded">No Data</div>;
-  }
-  const xs = points.map((p) => p[0]);
-  const ys = points.map((p) => p[1]);
-  const minX = Math.min(...xs);
-  const maxX = Math.max(...xs);
-  const minY = Math.min(...ys);
-  const maxY = Math.max(...ys);
-  const scaleX = (x: number) => ((x - minX) / (maxX - minX || 1)) * width;
-  const scaleY = (y: number) => height - ((y - minY) / (maxY - minY || 1)) * height;
-  const path = points
-    .map((p, i) => `${i === 0 ? "M" : "L"}${scaleX(p[0])},${scaleY(p[1])}`)
-    .join(" ");
-  return (
-    <div className="p-2 bg-white border rounded">
-      <svg width={width} height={height}>
-        <path d={path} fill="none" stroke="black" />
-        {points.map((p, i) => (
-          <circle key={i} cx={scaleX(p[0])} cy={scaleY(p[1])} r={3} fill="red" />
-        ))}
-      </svg>
-    </div>
-  );
-}
+import { TriggerNode, ActionNode } from "../CustomNodes";
 
 function ExampleInner() {
   const { run } = useWorkflowExecution();
   const [points, setPoints] = useState<[number, number][]>([]);
+  const [nodes, setNodes, onNodesChange] = useNodesState<Node[]>([]);
+  const [edges, setEdges, onEdgesChange] = useEdgesState<Edge[]>([]);
+  const [height, setHeight] = useState(300);
+  const [bgVariant, setBgVariant] = useState<BackgroundVariant>(BackgroundVariant.Dots);
 
-  const handleTrigger = useCallback(() => {
-    const newPoints = Array.from({ length: 12 }, (_, i) => [
-      i + 1,
-      Math.random() * 100,
-    ]) as [number, number][];
-    const actions = {
-      generate: async () => {
-        setPoints(newPoints);
-      },
-      show: async () => {},
+  useEffect(() => {
+    addTriggerNode();
+    addActionNode();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const onConnect = useCallback((connection: Connection) => {
+    setEdges((eds) => addEdge(connection, eds));
+  }, []);
+
+  const handleTrigger = useCallback(
+    (id: string) => {
+      const newPoints = Array.from({ length: 12 }, (_, i) => [
+        i + 1,
+        Math.random() * 100,
+      ]) as [number, number][];
+      setPoints(newPoints);
+      const updatedNodes = nodes.map((n) =>
+        n.type === "action" ? { ...n, data: { ...n.data, points: newPoints } } : n
+      );
+      setNodes(updatedNodes);
+      const startIndex = updatedNodes.findIndex((n) => n.id === id);
+      const ordered =
+        startIndex > -1
+          ? [updatedNodes[startIndex], ...updatedNodes.filter((_, i) => i !== startIndex)]
+          : updatedNodes;
+      const actions = { generate: async () => {}, show: async () => {} };
+      run({ nodes: ordered as any, edges }, actions);
+    },
+    [nodes, edges, run]
+  );
+
+  const addTriggerNode = useCallback(() => {
+    const id = `trigger-${nodes.length + 1}`;
+    const newNode: Node = {
+      id,
+      type: "trigger",
+      position: { x: 50 * nodes.length, y: 0 },
+      data: { trigger: "onClick", onTrigger: () => handleTrigger(id) },
     };
-    const graph: WorkflowGraph = {
-      nodes: [
-        {
-          id: "trigger",
-          type: "trigger",
-          action: "generate",
-          data: { onTrigger: handleTrigger },
-          position: { x: 0, y: 0 },
-        },
-        {
-          id: "graph",
-          type: "graph",
-          action: "show",
-          data: { points: newPoints },
-          position: { x: 150, y: 0 },
-        },
-      ],
-      edges: [{ id: "e1", source: "trigger", target: "graph" }],
+    setNodes((nds) => nds.concat(newNode));
+  }, [nodes, handleTrigger, setNodes]);
+
+  const addActionNode = useCallback(() => {
+    const id = `action-${nodes.length + 1}`;
+    const newNode: Node = {
+      id,
+      type: "action",
+      position: { x: 150 + 50 * nodes.length, y: 0 },
+      data: { action: "createRandomLineGraph", points },
     };
-    run(graph, actions);
-  }, [run]);
+    setNodes((nds) => nds.concat(newNode));
+  }, [nodes, points, setNodes]);
 
-  const graph: WorkflowGraph = {
-    nodes: [
-      {
-        id: "trigger",
-        type: "trigger",
-        action: "generate",
-        data: { onTrigger: handleTrigger },
-        position: { x: 0, y: 0 },
-      },
-      {
-        id: "graph",
-        type: "graph",
-        action: "show",
-        data: { points },
-        position: { x: 150, y: 0 },
-      },
-    ],
-    edges: [{ id: "e1", source: "trigger", target: "graph" }],
-  };
+  const nodeTypes: NodeTypes = { trigger: TriggerNode, action: ActionNode };
 
-  const nodeTypes: NodeTypes = { trigger: TriggerNode, graph: GraphNode };
-
-  return <WorkflowRunnerInner  graph={graph} nodeTypes={nodeTypes} />;
+  return (
+    <div className="space-y-2">
+      <div className="flex gap-4">
+        <label className="flex items-center gap-1 text-sm">
+          Height:
+          <input
+            type="number"
+            value={height}
+            onChange={(e) => setHeight(Number(e.target.value))}
+            className="border p-1 w-20"
+          />
+        </label>
+        <label className="flex items-center gap-1 text-sm">
+          Background:
+          <select
+            value={bgVariant}
+            onChange={(e) => setBgVariant(e.target.value as BackgroundVariant)}
+            className="border p-1"
+          >
+            <option value={BackgroundVariant.Dots}>Dots</option>
+            <option value={BackgroundVariant.Lines}>Lines</option>
+            <option value={BackgroundVariant.Cross}>Cross</option>
+          </select>
+        </label>
+      </div>
+      <div style={{ height }} className="relative border">
+        <div className="absolute left-2 top-2 z-10 flex flex-col gap-2">
+          <Button onClick={addTriggerNode}>Add Trigger</Button>
+          <Button onClick={addActionNode}>Add Action</Button>
+        </div>
+        <ReactFlow
+          nodes={nodes}
+          edges={edges}
+          onNodesChange={onNodesChange}
+          onEdgesChange={onEdgesChange}
+          onConnect={onConnect}
+          nodeTypes={nodeTypes}
+          fitView
+        >
+          <Background variant={bgVariant} />
+          <MiniMap />
+          <Controls />
+        </ReactFlow>
+      </div>
+    </div>
+  );
 }
 
 export default function RandomDataPlotExample() {
   return (
-    <WorkflowExecutionProvider >
+    <WorkflowExecutionProvider>
       <ExampleInner />
     </WorkflowExecutionProvider>
   );


### PR DESCRIPTION
## Summary
- make RandomDataPlotExample customizable
- allow adding trigger/action nodes and connecting them

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_686dc09ef6648329b882b530d55384dd