### PR TITLE
Add send email action

### DIFF
--- a/lib/registerDefaultWorkflowActions.ts
+++ b/lib/registerDefaultWorkflowActions.ts
@@ -1,7 +1,19 @@
 import { registerWorkflowAction } from "@/lib/workflowActions";
+import { sendEmail } from "@/lib/actions/gmail.actions";
+
+const from = process.env.GMAIL_FROM ?? "";
+const to = process.env.GMAIL_TO ?? "";
+const subject = process.env.GMAIL_SUBJECT ?? "";
+const message = process.env.GMAIL_MESSAGE ?? "";
+const accessToken = process.env.GMAIL_ACCESS_TOKEN ?? "";
 
 export function registerDefaultWorkflowActions() {
   registerWorkflowAction("createRandomLineGraph", async () => {
     // action handled in WorkflowRunner
   });
+  registerWorkflowAction("gmail:sendEmail", async () => {
+    if (!from || !to || !accessToken) return;
+    await sendEmail({ from, to, subject, message, accessToken });
+  });
 }
+

--- a/tests/registerDefaultWorkflowActions.test.ts
+++ b/tests/registerDefaultWorkflowActions.test.ts
@@ -4,6 +4,8 @@ import { registerDefaultWorkflowActions } from "@/lib/registerDefaultWorkflowAct
 test("registers default actions", () => {
   registerDefaultWorkflowActions();
   expect(getWorkflowAction("createRandomLineGraph")).toBeDefined();
+  expect(getWorkflowAction("gmail:sendEmail")).toBeDefined();
   expect(getWorkflowAction("github:latestIssue")).toBeUndefined();
   expect(getWorkflowAction("slack:sendMessage")).toBeUndefined();
 });
+


### PR DESCRIPTION
## Summary
- register default `gmail:sendEmail` workflow action
- expect new action in default actions test

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm test` *(fails: `jest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ee87dfff083299ef90f3717d981ba