### PR TITLE
Fix ReactMarkdown className issue

### DIFF
--- a/components/ui/markdown-content.tsx
+++ b/components/ui/markdown-content.tsx
@@ -282,17 +282,18 @@ interface MarkdownBlockProps {
 }
 
 const MemoizedMarkdownBlock = memo(
-	({ content, className }: MarkdownBlockProps) => {
-		return (
-			<ReactMarkdown
-				remarkPlugins={[remarkGfm]}
-				components={components}
-				className={className}
-			>
-				{content}
-			</ReactMarkdown>
-		);
-	},
+       ({ content, className }: MarkdownBlockProps) => {
+               return (
+                       <div className={className}>
+                               <ReactMarkdown
+                                       remarkPlugins={[remarkGfm]}
+                                       components={components}
+                               >
+                                       {content}
+                               </ReactMarkdown>
+                       </div>
+               );
+       },
 	(prevProps, nextProps) => {
 		if (prevProps.content !== nextProps.content) {
 			return false;


### PR DESCRIPTION
## Summary
- wrap ReactMarkdown output in a div to avoid passing the removed `className` prop

## Testing
- `npm run lint`
- `npm test -- -w=1` *(fails: Can't reach database server)*

------
https://chatgpt.com/codex/tasks/task_e_6871ed84a4b48329966e8d5cf0bc1863