### PR TITLE
Add entropy game post type

### DIFF
--- a/app/(root)/(standard)/page.tsx
+++ b/app/(root)/(standard)/page.tsx
@@ -23,6 +23,7 @@ export default async function Home() {
       "GALLERY",
       "DRAW",
       "LIVECHAT",
+      "ENTROPY",
       "PLUGIN",
       "PRODUCT_REVIEW",
 

--- a/app/api/random-secret/route.ts
+++ b/app/api/random-secret/route.ts
@@ -1,0 +1,7 @@
+import { NextResponse } from "next/server";
+import { pickRandomSecret } from "@/lib/entropy/server";
+
+export async function GET() {
+  const word = pickRandomSecret();
+  return NextResponse.json({ word });
+}

--- a/components/cards/EntropyCard.tsx
+++ b/components/cards/EntropyCard.tsx
@@ -1,0 +1,100 @@
+"use client";
+import { useEffect, useState } from "react";
+import { supabase } from "@/lib/supabaseclient";
+import { useAuth } from "@/lib/AuthContext";
+import { fetchUser } from "@/lib/actions/user.actions";
+import { entropyDigits, TileInfo } from "@/lib/entropy/utils";
+import { updateRealtimePost } from "@/lib/actions/realtimepost.actions";
+
+interface EntropyCardProps {
+  id: string;
+  content: string;
+  inviteeId: number;
+  authorId: number;
+}
+
+function EntropyCard({ id, content, inviteeId, authorId }: EntropyCardProps) {
+  const { user: currentUser } = useAuth();
+  const [secret, setSecret] = useState<string>("SECRET");
+  const [guesses, setGuesses] = useState<string[]>([]);
+  const [channel, setChannel] = useState<any>(null);
+  const [current, setCurrent] = useState("");
+  const [otherUsername, setOtherUsername] = useState("");
+
+  useEffect(() => {
+    if (content) {
+      try {
+        const parsed = JSON.parse(content);
+        if (parsed.secret) setSecret(parsed.secret);
+        if (Array.isArray(parsed.guesses)) setGuesses(parsed.guesses);
+      } catch {}
+    }
+  }, [content]);
+
+  useEffect(() => {
+    const ch = supabase.channel(`entropy-${id}`);
+    ch.on("broadcast", { event: "guess" }, ({ payload }) => {
+      setGuesses((prev) => [...prev, payload.guess]);
+    });
+    ch.subscribe();
+    setChannel(ch);
+    return () => {
+      supabase.removeChannel(ch);
+    };
+  }, [id]);
+
+  useEffect(() => {
+    if (!currentUser) return;
+    const otherId = Number(currentUser.userId) === Number(authorId) ? inviteeId : authorId;
+    if (!otherId) return;
+    fetchUser(BigInt(otherId)).then((u) => u && setOtherUsername(u.username));
+  }, [currentUser, inviteeId, authorId]);
+
+  const sendGuess = async () => {
+    if (!channel) return;
+    if (current.length !== 6) return;
+    channel.send({ type: "broadcast", event: "guess", payload: { guess: current } });
+    const updated = [...guesses, current];
+    setGuesses(updated);
+    setCurrent("");
+    await updateRealtimePost({ id, path: "/", content: JSON.stringify({ inviteeId, secret, guesses: updated }) });
+  };
+
+  if (
+    currentUser &&
+    Number(currentUser.userId) !== Number(inviteeId) &&
+    Number(currentUser.userId) !== Number(authorId)
+  ) {
+    return null;
+  }
+
+  return (
+    <div className="flex flex-col gap-2">
+      <p className="text-[1rem]">Opponent: {otherUsername || ""}</p>
+      <ul className="font-mono text-sm space-y-1">
+        {guesses.map((g, i) => {
+          const res = entropyDigits(secret, g);
+          return (
+            <li key={i} className="flex gap-2">
+              <span>{g}</span>
+              <span>{res.tiles.map(t => t.digit).join(" ")}</span>
+            </li>
+          );
+        })}
+      </ul>
+      <div className="flex gap-2 mt-2">
+        <input
+          value={current}
+          onChange={(e) => setCurrent(e.target.value.toUpperCase())}
+          className="border p-1 text-black text-sm"
+          maxLength={6}
+        />
+        <button onClick={sendGuess} className="likebutton border-none px-2 rounded">
+          Guess
+        </button>
+      </div>
+    </div>
+  );
+}
+
+export default EntropyCard;

--- a/components/cards/PostCard.tsx
+++ b/components/cards/PostCard.tsx
@@ -21,6 +21,7 @@ import localFont from 'next/font/local'
 const founders = localFont({ src: './NewEdgeTest-RegularRounded.otf' })
 const DrawCanvas = dynamic(() => import("./DrawCanvas"), { ssr: false })
 const LivechatCard = dynamic(() => import("./LivechatCard"), { ssr: false })
+const EntropyCard = dynamic(() => import("./EntropyCard"), { ssr: false })
 const Spline = dynamic(() => import("@splinetool/react-spline"), { ssr: false })
 
 interface Props {
@@ -166,6 +167,26 @@ const PostCard = async ({
                   <div className="mt-2 mb-2 flex justify-center items-center">
                     <LivechatCard
                       id={id.toString()}
+                      inviteeId={inviteeId}
+                      authorId={Number(author.id)}
+                    />
+                  </div>
+                );
+              })()
+            )}
+            {type === "ENTROPY" && content && (
+              (() => {
+                let inviteeId = 0;
+                try {
+                  inviteeId = JSON.parse(content).inviteeId;
+                } catch (e) {
+                  inviteeId = 0;
+                }
+                return (
+                  <div className="mt-2 mb-2 flex justify-center items-center">
+                    <EntropyCard
+                      id={id.toString()}
+                      content={content}
                       inviteeId={inviteeId}
                       authorId={Number(author.id)}
                     />

--- a/components/forms/CreateFeedPost.tsx
+++ b/components/forms/CreateFeedPost.tsx
@@ -18,6 +18,7 @@ import CollageCreationModal from "@/components/modals/CollageCreationModal";
 import GalleryNodeModal from "@/components/modals/GalleryNodeModal";
 import PortalNodeModal from "@/components/modals/PortalNodeModal";
 import LivechatNodeModal from "@/components/modals/LivechatNodeModal";
+import EntropyNodeModal from "@/components/modals/EntropyNodeModal";
 import PdfViewerNodeModal from "@/components/modals/PdfViewerNodeModal";
 import ProductReviewNodeModal from "../modals/ProductReviewNodeModal";
 import SplineViewerNodeModal from "../modals/SplineViewerNodeModal";
@@ -49,6 +50,7 @@ const nodeOptions: { label: string; nodeType: string }[] = [
   { label: "PORTAL", nodeType: "PORTAL" },
   { label: "DRAW", nodeType: "DRAW" },
   { label: "LIVECHAT", nodeType: "LIVECHAT" },
+  { label: "ENTROPY", nodeType: "ENTROPY" },
   { label: "PDF", nodeType: "PDF_VIEWER" },
   { label: "SPLINE", nodeType: "SPLINE_VIEWER" },
   { label: "PRODUCT_REVIEW", nodeType: "PRODUCT_REVIEW" },
@@ -218,6 +220,29 @@ const CreateFeedPost = () => {
                 type: "LIVECHAT",
                 realtimeRoomId: "global",
                 text: JSON.stringify({ inviteeId: Number(user.id) }),
+              });
+              reset();
+              router.refresh();
+            }}
+          />
+        );
+      case "ENTROPY":
+        return (
+          <EntropyNodeModal
+            isOwned={true}
+            currentInvitee=""
+            onSubmit={async (vals) => {
+              const username = vals.invitee.replace(/^@/, "");
+              const user = await fetchUserByUsername(username);
+              if (!user) return;
+              const res = await fetch("/api/random-secret");
+              const { word } = await res.json();
+              await createRealtimePost({
+                path: "/",
+                coordinates: { x: 0, y: 0 },
+                type: "ENTROPY",
+                realtimeRoomId: "global",
+                text: JSON.stringify({ inviteeId: Number(user.id), secret: word, guesses: [] }),
               });
               reset();
               router.refresh();

--- a/components/forms/EntropyNodeForm.tsx
+++ b/components/forms/EntropyNodeForm.tsx
@@ -1,0 +1,38 @@
+import { EntropyInviteValidation } from "@/lib/validations/thread";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useForm } from "react-hook-form";
+import { z } from "zod";
+import { Button } from "../ui/button";
+import { Input } from "../ui/input";
+
+interface Props {
+  onSubmit: (values: z.infer<typeof EntropyInviteValidation>) => void;
+  currentInvitee: string;
+}
+
+function EntropyNodeForm({ onSubmit, currentInvitee }: Props) {
+  const form = useForm({
+    resolver: zodResolver(EntropyInviteValidation),
+    defaultValues: { invitee: currentInvitee },
+  });
+
+  return (
+    <form method="post" className="ml-3 mr-3" onSubmit={form.handleSubmit(onSubmit)}>
+      <hr />
+      <div className="py-4 grid gap-2">
+        <label className="flex flex-col text-white gap-3 text-[1rem]">
+          Invitee Username:
+          <Input type="text" {...form.register("invitee")} placeholder="@username" className="text-black" />
+        </label>
+      </div>
+      <hr />
+      <div className="py-4 mb-0">
+        <Button type="submit" className="form-submit-button" size={"lg"}>
+          Save Changes
+        </Button>
+      </div>
+    </form>
+  );
+}
+
+export default EntropyNodeForm;

--- a/components/modals/EntropyNodeModal.tsx
+++ b/components/modals/EntropyNodeModal.tsx
@@ -1,0 +1,47 @@
+import { EntropyInviteValidation } from "@/lib/validations/thread";
+import { z } from "zod";
+import EntropyNodeForm from "@/components/forms/EntropyNodeForm";
+import { DialogContent, DialogHeader } from "@/components/ui/dialog";
+
+interface Props {
+  id?: string;
+  isOwned: boolean;
+  onSubmit?: (values: z.infer<typeof EntropyInviteValidation>) => void;
+  currentInvitee: string;
+}
+
+const renderCreate = ({ onSubmit }: { onSubmit?: (v: z.infer<typeof EntropyInviteValidation>) => void }) => (
+  <div>
+    <DialogHeader className="dialog-header text-white text-lg py-4 mb-2">
+      <b>Create Game</b>
+    </DialogHeader>
+    <hr />
+    <EntropyNodeForm onSubmit={onSubmit!} currentInvitee="" />
+  </div>
+);
+
+const renderEdit = ({ onSubmit, currentInvitee }: { onSubmit?: (v: z.infer<typeof EntropyInviteValidation>) => void; currentInvitee: string }) => (
+  <div>
+    <DialogHeader className="dialog-header ml-2 text-white text-lg mb-2 mt-0">
+      <b>Edit Game</b>
+    </DialogHeader>
+    <EntropyNodeForm onSubmit={onSubmit!} currentInvitee={currentInvitee} />
+  </div>
+);
+
+function EntropyNodeModal({ id, isOwned, onSubmit, currentInvitee }: Props) {
+  const isCreate = !id && isOwned;
+  const isEdit = id && isOwned;
+  return (
+    <div>
+      <DialogContent className="max-w-[57rem]">
+        <div className="grid rounded-md px-4 py-4">
+          {isCreate && renderCreate({ onSubmit })}
+          {isEdit && renderEdit({ onSubmit, currentInvitee })}
+        </div>
+      </DialogContent>
+    </div>
+  );
+}
+
+export default EntropyNodeModal;

--- a/components/nodes/EntropyNode.tsx
+++ b/components/nodes/EntropyNode.tsx
@@ -1,0 +1,151 @@
+"use client";
+import { fetchUser, fetchUserByUsername } from "@/lib/actions/user.actions";
+import { updateRealtimePost } from "@/lib/actions/realtimepost.actions";
+import { useAuth } from "@/lib/AuthContext";
+import { AuthorOrAuthorId, AppState } from "@/lib/reactflow/types";
+import { NodeProps } from "@xyflow/react";
+import { useEffect, useState } from "react";
+import { supabase } from "@/lib/supabaseclient";
+import { usePathname } from "next/navigation";
+import BaseNode from "./BaseNode";
+import EntropyNodeModal from "../modals/EntropyNodeModal";
+import useStore from "@/lib/reactflow/store";
+import { useShallow } from "zustand/react/shallow";
+import { EntropyInviteValidation } from "@/lib/validations/thread";
+import { z } from "zod";
+import { entropyDigits } from "@/lib/entropy/utils";
+
+interface EntropyNodeData {
+  inviteeId: number;
+  author: AuthorOrAuthorId;
+  locked: boolean;
+  secret?: string;
+  guesses?: string[];
+}
+
+function EntropyNode({ id, data }: NodeProps<EntropyNodeData>) {
+  const path = usePathname();
+  const currentUser = useAuth().user;
+  const [author, setAuthor] = useState(data.author);
+  const store = useStore(
+    useShallow((state: AppState) => ({
+      closeModal: state.closeModal,
+    }))
+  );
+  const [secret, setSecret] = useState(data.secret || "SECRET");
+  const [guesses, setGuesses] = useState<string[]>(data.guesses || []);
+  const [channel, setChannel] = useState<any>(null);
+  const [inviteeUsername, setInviteeUsername] = useState("");
+  const otherUsername =
+    Number(currentUser?.userId) === Number(data.author.id)
+      ? inviteeUsername
+      : "username" in author
+      ? author.username
+      : "";
+
+  useEffect(() => {
+    if ("username" in author) return;
+    fetchUser(data.author.id).then((user) => user && setAuthor(user));
+  }, [data, author]);
+
+  useEffect(() => {
+    if (!data.inviteeId) return;
+    fetchUser(BigInt(data.inviteeId)).then((u) => u && setInviteeUsername(u.username));
+  }, [data.inviteeId]);
+
+  useEffect(() => {
+    const ch = supabase.channel(`entropy-${id}`);
+    ch.on("broadcast", { event: "guess" }, ({ payload }) => {
+      setGuesses((g) => [...g, payload.guess]);
+    });
+    ch.subscribe();
+    setChannel(ch);
+    return () => {
+      supabase.removeChannel(ch);
+    };
+  }, [id]);
+
+  const isOwned = currentUser ? Number(currentUser.userId) === Number(data.author.id) : false;
+
+  async function onSubmit(values: z.infer<typeof EntropyInviteValidation>) {
+    const username = values.invitee.replace(/^@/, "");
+    const user = await fetchUserByUsername(username);
+    if (user) {
+      await updateRealtimePost({
+        id,
+        path,
+        content: JSON.stringify({ inviteeId: Number(user.id), secret, guesses }),
+      });
+      setInviteeUsername(user.username);
+    }
+    store.closeModal();
+  }
+
+  const [current, setCurrent] = useState("");
+
+  const sendGuess = async () => {
+    if (!channel) return;
+    if (current.length !== 6) return;
+    channel.send({ type: "broadcast", event: "guess", payload: { guess: current } });
+    const updated = [...guesses, current];
+    setGuesses(updated);
+    setCurrent("");
+    await updateRealtimePost({ id, path, content: JSON.stringify({ inviteeId: data.inviteeId, secret, guesses: updated }) });
+  };
+
+  if (
+    currentUser &&
+    Number(currentUser.userId) !== Number(data.inviteeId) &&
+    Number(currentUser.userId) !== Number("id" in data.author ? data.author.id : data.author.id)
+  ) {
+    return null;
+  }
+
+  return (
+    <BaseNode
+      modalContent={
+        isOwned ? (
+          <EntropyNodeModal
+            id={id}
+            isOwned={isOwned}
+            currentInvitee={inviteeUsername}
+            onSubmit={onSubmit}
+          />
+        ) : null
+      }
+      id={id}
+      author={author}
+      isOwned={isOwned}
+      type={"ENTROPY"}
+      isLocked={data.locked}
+    >
+      <div className="flex flex-col gap-2 p-2">
+        <label className="text-[1rem]">{otherUsername || "Other"}</label>
+        <ul className="font-mono text-sm space-y-1">
+          {guesses.map((g, i) => {
+            const res = entropyDigits(secret, g);
+            return (
+              <li key={i} className="flex gap-2">
+                <span>{g}</span>
+                <span>{res.tiles.map((t) => t.digit).join(" ")}</span>
+              </li>
+            );
+          })}
+        </ul>
+        <div className="flex gap-2 mt-2">
+          <input
+            value={current}
+            onChange={(e) => setCurrent(e.target.value.toUpperCase())}
+            className="border p-1 text-black text-sm"
+            maxLength={6}
+          />
+          <button onClick={sendGuess} className="likebutton border-none px-2 rounded">
+            Guess
+          </button>
+        </div>
+      </div>
+    </BaseNode>
+  );
+}
+
+export default EntropyNode;

--- a/components/shared/NodeSidebar.tsx
+++ b/components/shared/NodeSidebar.tsx
@@ -46,6 +46,7 @@ import CollageCreationModal from "@/components/modals/CollageCreationModal";
 import PortalNodeModal from "@/components/modals/PortalNodeModal";
 import GalleryNodeModal from "@/components/modals/GalleryNodeModal";
 import LivechatNodeModal from "@/components/modals/LivechatNodeModal";
+import EntropyNodeModal from "@/components/modals/EntropyNodeModal";
 import PortfolioNodeModal from "@/components/modals/PortfolioNodeModal";
 import SplineViewerNodeModal from "@/components/modals/SplineViewerNodeModal";
 import ProductReviewNodeModal from "@/components/modals/ProductReviewNodeModal";
@@ -124,6 +125,7 @@ export default function NodeSidebar({
     { label: "PORTAL", nodeType: "PORTAL" },
     { label: "DRAW", nodeType: "DRAW" },
     { label: "LIVECHAT", nodeType: "LIVECHAT" },
+    { label: "ENTROPY", nodeType: "ENTROPY" },
     { label: "AUDIO", nodeType: "AUDIO" },
     { label: "LLM", nodeType: "LLM_INSTRUCTION" },
     { label: "PORTFOLIO", nodeType: "PORTFOLIO" },
@@ -314,6 +316,28 @@ export default function NodeSidebar({
                   realtimeRoomId: roomId,
                   text: JSON.stringify({ inviteeId: Number(user.id) }),
                 });
+              }}
+            />
+          );
+          break;
+        case "ENTROPY":
+          store.openModal(
+            <EntropyNodeModal
+              isOwned={true}
+              currentInvitee=""
+              onSubmit={async (vals) => {
+                const username = vals.invitee.replace(/^@/, "");
+                const user = await fetchUserByUsername(username);
+                if (!user) return;
+                const res = await fetch("/api/random-secret");
+                const { word } = await res.json();
+                createPostAndAddToCanvas({
+                  path: pathname,
+                  coordinates: centerPosition,
+                  type: "ENTROPY",
+                  realtimeRoomId: roomId,
+                  text: JSON.stringify({ inviteeId: Number(user.id), secret: word, guesses: [] }),
+                } as any);
               }}
             />
           );

--- a/lib/entropy/server.ts
+++ b/lib/entropy/server.ts
@@ -1,0 +1,6 @@
+import { dictionaryArray } from "@/app/(root)/(standard)/entropy/data";
+
+export function pickRandomSecret(): string {
+  const idx = Math.floor(Math.random() * dictionaryArray.length);
+  return dictionaryArray[idx];
+}

--- a/lib/entropy/utils.ts
+++ b/lib/entropy/utils.ts
@@ -1,0 +1,40 @@
+export type TileInfo = { digit: number; status: "G" | "Y" | "X" };
+export type SetSizes = { G: number; Y: number; X: number };
+
+export function entropyDigits(secret: string, guess: string): {
+  tiles: TileInfo[];
+  setSizes: SetSizes;
+} {
+  const status: ("G" | "Y" | "X")[] = Array(6).fill("X");
+  const secretRem = secret.split("");
+  for (let i = 0; i < 6; i++) {
+    if (guess[i] === secret[i]) {
+      status[i] = "G";
+      secretRem[i] = "_";
+    }
+  }
+  for (let i = 0; i < 6; i++) {
+    if (status[i] === "X") {
+      const idx = secretRem.indexOf(guess[i]);
+      if (idx !== -1) {
+        status[i] = "Y";
+        secretRem[idx] = "_";
+      }
+    }
+  }
+  const Gre = new Set<string>();
+  const Yel = new Set<string>();
+  const Gry = new Set<string>();
+  status.forEach((st, i) => {
+    const c = guess[i];
+    if (st === "G") Gre.add(c);
+    else if (st === "Y") Yel.add(c);
+    else Gry.add(c);
+  });
+  const sizes = { G: Gre.size, Y: Yel.size, X: Gry.size };
+  const tiles = status.map<TileInfo>(st => ({
+    status: st,
+    digit: st === "G" ? sizes.G : st === "Y" ? sizes.Y : sizes.X,
+  }));
+  return { tiles, setSizes: sizes };
+}

--- a/lib/models/schema.prisma
+++ b/lib/models/schema.prisma
@@ -315,6 +315,7 @@ enum realtime_post_type {
   AUDIO
   DRAW
   LIVECHAT
+  ENTROPY
   DOCUMENT
   THREAD
   CODE

--- a/lib/reactflow/reactflowutils.ts
+++ b/lib/reactflow/reactflowutils.ts
@@ -217,6 +217,25 @@ export function convertPostToNode(
           position: { x: realtimePost.x_coordinate, y: realtimePost.y_coordinate }
         } as LivechatNode;
       }
+      case "ENTROPY": {
+        let inviteeId = 0;
+        let secret = "";
+        let guesses: string[] = [];
+        if (realtimePost.content) {
+          try {
+            const parsed = JSON.parse(realtimePost.content);
+            inviteeId = parsed.inviteeId || 0;
+            secret = parsed.secret || "";
+            guesses = parsed.guesses || [];
+          } catch {}
+        }
+        return {
+          id: realtimePost.id.toString(),
+          type: realtimePost.type,
+          data: { inviteeId, author: authorToSet, locked: realtimePost.locked, secret, guesses },
+          position: { x: realtimePost.x_coordinate, y: realtimePost.y_coordinate },
+        } as AppNode;
+      }
       case "AUDIO":
         return {
           id: realtimePost.id.toString(),

--- a/lib/reactflow/types.ts
+++ b/lib/reactflow/types.ts
@@ -119,6 +119,17 @@ export type LivechatNode = Node<
   "LIVECHAT"
 >;
 
+export type EntropyNode = Node<
+  {
+    inviteeId: number;
+    author: AuthorOrAuthorId;
+    locked: boolean;
+    secret?: string;
+    guesses?: string[];
+  },
+  "ENTROPY"
+>;
+
 export type AudioNode = Node<
   {
     audioUrl: string;
@@ -209,6 +220,7 @@ export const NodeTypeMap = {
   PORTAL: {} as PortalNode,
   DRAW: {} as DrawNode,
   LIVECHAT: {} as LivechatNode,
+  ENTROPY: {} as EntropyNode,
   AUDIO: {} as AudioNode,
   DOCUMENT: {} as DocumentNode,
   THREAD: {} as ThreadNode,
@@ -236,6 +248,7 @@ export const NodeTypeToModalMap = {
   PRODUCT_REVIEW: ProductReviewNodeModal,
   PORTAL: ShareRoomModal,
   LIVECHAT: ShareRoomModal,
+  ENTROPY: ShareRoomModal,
 };
 
 export type AppNode =
@@ -249,6 +262,7 @@ export type AppNode =
   | PortalNode
   | DrawNode
   | LivechatNode
+  | EntropyNode
   | AudioNode
   | DocumentNode
   | ThreadNode
@@ -274,6 +288,7 @@ export const DEFAULT_NODE_VALUES: Record<AppNodeType, string> = {
   ["PORTAL"]: "",
   ["DRAW"]: "",
   ["LIVECHAT"]: "",
+  ["ENTROPY"]: "",
   ["AUDIO"]: "",
   ["DOCUMENT"]: "",
   ["THREAD"]: "",

--- a/lib/validations/thread.ts
+++ b/lib/validations/thread.ts
@@ -96,6 +96,10 @@ export const LivechatInviteValidation = z.object({
   invitee: z.string().min(1),
 });
 
+export const EntropyInviteValidation = z.object({
+  invitee: z.string().min(1),
+});
+
 export const PortfolioNodeValidation = z.object({
   text: z.string().min(1),
   images: z


### PR DESCRIPTION
## Summary
- add ENTROPY to realtime_post_type
- create EntropyCard, EntropyNode and related form/modal components
- support ENTROPY posts in feed and node sidebar
- expose random secret API
- utility functions for entropy game logic

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_687171f5fa188329a141f3c49a3ccaec