### PR TITLE
Add multi-claim inputs for review modal

### DIFF
--- a/components/forms/CreateFeedPost.tsx
+++ b/components/forms/CreateFeedPost.tsx
@@ -272,8 +272,9 @@ const CreateFeedPost = () => {
             currentProductLink=""
             currentClaims={[]}
             onSubmit={async (vals) => {
+              const filtered = vals.claims.filter((c) => c.trim() !== "");
               await createRealtimePost({
-                text: JSON.stringify(vals),
+                text: JSON.stringify({ ...vals, claims: filtered }),
                 path: "/",
                 coordinates: { x: 0, y: 0 },
                 type: "PRODUCT_REVIEW",

--- a/components/forms/ProductReviewNodeForm.tsx
+++ b/components/forms/ProductReviewNodeForm.tsx
@@ -5,7 +5,6 @@ import { Controller } from "react-hook-form";
 import { z } from "zod";
 import { Button } from "../ui/button";
 import { Input } from "../ui/input";
-import { Textarea } from "../ui/textarea";
 
 interface Props {
   onSubmit: (values: z.infer<typeof ProductReviewValidation>) => void;
@@ -31,12 +30,23 @@ const ProductReviewNodeForm = ({
       rating: currentRating,
       summary: currentSummary,
       productLink: currentProductLink,
-      claims: currentClaims,
+      claims: [
+        currentClaims[0] || "",
+        currentClaims[1] || "",
+        currentClaims[2] || "",
+      ],
     },
   });
 
   return (
-    <form method="post" className="ml-3 mr-3" onSubmit={form.handleSubmit(onSubmit)}>
+    <form
+      method="post"
+      className="ml-3 mr-3"
+      onSubmit={form.handleSubmit((vals) => {
+        const filtered = vals.claims.filter((c) => c.trim() !== "");
+        onSubmit({ ...vals, claims: filtered });
+      })}
+    >
       <hr />
       <div className="py-4 grid gap-2">
         <label className="flex flex-col text-slate-500 gap-3 text-[14px]">
@@ -56,21 +66,25 @@ const ProductReviewNodeForm = ({
           <Input type="url" {...form.register("productLink")} defaultValue={currentProductLink} />
         </label>
         <label className="flex flex-col text-slate-500 gap-3 text-[14px]">
-          Claims (one per line):
+          Claims:
           <Controller
             control={form.control}
             name="claims"
             render={({ field }) => (
-              <Textarea
-                {...field}
-                value={field.value.join("\n")}
-                onChange={(e) => {
-                  const vals = e.target.value
-                    .split("\n")
-                    .filter((v) => v.trim() !== "");
-                  field.onChange(vals);
-                }}
-              />
+              <div className="flex flex-col gap-2">
+                {[0, 1, 2].map((idx) => (
+                  <Input
+                    key={idx}
+                    type="text"
+                    value={field.value[idx] || ""}
+                    onChange={(e) => {
+                      const copy = [...field.value];
+                      copy[idx] = e.target.value;
+                      field.onChange(copy);
+                    }}
+                  />
+                ))}
+              </div>
             )}
           />
         </label>

--- a/components/nodes/ProductReviewNode.tsx
+++ b/components/nodes/ProductReviewNode.tsx
@@ -46,15 +46,16 @@ function ProductReviewNode({ id, data }: NodeProps<ProductReviewNodeData>) {
   const isOwned = currentUser ? Number(currentUser.userId) === Number(data.author.id) : false;
 
   async function onSubmit(values: z.infer<typeof ProductReviewValidation>) {
+    const filtered = values.claims.filter((c) => c.trim() !== "");
     setProductName(values.productName);
     setRating(values.rating);
     setSummary(values.summary);
     setProductLink(values.productLink);
-    setClaims(values.claims);
+    setClaims(filtered);
     await updateRealtimePost({
       id,
       path,
-      content: JSON.stringify(values),
+      content: JSON.stringify({ ...values, claims: filtered }),
     });
     store.closeModal();
   }

--- a/components/shared/NodeSidebar.tsx
+++ b/components/shared/NodeSidebar.tsx
@@ -383,8 +383,9 @@ export default function NodeSidebar({
               currentProductLink=""
               currentClaims={[]}
               onSubmit={(vals: z.infer<typeof ProductReviewValidation>) => {
+                const filtered = vals.claims.filter((c) => c.trim() !== "");
                 createPostAndAddToCanvas({
-                  text: JSON.stringify(vals),
+                  text: JSON.stringify({ ...vals, claims: filtered }),
                   path: pathname,
                   coordinates: centerPosition,
                   type: "PRODUCT_REVIEW",


### PR DESCRIPTION
## Summary
- allow three claim text fields in `ProductReviewNodeForm`
- filter empty claims before saving reviews
- update create post and sidebar logic to store filtered claims

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6870ae769d688329adbae7b4ffe0a8d3