### PR TITLE
Validate Bigcapital URL protocol

### DIFF
--- a/lib/actions/bigcapital.actions.ts
+++ b/lib/actions/bigcapital.actions.ts
@@ -2,7 +2,16 @@
 
 const BASE_URL = process.env.BIGCAPITAL_URL || "http://localhost:4000";
 
+function assertValidUrl() {
+  if (!/^https?:\/\//.test(BASE_URL)) {
+    throw new Error(
+      "BIGCAPITAL_URL must start with http:// or https://"
+    );
+  }
+}
+
 async function request(path: string, method: string, token: string, body?: any) {
+  assertValidUrl();
   const res = await fetch(`${BASE_URL}${path}`, {
     method,
     headers: {

--- a/tests/bigcapital.actions.test.ts
+++ b/tests/bigcapital.actions.test.ts
@@ -1,0 +1,13 @@
+describe("bigcapital actions", () => {
+  afterEach(() => {
+    delete process.env.BIGCAPITAL_URL;
+  });
+
+  it("throws when BIGCAPITAL_URL lacks protocol", async () => {
+    process.env.BIGCAPITAL_URL = "localhost:4000";
+    const { createInvoice } = await import("@/lib/actions/bigcapital.actions");
+    await expect(
+      createInvoice({ token: "t", invoice: {} })
+    ).rejects.toThrow("http:// or https://");
+  });
+});


### PR DESCRIPTION
## Summary
- verify BIGCAPITAL_URL has http/https protocol before fetching
- add a unit test for invalid base URL

## Testing
- `yarn lint` *(fails: Couldn't find the node_modules state file)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6870475efe6883298b97682bde5f104a