### PR TITLE
Fix RandomDataPlotExample

### DIFF
--- a/components/workflow/WorkflowRunner.tsx
+++ b/components/workflow/WorkflowRunner.tsx
@@ -12,7 +12,7 @@ import {
   useWorkflowExecution,
 } from "./WorkflowExecutionContext";
 import WorkflowViewer from "./WorkflowViewer";
-import { NodeTypes } from "@xyflow/react";
+import { NodeTypes, BackgroundVariant } from "@xyflow/react";
 import { TriggerNode, ActionNode } from "./CustomNodes";
 import { supabase } from "@/lib/supabaseclient";
 import {
@@ -26,9 +26,17 @@ interface Props {
   graph: WorkflowGraph;
   nodeTypes?: NodeTypes;
   workflowId?: string;
+  height?: number;
+  bgVariant?: BackgroundVariant;
 }
 
-export function WorkflowRunnerInner({ graph, nodeTypes, workflowId }: Props) {
+export function WorkflowRunnerInner({
+  graph,
+  nodeTypes,
+  workflowId,
+  height,
+  bgVariant,
+}: Props) {
   const { run, pause, resume, paused, running, logs, executed } =
     useWorkflowExecution();
   const [remoteLogs, setRemoteLogs] = useState<string[]>([]);
@@ -128,6 +136,8 @@ export function WorkflowRunnerInner({ graph, nodeTypes, workflowId }: Props) {
       <WorkflowViewer
         graph={computedGraph}
         nodeTypes={nodeTypes ?? { trigger: TriggerNode, action: ActionNode }}
+        height={height}
+        bgVariant={bgVariant}
       />
       <div className="border h-32 overflow-auto p-2 text-sm">
         {logs.map((log, i) => (
@@ -143,10 +153,22 @@ export function WorkflowRunnerInner({ graph, nodeTypes, workflowId }: Props) {
   );
 }
 
-export default function WorkflowRunner({ graph, nodeTypes, workflowId }: Props) {
+export default function WorkflowRunner({
+  graph,
+  nodeTypes,
+  workflowId,
+  height,
+  bgVariant,
+}: Props) {
   return (
     <WorkflowExecutionProvider>
-      <WorkflowRunnerInner graph={graph} nodeTypes={nodeTypes} workflowId={workflowId} />
+      <WorkflowRunnerInner
+        graph={graph}
+        nodeTypes={nodeTypes}
+        workflowId={workflowId}
+        height={height}
+        bgVariant={bgVariant}
+      />
     </WorkflowExecutionProvider>
   );
 }

--- a/components/workflow/WorkflowViewer.tsx
+++ b/components/workflow/WorkflowViewer.tsx
@@ -8,6 +8,7 @@ import {
   Node,
   Edge,
   NodeTypes,
+  BackgroundVariant,
 } from "@xyflow/react";
 import "@xyflow/react/dist/style.css";
 import { WorkflowGraph } from "@/lib/workflowExecutor";
@@ -16,9 +17,16 @@ import { useWorkflowExecution } from "./WorkflowExecutionContext";
 interface ViewerProps {
   graph: WorkflowGraph;
   nodeTypes?: NodeTypes;
+  height?: number;
+  bgVariant?: BackgroundVariant;
 }
 
-export default function WorkflowViewer({ graph, nodeTypes }: ViewerProps) {
+export default function WorkflowViewer({
+  graph,
+  nodeTypes,
+  height = 300,
+  bgVariant = BackgroundVariant.Dots,
+}: ViewerProps) {
   const { current, graph: execGraph } = useWorkflowExecution();
   const [nodes, setNodes] = useState<Node[]>(graph.nodes as Node[]);
   const [edges, setEdges] = useState<Edge[]>(graph.edges as Edge[]);
@@ -41,9 +49,9 @@ export default function WorkflowViewer({ graph, nodeTypes }: ViewerProps) {
   }, [current]);
 
   return (
-    <div style={{ height: 300 }}>
+    <div style={{ height }}>
       <ReactFlow nodes={nodes} edges={edges} nodeTypes={nodeTypes}>
-        <Background />
+        <Background variant={bgVariant} />
         <Controls />
       </ReactFlow>
     </div>

--- a/components/workflow/examples/RandomDataPlotExample.tsx
+++ b/components/workflow/examples/RandomDataPlotExample.tsx
@@ -1,91 +1,114 @@
 "use client";
 
-import { useCallback, useEffect, useState } from "react";
-import {
-  ReactFlow,
-  Background,
-  MiniMap,
-  Controls,
-  BackgroundVariant,
-  useNodesState,
-  useEdgesState,
-  addEdge,
-  Connection,
-  NodeTypes,
-  Node,
-  Edge,
-} from "@xyflow/react";
-import { Button } from "@/components/ui/button";
+import { useCallback, useState } from "react";
+import { NodeProps, NodeTypes, BackgroundVariant } from "@xyflow/react";
 import { WorkflowGraph } from "@/lib/workflowExecutor";
 import {
   WorkflowExecutionProvider,
   useWorkflowExecution,
 } from "../WorkflowExecutionContext";
-import { TriggerNode, ActionNode } from "../CustomNodes";
+import { WorkflowRunnerInner } from "../WorkflowRunner";
+
+function TriggerNode({ data }: NodeProps) {
+  return (
+    <div className="p-2 bg-white border rounded">
+      <button className="nodrag" onClick={data.onTrigger}>
+        Generate Data
+      </button>
+    </div>
+  );
+}
+
+function GraphNode({ data }: NodeProps) {
+  const points: [number, number][] = data.points || [];
+  const width = 200;
+  const height = 100;
+  if (points.length === 0) {
+    return <div className="p-2 bg-white border rounded">No Data</div>;
+  }
+  const xs = points.map((p) => p[0]);
+  const ys = points.map((p) => p[1]);
+  const minX = Math.min(...xs);
+  const maxX = Math.max(...xs);
+  const minY = Math.min(...ys);
+  const maxY = Math.max(...ys);
+  const scaleX = (x: number) => ((x - minX) / (maxX - minX || 1)) * width;
+  const scaleY = (y: number) => height - ((y - minY) / (maxY - minY || 1)) * height;
+  const path = points
+    .map((p, i) => `${i === 0 ? "M" : "L"}${scaleX(p[0])},${scaleY(p[1])}`)
+    .join(" ");
+  return (
+    <div className="p-2 bg-white border rounded">
+      <svg width={width} height={height}>
+        <path d={path} fill="none" stroke="black" />
+        {points.map((p, i) => (
+          <circle key={i} cx={scaleX(p[0])} cy={scaleY(p[1])} r={3} fill="red" />
+        ))}
+      </svg>
+    </div>
+  );
+}
 
 function ExampleInner() {
   const { run } = useWorkflowExecution();
   const [points, setPoints] = useState<[number, number][]>([]);
-  const [nodes, setNodes, onNodesChange] = useNodesState<Node[]>([]);
-  const [edges, setEdges, onEdgesChange] = useEdgesState<Edge[]>([]);
   const [height, setHeight] = useState(300);
   const [bgVariant, setBgVariant] = useState<BackgroundVariant>(BackgroundVariant.Dots);
 
-  useEffect(() => {
-    addTriggerNode();
-    addActionNode();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
-
-  const onConnect = useCallback((connection: Connection) => {
-    setEdges((eds) => addEdge(connection, eds));
-  }, []);
-
-  const handleTrigger = useCallback(
-    (id: string) => {
-      const newPoints = Array.from({ length: 12 }, (_, i) => [
-        i + 1,
-        Math.random() * 100,
-      ]) as [number, number][];
-      setPoints(newPoints);
-      const updatedNodes = nodes.map((n) =>
-        n.type === "action" ? { ...n, data: { ...n.data, points: newPoints } } : n
-      );
-      setNodes(updatedNodes);
-      const startIndex = updatedNodes.findIndex((n) => n.id === id);
-      const ordered =
-        startIndex > -1
-          ? [updatedNodes[startIndex], ...updatedNodes.filter((_, i) => i !== startIndex)]
-          : updatedNodes;
-      const actions = { generate: async () => {}, show: async () => {} };
-      run({ nodes: ordered as any, edges }, actions);
-    },
-    [nodes, edges, run]
-  );
-
-  const addTriggerNode = useCallback(() => {
-    const id = `trigger-${nodes.length + 1}`;
-    const newNode: Node = {
-      id,
-      type: "trigger",
-      position: { x: 50 * nodes.length, y: 0 },
-      data: { trigger: "onClick", onTrigger: () => handleTrigger(id) },
+  const handleTrigger = useCallback(() => {
+    const newPoints = Array.from({ length: 12 }, (_, i) => [
+      i + 1,
+      Math.random() * 100,
+    ]) as [number, number][];
+    const actions = {
+      generate: async () => {
+        setPoints(newPoints);
+      },
+      show: async () => {},
     };
-    setNodes((nds) => nds.concat(newNode));
-  }, [nodes, handleTrigger, setNodes]);
-
-  const addActionNode = useCallback(() => {
-    const id = `action-${nodes.length + 1}`;
-    const newNode: Node = {
-      id,
-      type: "action",
-      position: { x: 150 + 50 * nodes.length, y: 0 },
-      data: { action: "createRandomLineGraph", points },
+    const graph: WorkflowGraph = {
+      nodes: [
+        {
+          id: "trigger",
+          type: "trigger",
+          action: "generate",
+          data: { onTrigger: handleTrigger },
+          position: { x: 0, y: 0 },
+        },
+        {
+          id: "graph",
+          type: "graph",
+          action: "show",
+          data: { points: newPoints },
+          position: { x: 150, y: 0 },
+        },
+      ],
+      edges: [{ id: "e1", source: "trigger", target: "graph" }],
     };
-    setNodes((nds) => nds.concat(newNode));
-  }, [nodes, points, setNodes]);
+    run(graph, actions);
+  }, [run]);
 
-  const nodeTypes: NodeTypes = { trigger: TriggerNode, action: ActionNode };
+  const graph: WorkflowGraph = {
+    nodes: [
+      {
+        id: "trigger",
+        type: "trigger",
+        action: "generate",
+        data: { onTrigger: handleTrigger },
+        position: { x: 0, y: 0 },
+      },
+      {
+        id: "graph",
+        type: "graph",
+        action: "show",
+        data: { points },
+        position: { x: 150, y: 0 },
+      },
+    ],
+    edges: [{ id: "e1", source: "trigger", target: "graph" }],
+  };
+
+  const nodeTypes: NodeTypes = { trigger: TriggerNode, graph: GraphNode };
 
   return (
     <div className="space-y-2">
@@ -112,25 +135,12 @@ function ExampleInner() {
           </select>
         </label>
       </div>
-      <div style={{ height }} className="relative border">
-        <div className="absolute left-2 top-2 z-10 flex flex-col gap-2">
-          <Button onClick={addTriggerNode}>Add Trigger</Button>
-          <Button onClick={addActionNode}>Add Action</Button>
-        </div>
-        <ReactFlow
-          nodes={nodes}
-          edges={edges}
-          onNodesChange={onNodesChange}
-          onEdgesChange={onEdgesChange}
-          onConnect={onConnect}
-          nodeTypes={nodeTypes}
-          fitView
-        >
-          <Background variant={bgVariant} />
-          <MiniMap />
-          <Controls />
-        </ReactFlow>
-      </div>
+      <WorkflowRunnerInner
+        graph={graph}
+        nodeTypes={nodeTypes}
+        height={height}
+        bgVariant={bgVariant}
+      />
     </div>
   );
 }
@@ -142,4 +152,3 @@ export default function RandomDataPlotExample() {
     </WorkflowExecutionProvider>
   );
 }
-


### PR DESCRIPTION
## Summary
- allow WorkflowViewer canvas height and background variant to be customized
- pass these options through WorkflowRunner
- restore simple RandomDataPlotExample with controls for canvas height and background style

## Testing
- `yarn install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_686dc54e9d0083299b13f3ab75f27a3e