### PR TITLE
Fix ReactFlow styling for RandomDataPlotExample

### DIFF
--- a/components/workflow/examples/RandomDataPlotExample.tsx
+++ b/components/workflow/examples/RandomDataPlotExample.tsx
@@ -15,6 +15,7 @@ import {
   Background,
   Controls,
 } from "@xyflow/react";
+import "@xyflow/react/dist/style.css";
 import { WorkflowGraph } from "@/lib/workflowExecutor";
 import {
   WorkflowExecutionProvider,


### PR DESCRIPTION
## Summary
- include ReactFlow default styles in `RandomDataPlotExample`

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_686dea35569083298b051cdff61f2f4c