### PR TITLE
Exclude bigcapital from tsc

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -26,5 +26,5 @@
 ,  "osc.d.ts",
    "**/*.tsx","app/**/*", ".next/types/**/*.ts"],
    
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules", "bigcapital"]
 }


### PR DESCRIPTION
## Summary
- avoid compiling the `bigcapital` submodule by excluding it from TypeScript config

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68708c2337648329b90f34b07f56386d