### PR TITLE
Add Slack integration and notes

### DIFF
--- a/docs/integration_automation_notes.md
+++ b/docs/integration_automation_notes.md
@@ -1,0 +1,33 @@
+# Integration Development Notes
+
+This document summarizes the steps followed when implementing the Slack integration for the Linear Workflow Builder. It can serve as a reference for automating future integrations.
+
+## Environment Setup
+- Run `yarn install` to install dependencies (Node.js 18+).
+- Lint the codebase with `npm run lint` before committing.
+
+## Integration Structure
+- Modules live in `integrations/` and export an `integration` object of type `IntegrationApp`.
+- Shared types are defined in `lib/integrations/types.ts`.
+- Actions and triggers are implemented under `lib/actions/`.
+- The loader in `lib/integrationLoader.ts` collects modules and is used by `registerIntegrationActions`.
+
+## Slack Integration Steps
+1. Create `integrations/SlackIntegration.ts` exporting an `IntegrationApp`.
+2. Implement actions using helper functions from `lib/actions` (e.g., `sendSlackMessage`).
+3. Actions receive `params` and `creds` objects to pass dynamic data and credentials.
+4. Credentials can be stored via the IntegrationConfigModal which POSTs to `/api/integrations`.
+5. Register the module by importing it through dynamic imports where workflows are executed or built.
+6. Include the action in workflow templates (`slack:sendMessage`).
+
+## Production Considerations
+- Store credentials securely in the database (see `docs/integrations.md`).
+- Use environment variables for API keys when possible.
+- Ensure actions return promises and handle errors gracefully.
+- Add unit tests for loaders and action registration.
+
+## Automation Ideas
+- Provide a CLI script that scaffolds a new integration module with boilerplate code.
+- Automatically generate action registration and sample template entries.
+- Validate required credentials and environment variables during setup.
+

--- a/integrations/SlackIntegration.ts
+++ b/integrations/SlackIntegration.ts
@@ -1,10 +1,23 @@
 import { IntegrationApp } from "@/lib/integrations/types";
-// Slack integration placeholder removed
+import { sendSlackMessage } from "@/lib/actions/slack.actions";
 
 export const integration: IntegrationApp = {
   name: "slack",
   description: "Post messages to Slack channels using a webhook",
-  actions: [],
+  actions: [
+    {
+      name: "sendMessage",
+      run: async (
+        params: { text: string },
+        creds: { webhookUrl: string }
+      ) => {
+        await sendSlackMessage({
+          webhookUrl: creds.webhookUrl,
+          text: params.text,
+        });
+      },
+    },
+  ],
 };
 
 export default integration;


### PR DESCRIPTION
## Summary
- implement Slack action using sendSlackMessage
- document steps for building integrations

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ef88c2f348329bff79f347a403aa6