### PR TITLE
Add workflow listing

### DIFF
--- a/app/(root)/(standard)/workflows/page.tsx
+++ b/app/(root)/(standard)/workflows/page.tsx
@@ -1,0 +1,23 @@
+import Link from "next/link";
+import { listWorkflows } from "@/lib/actions/workflow.actions";
+
+export const metadata = {
+  title: "My Workflows",
+  description: "List of saved workflows",
+};
+
+export default async function Page() {
+  const workflows = await listWorkflows();
+  return (
+    <section className="p-4 space-y-4">
+      <h1 className="text-2xl font-bold">My Workflows</h1>
+      <ul className="space-y-2">
+        {workflows.map((w) => (
+          <li key={w.id.toString()} className="border p-2 rounded">
+            <Link href={`/workflows/${w.id}`}>{w.name}</Link>
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+}

--- a/app/api/workflows/route.ts
+++ b/app/api/workflows/route.ts
@@ -1,0 +1,7 @@
+import { listWorkflows } from "@/lib/actions/workflow.actions";
+import { NextResponse } from "next/server";
+
+export async function GET() {
+  const workflows = await listWorkflows();
+  return NextResponse.json(workflows);
+}

--- a/lib/actions/workflow.actions.ts
+++ b/lib/actions/workflow.actions.ts
@@ -115,3 +115,13 @@ export async function fetchWorkflow({
     },
   });
 }
+
+export async function listWorkflows() {
+  const user = await getUserFromCookies();
+  if (!user) throw new Error("User not authenticated");
+  return prisma.workflow.findMany({
+    where: { owner_id: user.userId! },
+    select: { id: true, name: true, created_at: true },
+    orderBy: { created_at: "desc" },
+  });
+}

--- a/tests/listWorkflows.test.ts
+++ b/tests/listWorkflows.test.ts
@@ -1,0 +1,24 @@
+import { listWorkflows } from "@/lib/actions/workflow.actions";
+
+var mockPrisma: any;
+
+jest.mock("@/lib/prismaclient", () => {
+  mockPrisma = { workflow: { findMany: jest.fn() } };
+  return { prisma: mockPrisma };
+});
+
+jest.mock("@/lib/serverutils", () => ({
+  getUserFromCookies: jest.fn(async () => ({ userId: BigInt(1) })),
+}));
+
+test("listWorkflows queries user workflows", async () => {
+  const now = new Date();
+  mockPrisma.workflow.findMany.mockResolvedValue([{ id: BigInt(1), name: "A", created_at: now }]);
+  const result = await listWorkflows();
+  expect(mockPrisma.workflow.findMany).toHaveBeenCalledWith({
+    where: { owner_id: BigInt(1) },
+    select: { id: true, name: true, created_at: true },
+    orderBy: { created_at: "desc" },
+  });
+  expect(result[0].name).toBe("A");
+});


### PR DESCRIPTION
## Summary
- list workflows via `listWorkflows` server action
- expose API route `/api/workflows`
- add page to view saved workflows
- cover listing logic in tests

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686eefee4cb08329a1fd1eb8b12ea586