### PR TITLE
Fix Google Sheets auth

### DIFF
--- a/components/pageflow/PageFlowBuilder.tsx
+++ b/components/pageflow/PageFlowBuilder.tsx
@@ -87,8 +87,8 @@ export default function PageFlowBuilder() {
       if (sheets) {
         try {
           const c = JSON.parse(sheets.credential);
-          if (c.apiKey) {
-            setSheetsKey(c.apiKey);
+          if (c.accessToken) {
+            setSheetsKey(c.accessToken);
           }
         } catch {
           if (typeof sheets.credential === "string") {
@@ -209,7 +209,7 @@ export default function PageFlowBuilder() {
             actionsMap[step.name] = async () => {
               const id = await createSpreadsheet({
                 title: step.title ?? "",
-                apiKey: sheetsKey,
+                accessToken: sheetsKey,
               });
               setLogs((l) => [...l, `Created spreadsheet ${id}`]);
             };
@@ -222,7 +222,7 @@ export default function PageFlowBuilder() {
                 spreadsheetId: step.spreadsheetId ?? "",
                 range: step.range ?? "",
                 values: vals,
-                apiKey: sheetsKey,
+                accessToken: sheetsKey,
               });
             };
           } else if (step.name === "googleSheets:readRange") {
@@ -230,7 +230,7 @@ export default function PageFlowBuilder() {
               const data = await readRange({
                 spreadsheetId: step.spreadsheetId ?? "",
                 range: step.range ?? "",
-                apiKey: sheetsKey,
+                accessToken: sheetsKey,
               });
               setLogs((l) => [...l, JSON.stringify(data ?? [])]);
             };
@@ -245,7 +245,7 @@ export default function PageFlowBuilder() {
       setLogs((l) => [...l, "Gmail credentials not found. Connect an account first."]);
     }
     if (!sheetsKey && steps.some((s) => s.type === "action" && s.name.startsWith("googleSheets:"))) {
-      setLogs((l) => [...l, "Google Sheets API key not found. Configure integration first."]);
+      setLogs((l) => [...l, "Google Sheets access token not found. Configure integration first."]);
     }
     const graph: WorkflowGraph = { nodes, edges };
     await executeWorkflow(graph, actionsMap, undefined, {}, (id) => {

--- a/docs/integration_automation_notes.md
+++ b/docs/integration_automation_notes.md
@@ -24,14 +24,14 @@ This document summarizes the steps followed when implementing the Slack integrat
 1. Create `integrations/GoogleSheetsIntegration.ts` exporting an `IntegrationApp`.
 2. Add helper functions in `lib/actions/googleSheets.actions.ts` using the `googleapis` library.
 3. Implement actions such as `appendRow` that call the Sheets API.
-4. Read the API key from `.env` (`GOOGLE_API_KEY`) or saved credentials via `IntegrationConfigModal`.
+4. Authenticate using an OAuth access token stored via `ConnectAccountModal` or environment variables (`GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET`, etc.).
 5. Register the module with `registerIntegrationActions` so workflow cards can use `googleSheets:appendRow`.
-6. Newly created spreadsheets are stored in the Google Drive of the account tied to the API key and appear under <https://docs.google.com/spreadsheets/>.
+6. Newly created spreadsheets are stored in the Google Drive of the authenticated account and appear under <https://docs.google.com/spreadsheets/>.
 7. Follow SRS requirements on security and reliability when handling spreadsheet data.
 
-## Production Considerations
+-## Production Considerations
 - Store credentials securely in the database (see `docs/integrations.md`).
-- Use environment variables for API keys when possible.
+- Use environment variables for tokens when possible.
 - Ensure actions return promises and handle errors gracefully.
 - Add unit tests for loaders and action registration.
 

--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -78,3 +78,18 @@ The Gmail integration uses OAuth tokens to send mail on a user's behalf.
    ```
 
 The workflow action `gmail:sendEmail` reads these credentials to send messages through the Gmail API.
+
+## Google Sheets API Setup
+
+Creating and modifying spreadsheets requires OAuth credentials.
+
+1. Create an OAuth client in the [Google Cloud Console](https://console.cloud.google.com/apis/credentials) and enable the **Google Sheets API**.
+2. Add the credentials to `.env` as `GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET`, and `GOOGLE_REFRESH_TOKEN`. Optionally set `GOOGLE_REDIRECT_URI`.
+3. Run `yarn sheets-token` to generate an access token. Save it using the **Connect Account** modal in the JSON format:
+   ```json
+   {
+     "accessToken": "<token from script>"
+   }
+   ```
+
+The workflow actions under `googleSheets:*` use this token to authenticate requests.

--- a/integrations/GoogleSheetsIntegration.ts
+++ b/integrations/GoogleSheetsIntegration.ts
@@ -13,32 +13,32 @@ export const integration: IntegrationApp = {
       name: "appendRow",
       run: async (
         params: { spreadsheetId: string; range: string; values: (string | number)[] },
-        creds: { apiKey: string }
+        creds: { accessToken: string }
       ) => {
         await appendRow({
           spreadsheetId: params.spreadsheetId,
           range: params.range,
           values: params.values,
-          apiKey: creds.apiKey,
+          accessToken: creds.accessToken,
         });
       },
     },
     {
       name: "createSpreadsheet",
-      run: async (params: { title: string }, creds: { apiKey: string }) => {
-        return await createSpreadsheet({ title: params.title, apiKey: creds.apiKey });
+      run: async (params: { title: string }, creds: { accessToken: string }) => {
+        return await createSpreadsheet({ title: params.title, accessToken: creds.accessToken });
       },
     },
     {
       name: "readRange",
       run: async (
         params: { spreadsheetId: string; range: string },
-        creds: { apiKey: string }
+        creds: { accessToken: string }
       ) => {
         return await readRange({
           spreadsheetId: params.spreadsheetId,
           range: params.range,
-          apiKey: creds.apiKey,
+          accessToken: creds.accessToken,
         });
       },
     },

--- a/lib/actions/googleSheets.actions.ts
+++ b/lib/actions/googleSheets.actions.ts
@@ -2,18 +2,24 @@
 
 import { google } from "googleapis";
 
+function getClient(accessToken: string) {
+  const auth = new google.auth.OAuth2();
+  auth.setCredentials({ access_token: accessToken });
+  return google.sheets({ version: "v4", auth });
+}
+
 export async function appendRow({
   spreadsheetId,
   range,
   values,
-  apiKey,
+  accessToken,
 }: {
   spreadsheetId: string;
   range: string;
   values: (string | number)[];
-  apiKey: string;
+  accessToken: string;
 }) {
-  const sheets = google.sheets({ version: "v4", auth: apiKey });
+  const sheets = getClient(accessToken);
   await sheets.spreadsheets.values.append({
     spreadsheetId,
     range,
@@ -26,12 +32,12 @@ export async function appendRow({
 
 export async function createSpreadsheet({
   title,
-  apiKey,
+  accessToken,
 }: {
   title: string;
-  apiKey: string;
+  accessToken: string;
 }) {
-  const sheets = google.sheets({ version: "v4", auth: apiKey });
+  const sheets = getClient(accessToken);
   const res = await sheets.spreadsheets.create({
     requestBody: {
       properties: { title },
@@ -43,13 +49,13 @@ export async function createSpreadsheet({
 export async function readRange({
   spreadsheetId,
   range,
-  apiKey,
+  accessToken,
 }: {
   spreadsheetId: string;
   range: string;
-  apiKey: string;
+  accessToken: string;
 }) {
-  const sheets = google.sheets({ version: "v4", auth: apiKey });
+  const sheets = getClient(accessToken);
   const res = await sheets.spreadsheets.values.get({
     spreadsheetId,
     range,

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "test": "jest",
     "postinstall": "prisma generate",
     "seed": "tsx --env-file=.env scripts/seed.ts",
-    "gmail-token": "tsx --env-file=.env scripts/gmail-token.ts"
+    "gmail-token": "tsx --env-file=.env scripts/gmail-token.ts",
+    "sheets-token": "tsx --env-file=.env scripts/google-sheets-token.ts"
   },
   "dependencies": {
     "@gsap/react": "^2.1.1",

--- a/scripts/google-sheets-token.ts
+++ b/scripts/google-sheets-token.ts
@@ -1,0 +1,34 @@
+import { google } from "googleapis";
+
+async function fetchAccessToken() {
+  const clientId = process.env.GOOGLE_CLIENT_ID;
+  const clientSecret = process.env.GOOGLE_CLIENT_SECRET;
+
+  if (!clientId || !clientSecret) {
+    console.error("GOOGLE_CLIENT_ID or GOOGLE_CLIENT_SECRET is not set");
+    process.exit(1);
+  }
+
+  const client = new google.auth.OAuth2(
+    clientId,
+    clientSecret,
+    process.env.GOOGLE_REDIRECT_URI ?? "http://localhost"
+  );
+
+  const refreshToken = process.env.GOOGLE_REFRESH_TOKEN;
+  if (!refreshToken) {
+    console.error("GOOGLE_REFRESH_TOKEN is not set");
+    process.exit(1);
+  }
+
+  client.setCredentials({ refresh_token: refreshToken });
+  const { token } = await client.getAccessToken();
+  if (!token) {
+    console.error("Failed to retrieve access token");
+    process.exit(1);
+  }
+
+  console.log(token);
+}
+
+fetchAccessToken();


### PR DESCRIPTION
## Summary
- use OAuth tokens for Google Sheets actions
- update integration to accept access tokens
- adjust workflow builder to load/use token
- document Google Sheets API setup and token script
- add `sheets-token` script

## Testing
- `yarn install`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_686f1c943ab8832988e7ac95261ead87