### PR TITLE
Implement realtime messaging

### DIFF
--- a/app/(root)/(standard)/messages/[id]/page.tsx
+++ b/app/(root)/(standard)/messages/[id]/page.tsx
@@ -2,6 +2,7 @@ import { fetchConversation, fetchMessages } from "@/lib/actions/message.actions"
 import { getUserFromCookies } from "@/lib/serverutils";
 import { redirect, notFound } from "next/navigation";
 import MessageForm from "./send-form";
+import ChatRoom from "@/components/chat/ChatRoom";
 
 export default async function Page({ params }: { params: { id: string } }) {
   const user = await getUserFromCookies();
@@ -15,14 +16,17 @@ export default async function Page({ params }: { params: { id: string } }) {
   return (
     <main className="p-4 space-y-4">
       <h1 className="head-text">Chat with {other.name}</h1>
-      <div className="space-y-2">
-        {messages.map((m) => (
-          <div key={m.id.toString()} className="rounded p-2 bg-light-4">
-            <p className="text-sm font-semibold">{m.sender.name}</p>
-            <p>{m.text}</p>
-          </div>
-        ))}
-      </div>
+      <ChatRoom
+        conversationId={conversationId}
+        currentUserId={user.userId}
+        initialMessages={messages.map((m) => ({
+          id: m.id.toString(),
+          text: m.text,
+          created_at: m.created_at.toISOString(),
+          sender_id: m.sender_id.toString(),
+          sender: { name: m.sender.name, image: m.sender.image },
+        }))}
+      />
       <MessageForm conversationId={conversationId} />
     </main>
   );

--- a/app/(root)/(standard)/messages/[id]/send-form.tsx
+++ b/app/(root)/(standard)/messages/[id]/send-form.tsx
@@ -1,6 +1,5 @@
 "use client";
 import { useState } from "react";
-import { useRouter } from "next/navigation";
 
 interface Props {
   conversationId: bigint;
@@ -8,7 +7,6 @@ interface Props {
 
 export default function MessageForm({ conversationId }: Props) {
   const [text, setText] = useState("");
-  const router = useRouter();
   async function send() {
     if (!text.trim()) return;
     await fetch(`/api/messages/${conversationId}`, {
@@ -17,7 +15,6 @@ export default function MessageForm({ conversationId }: Props) {
       body: JSON.stringify({ text }),
     });
     setText("");
-    router.refresh();
   }
   return (
     <div className="flex gap-2">

--- a/components/chat/ChatRoom.tsx
+++ b/components/chat/ChatRoom.tsx
@@ -1,0 +1,63 @@
+"use client";
+import { useEffect, useState } from "react";
+import { supabase } from "@/lib/supabaseclient";
+import {
+  ChatMessage,
+  ChatMessageAvatar,
+  ChatMessageContent,
+} from "@/components/ui/chat-message";
+import Image from "next/image";
+
+interface UserLite {
+  name: string;
+  image: string | null;
+}
+
+interface MessageData {
+  id: string;
+  text: string;
+  created_at: string;
+  sender_id: string;
+  sender: UserLite;
+}
+
+interface Props {
+  conversationId: bigint;
+  currentUserId: bigint;
+  initialMessages: MessageData[];
+}
+
+export default function ChatRoom({
+  conversationId,
+  currentUserId,
+  initialMessages,
+}: Props) {
+  const [messages, setMessages] = useState<MessageData[]>(initialMessages);
+
+  useEffect(() => {
+    const channel = supabase.channel(`conversation-${conversationId.toString()}`);
+    channel.on("broadcast", { event: "new-message" }, ({ payload }) => {
+      setMessages((prev) => [...prev, payload as MessageData]);
+    });
+    channel.subscribe();
+    return () => {
+      supabase.removeChannel(channel);
+    };
+  }, [conversationId]);
+
+  return (
+    <div className="space-y-2">
+      {messages.map((m) => (
+        <ChatMessage
+          key={m.id}
+          type={m.sender_id === currentUserId.toString() ? "outgoing" : "incoming"}
+          variant="bubble"
+          id={m.id}
+        >
+          <ChatMessageAvatar imageSrc={m.sender.image || "/assets/user-helsinki.svg"} />
+          <ChatMessageContent content={m.text} />
+        </ChatMessage>
+      ))}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add `ChatRoom` component for realtime message updates
- broadcast new messages via Supabase in `sendMessage`
- show realtime chat in messages page
- simplify message form client logic

## Testing
- `npm run lint`
- `yarn test` *(fails: Can't reach database server)*

------
https://chatgpt.com/codex/tasks/task_e_6871e8a478c88329a105e6baace80215