### PR TITLE
Extend product review node

### DIFF
--- a/components/cards/PostCard.tsx
+++ b/components/cards/PostCard.tsx
@@ -191,6 +191,7 @@ const PostCard = async ({
                       rating={vals.rating}
                       summary={vals.summary}
                       productLink={vals.productLink}
+                      claims={vals.claims || []}
                     />
                   )
                 );

--- a/components/cards/ProductReviewCard.tsx
+++ b/components/cards/ProductReviewCard.tsx
@@ -1,10 +1,14 @@
 "use client";
 
+import { ThumbsUp, ThumbsDown, BadgeDollarSign } from "lucide-react";
+import { useState } from "react";
+
 interface ProductReviewCardProps {
   productName: string;
   rating: number;
   summary: string;
   productLink: string;
+  claims: string[];
 }
 
 const ProductReviewCard = ({
@@ -12,7 +16,27 @@ const ProductReviewCard = ({
   rating,
   summary,
   productLink,
+  claims,
 }: ProductReviewCardProps) => {
+  const [voteCounts, setVoteCounts] = useState(
+    claims.map(() => ({ helpful: 0, unhelpful: 0, vouch: 0 }))
+  );
+
+  const handleVote = (idx: number, type: "helpful" | "unhelpful") => {
+    setVoteCounts((prev) => {
+      const copy = [...prev];
+      copy[idx] = { ...copy[idx], [type]: copy[idx][type] + 1 };
+      return copy;
+    });
+  };
+
+  const handleVouch = (idx: number) => {
+    setVoteCounts((prev) => {
+      const copy = [...prev];
+      copy[idx] = { ...copy[idx], vouch: copy[idx].vouch + 1 };
+      return copy;
+    });
+  };
   return (
     <div className="flex justify-center">
     <div className="w-[45rem] h-[24rem]  rounded-md">
@@ -20,6 +44,26 @@ const ProductReviewCard = ({
       <div className="font-bold">{productName}</div>
       <div>Rating: {rating}/5</div>
       <div className="text-sm mt-1">{summary}</div>
+      <ul className="list-disc pl-5 mt-2 space-y-2 w-full">
+        {claims.map((c, idx) => (
+          <li key={idx} className="text-sm">
+            <div className="flex justify-between items-center">
+              <span>{c}</span>
+              <div className="flex items-center gap-2 text-xs">
+                <button onClick={() => handleVote(idx, "helpful")} aria-label="Helpful" className="p-1">
+                  <ThumbsUp className="h-4 w-4" /> {voteCounts[idx].helpful}
+                </button>
+                <button onClick={() => handleVote(idx, "unhelpful")} aria-label="Unhelpful" className="p-1">
+                  <ThumbsDown className="h-4 w-4" /> {voteCounts[idx].unhelpful}
+                </button>
+                <button onClick={() => handleVouch(idx)} aria-label="Vouch" className="p-1">
+                  <BadgeDollarSign className="h-4 w-4" /> {voteCounts[idx].vouch}
+                </button>
+              </div>
+            </div>
+          </li>
+        ))}
+      </ul>
       <a
         href={productLink}
         className="text-xs text-blue-500"

--- a/components/forms/CreateFeedPost.tsx
+++ b/components/forms/CreateFeedPost.tsx
@@ -270,6 +270,7 @@ const CreateFeedPost = () => {
             currentRating={5}
             currentSummary=""
             currentProductLink=""
+            currentClaims={[]}
             onSubmit={async (vals) => {
               await createRealtimePost({
                 text: JSON.stringify(vals),

--- a/components/forms/ProductReviewNodeForm.tsx
+++ b/components/forms/ProductReviewNodeForm.tsx
@@ -4,6 +4,7 @@ import { useForm } from "react-hook-form";
 import { z } from "zod";
 import { Button } from "../ui/button";
 import { Input } from "../ui/input";
+import { Textarea } from "../ui/textarea";
 
 interface Props {
   onSubmit: (values: z.infer<typeof ProductReviewValidation>) => void;
@@ -11,6 +12,7 @@ interface Props {
   currentRating: number;
   currentSummary: string;
   currentProductLink: string;
+  currentClaims: string[];
 }
 
 const ProductReviewNodeForm = ({
@@ -19,6 +21,7 @@ const ProductReviewNodeForm = ({
   currentRating,
   currentSummary,
   currentProductLink,
+  currentClaims,
 }: Props) => {
   const form = useForm({
     resolver: zodResolver(ProductReviewValidation),
@@ -27,6 +30,7 @@ const ProductReviewNodeForm = ({
       rating: currentRating,
       summary: currentSummary,
       productLink: currentProductLink,
+      claims: currentClaims,
     },
   });
 
@@ -49,6 +53,17 @@ const ProductReviewNodeForm = ({
         <label className="flex flex-col text-slate-500 gap-3 text-[14px]">
           Product Link:
           <Input type="url" {...form.register("productLink")} defaultValue={currentProductLink} />
+        </label>
+        <label className="flex flex-col text-slate-500 gap-3 text-[14px]">
+          Claims (one per line):
+          <Textarea
+            {...form.register("claims")}
+            value={form.watch("claims").join("\n")}
+            onChange={(e) => {
+              const vals = e.target.value.split("\n").map((v) => v.trim()).filter(Boolean);
+              form.setValue("claims", vals);
+            }}
+          />
         </label>
       </div>
       <hr />

--- a/components/modals/ProductReviewNodeModal.tsx
+++ b/components/modals/ProductReviewNodeModal.tsx
@@ -16,9 +16,10 @@ interface Props {
   currentRating: number;
   currentSummary: string;
   currentProductLink: string;
+  currentClaims: string[];
 }
 
-const renderCreate = ({ onSubmit, currentProductName, currentRating, currentSummary, currentProductLink }: Omit<Props, "id" | "isOwned">) => (
+const renderCreate = ({ onSubmit, currentProductName, currentRating, currentSummary, currentProductLink, currentClaims }: Omit<Props, "id" | "isOwned">) => (
   <div>
     <DialogHeader className="dialog-header text-white text-lg py-4 mt-[-4rem]">
       <b>Create Review</b>
@@ -29,11 +30,12 @@ const renderCreate = ({ onSubmit, currentProductName, currentRating, currentSumm
         currentRating={currentRating}
         currentSummary={currentSummary}
         currentProductLink={currentProductLink}
+        currentClaims={currentClaims}
       />
   </div>
 );
 
-const renderEdit = ({ onSubmit, currentProductName, currentRating, currentSummary, currentProductLink }: Omit<Props, "id" | "isOwned">) => (
+const renderEdit = ({ onSubmit, currentProductName, currentRating, currentSummary, currentProductLink, currentClaims }: Omit<Props, "id" | "isOwned">) => (
   <div>
     <DialogHeader className="dialog-header text-white text-lg py-4 mt-[-4rem]">
       <b>Edit Review</b>
@@ -44,6 +46,7 @@ const renderEdit = ({ onSubmit, currentProductName, currentRating, currentSummar
         currentRating={currentRating}
         currentSummary={currentSummary}
         currentProductLink={currentProductLink}
+        currentClaims={currentClaims}
       />
   </div>
 );
@@ -56,6 +59,7 @@ const ProductReviewNodeModal = ({
   currentRating,
   currentSummary,
   currentProductLink,
+  currentClaims,
 }: Props) => {
   const isCreate = !id && isOwned;
   const isEdit = id && isOwned;
@@ -65,9 +69,9 @@ const ProductReviewNodeModal = ({
         <DialogTitle>ProductReviewNodeModal</DialogTitle>
         <div className="grid rounded-md px-4 py-2">
           {isCreate &&
-            renderCreate({ onSubmit, currentProductName, currentRating, currentSummary, currentProductLink })}
+            renderCreate({ onSubmit, currentProductName, currentRating, currentSummary, currentProductLink, currentClaims })}
           {isEdit &&
-            renderEdit({ onSubmit, currentProductName, currentRating, currentSummary, currentProductLink })}
+            renderEdit({ onSubmit, currentProductName, currentRating, currentSummary, currentProductLink, currentClaims })}
           {!isOwned && (
             <DialogClose id="animateButton" className={`form-submit-button pl-2 py-2 pr-[1rem]`}>
               <> Close </>

--- a/components/nodes/ProductReviewNode.tsx
+++ b/components/nodes/ProductReviewNode.tsx
@@ -28,6 +28,7 @@ function ProductReviewNode({ id, data }: NodeProps<ProductReviewNodeData>) {
   const [rating, setRating] = useState(data.rating);
   const [summary, setSummary] = useState(data.summary);
   const [productLink, setProductLink] = useState(data.productLink);
+  const [claims, setClaims] = useState<string[]>(data.claims || []);
 
   useEffect(() => {
     if ("username" in author) return;
@@ -39,6 +40,7 @@ function ProductReviewNode({ id, data }: NodeProps<ProductReviewNodeData>) {
     setRating(data.rating);
     setSummary(data.summary);
     setProductLink(data.productLink);
+    setClaims(data.claims || []);
   }, [data]);
 
   const isOwned = currentUser ? Number(currentUser.userId) === Number(data.author.id) : false;
@@ -48,6 +50,7 @@ function ProductReviewNode({ id, data }: NodeProps<ProductReviewNodeData>) {
     setRating(values.rating);
     setSummary(values.summary);
     setProductLink(values.productLink);
+    setClaims(values.claims);
     await updateRealtimePost({
       id,
       path,
@@ -66,6 +69,7 @@ function ProductReviewNode({ id, data }: NodeProps<ProductReviewNodeData>) {
         currentRating={rating}
         currentSummary={summary}
         currentProductLink={productLink}
+        currentClaims={claims}
         onSubmit={onSubmit}
       />
       }
@@ -79,6 +83,11 @@ function ProductReviewNode({ id, data }: NodeProps<ProductReviewNodeData>) {
         <div className="font-bold">{productName}</div>
         <div>Rating: {rating}/5</div>
         <div className="text-sm mt-1">{summary}</div>
+        <ul className="list-disc pl-5 mt-2 space-y-1 text-sm">
+          {claims.map((c, idx) => (
+            <li key={idx}>{c}</li>
+          ))}
+        </ul>
         <Button>
         <a href={productLink} className="text-xs text-blue-500" target="_blank" rel="noopener noreferrer">
           View Product

--- a/components/shared/NodeSidebar.tsx
+++ b/components/shared/NodeSidebar.tsx
@@ -381,6 +381,7 @@ export default function NodeSidebar({
               currentRating={5}
               currentSummary=""
               currentProductLink=""
+              currentClaims={[]}
               onSubmit={(vals: z.infer<typeof ProductReviewValidation>) => {
                 createPostAndAddToCanvas({
                   text: JSON.stringify(vals),

--- a/lib/reactflow/types.ts
+++ b/lib/reactflow/types.ts
@@ -187,6 +187,7 @@ export type ProductReviewNodeData = Node<
     rating: number;
     summary: string;
     productLink: string;
+    claims: string[];
     author: AuthorOrAuthorId;
     locked: boolean;
   },

--- a/lib/validations/thread.ts
+++ b/lib/validations/thread.ts
@@ -123,6 +123,7 @@ export const ProductReviewValidation = z.object({
   rating: z.number().min(1).max(5),
   summary: z.string().min(1),
   productLink: z.string().url(),
+  claims: z.array(z.string().min(1)).nonempty(),
 });
 
 export const SplineViewerPostValidation = z.object({


### PR DESCRIPTION
## Summary
- add claims array to ProductReviewValidation and node types
- support claims editing via ProductReviewNodeForm
- update modal, node logic, and sidebar to handle claims
- enhance ProductReviewCard with voting and micro vouch UI
- include claims when rendering ProductReviewCard in PostCard

## Testing
- `npm run lint`
- `npm run test`

------
https://chatgpt.com/codex/tasks/task_e_6870988be59c832986b628e75b8c71fd