### PR TITLE
Fix replicate display

### DIFF
--- a/components/cards/PostCard.tsx
+++ b/components/cards/PostCard.tsx
@@ -240,7 +240,7 @@ const PostCard = async ({
                 <Spline scene={(pluginData as any).sceneUrl} className="w-[100%] h-[30vw]" />
               </div>
             )}
-            {embedPost && <div className="mt-4 scale-90">{embedPost}</div>}
+            {embedPost && <div className="mt-4 scale-75">{embedPost}</div>}
             <hr className="mt-4 mb-3 w-full h-px border-t-0 bg-transparent bg-gradient-to-r from-transparent via-slate-100 to-transparent opacity-75" />
 
             <div className="mt-4 flex flex-col gap-x-3 gap-y-4">

--- a/lib/actions/realtimepost.actions.ts
+++ b/lib/actions/realtimepost.actions.ts
@@ -485,25 +485,14 @@ export async function replicateRealtimePost({
     if (!original) throw new Error("Real-time post not found");
     const newPost = await prisma.realtimePost.create({
       data: {
-        ...(original.content && { content: original.content }),
-        ...(original.image_url && { image_url: original.image_url }),
-        ...(original.video_url && { video_url: original.video_url }),
+        content: `REPLICATE:${oid.toString()}`,
         author_id: uid,
         x_coordinate: original.x_coordinate,
         y_coordinate: original.y_coordinate,
-        type: original.type,
+        type: "TEXT",
         realtime_room_id: original.realtime_room_id,
         locked: false,
         isPublic: original.isPublic,
-        ...(original.collageLayoutStyle && {
-          collageLayoutStyle: original.collageLayoutStyle,
-        }),
-        ...(original.collageColumns !== null && {
-          collageColumns: original.collageColumns ?? undefined,
-        }),
-        ...(original.collageGap !== null && {
-          collageGap: original.collageGap ?? undefined,
-        }),
       },
     });
     await prisma.user.update({


### PR DESCRIPTION
## Summary
- show embedded post at 75% scale
- create realtime reposts as references instead of copies

## Testing
- `npm run lint`
- `npm test --silent`
- `npx jest tests/workflowExecution.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_68717c07f2008329b33a4d7712fd58cd