### PR TITLE
Hide delete button on others' posts

### DIFF
--- a/components/cards/PostCard.tsx
+++ b/components/cards/PostCard.tsx
@@ -274,11 +274,13 @@ const PostCard = async ({
             isOwned={currentUserId === author.id}
             expirationDate={expirationDate ?? undefined}
           />
-          <DeleteCardButton
-            {...(isRealtimePost
-              ? { realtimePostId: id.toString() }
-              : { postId: id })}
-          />
+          {currentUserId === author.id && (
+            <DeleteCardButton
+              {...(isRealtimePost
+                ? { realtimePostId: id.toString() }
+                : { postId: id })}
+            />
+          )}
 
               </div>
             </div>


### PR DESCRIPTION
## Summary
- show DeleteCardButton only for posts owned by the current user

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6872b236ccb483298a07b8e90e9b5a59