### PR TITLE
Implement messaging skeleton

### DIFF
--- a/app/(root)/(standard)/messages/[id]/page.tsx
+++ b/app/(root)/(standard)/messages/[id]/page.tsx
@@ -1,0 +1,29 @@
+import { fetchConversation, fetchMessages } from "@/lib/actions/message.actions";
+import { getUserFromCookies } from "@/lib/serverutils";
+import { redirect, notFound } from "next/navigation";
+import MessageForm from "./send-form";
+
+export default async function Page({ params }: { params: { id: string } }) {
+  const user = await getUserFromCookies();
+  if (!user?.userId) redirect("/login");
+  const conversationId = BigInt(params.id);
+  const conversation = await fetchConversation({ conversationId });
+  if (!conversation) notFound();
+  if (conversation.user1_id !== user.userId && conversation.user2_id !== user.userId) notFound();
+  const messages = await fetchMessages({ conversationId });
+  const other = conversation.user1_id === user.userId ? conversation.user2 : conversation.user1;
+  return (
+    <main className="p-4 space-y-4">
+      <h1 className="head-text">Chat with {other.name}</h1>
+      <div className="space-y-2">
+        {messages.map((m) => (
+          <div key={m.id.toString()} className="rounded p-2 bg-light-4">
+            <p className="text-sm font-semibold">{m.sender.name}</p>
+            <p>{m.text}</p>
+          </div>
+        ))}
+      </div>
+      <MessageForm conversationId={conversationId} />
+    </main>
+  );
+}

--- a/app/(root)/(standard)/messages/[id]/send-form.tsx
+++ b/app/(root)/(standard)/messages/[id]/send-form.tsx
@@ -1,0 +1,34 @@
+"use client";
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+
+interface Props {
+  conversationId: bigint;
+}
+
+export default function MessageForm({ conversationId }: Props) {
+  const [text, setText] = useState("");
+  const router = useRouter();
+  async function send() {
+    if (!text.trim()) return;
+    await fetch(`/api/messages/${conversationId}`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ text }),
+    });
+    setText("");
+    router.refresh();
+  }
+  return (
+    <div className="flex gap-2">
+      <input
+        className="flex-1 border rounded p-2 text-black"
+        value={text}
+        onChange={(e) => setText(e.target.value)}
+      />
+      <button className="px-4 py-2 bg-primary-500 text-white rounded" onClick={send}>
+        Send
+      </button>
+    </div>
+  );
+}

--- a/app/(root)/(standard)/profile/messages/page.tsx
+++ b/app/(root)/(standard)/profile/messages/page.tsx
@@ -1,0 +1,41 @@
+import Link from "next/link";
+import Image from "next/image";
+import { fetchConversations } from "@/lib/actions/message.actions";
+import { getUserFromCookies } from "@/lib/serverutils";
+import { redirect } from "next/navigation";
+
+export default async function Page() {
+  const user = await getUserFromCookies();
+  if (!user?.userId) redirect("/login");
+  const conversations = await fetchConversations({ userId: user.userId });
+  return (
+    <main className="p-4">
+      <h1 className="head-text mb-4">Messages</h1>
+      <ul className="space-y-4">
+        {conversations.map((c) => {
+          const other = c.user1_id === user.userId ? c.user2 : c.user1;
+          const last = c.messages[0];
+          return (
+            <li key={c.id.toString()} className="flex items-center gap-3">
+              <Image
+                src={other.image || "/assets/user-helsinki.svg"}
+                alt={other.name}
+                width={40}
+                height={40}
+                className="rounded-full"
+              />
+              <Link href={`/messages/${c.id}`} className="flex-1">
+                <p className="font-bold">{other.name}</p>
+                {last && (
+                  <p className="text-sm text-gray-500 truncate max-w-xs">
+                    {last.text}
+                  </p>
+                )}
+              </Link>
+            </li>
+          );
+        })}
+      </ul>
+    </main>
+  );
+}

--- a/app/api/messages/[id]/route.ts
+++ b/app/api/messages/[id]/route.ts
@@ -1,0 +1,32 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getUserFromCookies } from "@/lib/serverutils";
+import { fetchMessages, sendMessage, fetchConversation } from "@/lib/actions/message.actions";
+
+export async function GET(req: NextRequest, { params }: { params: { id: string } }) {
+  const user = await getUserFromCookies();
+  if (!user?.userId) {
+    return new NextResponse("Unauthorized", { status: 401 });
+  }
+  const conversationId = BigInt(params.id);
+  const conv = await fetchConversation({ conversationId });
+  if (!conv || (conv.user1_id !== user.userId && conv.user2_id !== user.userId)) {
+    return new NextResponse("Not Found", { status: 404 });
+  }
+  const messages = await fetchMessages({ conversationId });
+  return NextResponse.json(messages);
+}
+
+export async function POST(req: NextRequest, { params }: { params: { id: string } }) {
+  const user = await getUserFromCookies();
+  if (!user?.userId) {
+    return new NextResponse("Unauthorized", { status: 401 });
+  }
+  const conversationId = BigInt(params.id);
+  const conv = await fetchConversation({ conversationId });
+  if (!conv || (conv.user1_id !== user.userId && conv.user2_id !== user.userId)) {
+    return new NextResponse("Not Found", { status: 404 });
+  }
+  const { text } = await req.json();
+  await sendMessage({ conversationId, senderId: user.userId, text, path: `/messages/${params.id}` });
+  return NextResponse.json({ status: "ok" });
+}

--- a/app/api/messages/start/route.ts
+++ b/app/api/messages/start/route.ts
@@ -1,0 +1,16 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getUserFromCookies } from "@/lib/serverutils";
+import { getOrCreateConversation } from "@/lib/actions/message.actions";
+
+export async function POST(req: NextRequest) {
+  const user = await getUserFromCookies();
+  if (!user?.userId) {
+    return new NextResponse("Unauthorized", { status: 401 });
+  }
+  const { targetUserId } = await req.json();
+  const conversation = await getOrCreateConversation({
+    userId: user.userId,
+    targetUserId: BigInt(targetUserId),
+  });
+  return NextResponse.json({ id: conversation.id });
+}

--- a/components/buttons/MessageButton.tsx
+++ b/components/buttons/MessageButton.tsx
@@ -1,10 +1,8 @@
 "use client";
 
-import { followUser, unfollowUser, areFriends } from "@/lib/actions/follow.actions";
 import { useAuth } from "@/lib/AuthContext";
 import { Button } from "@/components/ui/button";
 import { useRouter } from "next/navigation";
-import { useState } from "react";
 
 interface Props {
   targetUserId: bigint;
@@ -12,11 +10,9 @@ interface Props {
   initialIsFriend: boolean;
 }
 
-const MessageButton = ({ targetUserId, initialIsFollowing, initialIsFriend }: Props) => {
+const MessageButton = ({ targetUserId }: Props) => {
   const { user } = useAuth();
   const router = useRouter();
-  const [isFollowing, setIsFollowing] = useState(initialIsFollowing);
-  const [isFriend, setIsFriend] = useState(initialIsFriend);
 
   async function handleClick() {
     if (!user) {
@@ -27,23 +23,20 @@ const MessageButton = ({ targetUserId, initialIsFollowing, initialIsFriend }: Pr
       router.push("/onboarding");
       return;
     }
-    if (isFollowing) {
-      await unfollowUser({ followerId: user.userId, followingId: targetUserId });
-      setIsFollowing(false);
-      setIsFriend(false);
-    } else {
-      await followUser({ followerId: user.userId, followingId: targetUserId });
-      setIsFollowing(true);
-      const friend = await areFriends({ userId: user.userId, targetUserId });
-      setIsFriend(friend);
+    const res = await fetch("/api/messages/start", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ targetUserId: targetUserId.toString() }),
+    });
+    if (res.ok) {
+      const data = await res.json();
+      router.push(`/messages/${data.id}`);
     }
   }
 
-  const label = isFriend ? "Send Message" : isFollowing ? "Send Message" : "Send Message";
-
   return (
-    <Button variant="whiteborder" onClick={handleClick} className=" bg-transparent hover:bg-transparent">
-      {label}
+    <Button variant="whiteborder" onClick={handleClick} className="bg-transparent hover:bg-transparent">
+      Send Message
     </Button>
   );
 };

--- a/components/shared/MessagesTab.tsx
+++ b/components/shared/MessagesTab.tsx
@@ -15,11 +15,14 @@ const MessagesTab = async ({ currentUserId, accountId }: Props) => {
 
   return (
     <ul className="mt-9 space-y-4">
+      <li>
+        <Link href="/profile/messages" className="text-primary-500 hover:underline">
+          Go to Messages
+        </Link>
+      </li>
       {relations.map((rel) => (
         <li key={rel.id.toString()} className="text-base-regular text-black">
-          <Link href={`/profile/messages`} className="text-primary-500 hover:underline">
-          </Link>{" "}
-          <span className="text-light-3">- {rel.status}</span>
+          {rel.name} <span className="text-light-3">- {rel.status}</span>
         </li>
       ))}
     </ul>

--- a/lib/actions/message.actions.ts
+++ b/lib/actions/message.actions.ts
@@ -1,0 +1,89 @@
+"use server";
+
+import { prisma } from "../prismaclient";
+import { revalidatePath } from "next/cache";
+
+export async function getOrCreateConversation({
+  userId,
+  targetUserId,
+}: {
+  userId: bigint;
+  targetUserId: bigint;
+}) {
+  const existing = await prisma.conversation.findFirst({
+    where: {
+      OR: [
+        { user1_id: userId, user2_id: targetUserId },
+        { user1_id: targetUserId, user2_id: userId },
+      ],
+    },
+  });
+  if (existing) return existing;
+  return await prisma.conversation.create({
+    data: { user1_id: userId, user2_id: targetUserId },
+  });
+}
+
+export async function fetchConversations({
+  userId,
+}: {
+  userId: bigint;
+}) {
+  return await prisma.conversation.findMany({
+    where: { OR: [{ user1_id: userId }, { user2_id: userId }] },
+    include: {
+      user1: true,
+      user2: true,
+      messages: { orderBy: { created_at: "desc" }, take: 1 },
+    },
+    orderBy: { updated_at: "desc" },
+  });
+}
+
+export async function fetchConversation({
+  conversationId,
+}: {
+  conversationId: bigint;
+}) {
+  return await prisma.conversation.findUnique({
+    where: { id: conversationId },
+    include: { user1: true, user2: true },
+  });
+}
+
+export async function fetchMessages({
+  conversationId,
+}: {
+  conversationId: bigint;
+}) {
+  return await prisma.message.findMany({
+    where: { conversation_id: conversationId },
+    orderBy: { created_at: "asc" },
+    include: { sender: true },
+  });
+}
+
+export async function sendMessage({
+  conversationId,
+  senderId,
+  text,
+  path,
+}: {
+  conversationId: bigint;
+  senderId: bigint;
+  text: string;
+  path: string;
+}) {
+  await prisma.message.create({
+    data: {
+      conversation_id: conversationId,
+      sender_id: senderId,
+      text,
+    },
+  });
+  await prisma.conversation.update({
+    where: { id: conversationId },
+    data: { updated_at: new Date() },
+  });
+  revalidatePath(path);
+}

--- a/lib/models/schema.prisma
+++ b/lib/models/schema.prisma
@@ -446,3 +446,32 @@ model WorkflowRun {
   @@index([workflow_id])
   @@map("workflow_runs")
 }
+
+model Conversation {
+  id          BigInt   @id @default(autoincrement())
+  user1_id    BigInt
+  user2_id    BigInt
+  created_at  DateTime @default(now()) @db.Timestamptz(6)
+  updated_at  DateTime @default(now()) @updatedAt @db.Timestamptz(6)
+  messages    Message[]
+  user1       User     @relation("ConversationUser1", fields: [user1_id], references: [id])
+  user2       User     @relation("ConversationUser2", fields: [user2_id], references: [id])
+
+  @@index([user1_id])
+  @@index([user2_id])
+  @@unique([user1_id, user2_id])
+  @@map("conversations")
+}
+
+model Message {
+  id              BigInt      @id @default(autoincrement())
+  conversation_id BigInt
+  sender_id       BigInt
+  text            String
+  created_at      DateTime    @default(now()) @db.Timestamptz(6)
+  conversation    Conversation @relation(fields: [conversation_id], references: [id], onDelete: Cascade)
+  sender          User        @relation(fields: [sender_id], references: [id], onDelete: Cascade)
+
+  @@index([conversation_id])
+  @@map("messages")
+}


### PR DESCRIPTION
## Summary
- add Conversation and Message models to Prisma schema
- add message actions for conversations
- create API routes for starting chats and sending messages
- implement basic messages pages and chat room UI
- update MessageButton to open DM conversations
- link to Messages from profile tab

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6871d4228a408329b2ff613d289fb7fd