### PR TITLE
Fix product review voting persistence

### DIFF
--- a/lib/actions/realtimepost.actions.ts
+++ b/lib/actions/realtimepost.actions.ts
@@ -453,6 +453,7 @@ export async function fetchUserRealtimePosts({
     include: {
       author: true,
       _count: { select: { children: true } },
+      productReview: { include: { claims: true } },
     },
     orderBy: {
       created_at: "desc",
@@ -461,6 +462,16 @@ export async function fetchUserRealtimePosts({
 
   return realtimePosts.map((realtimePost) => ({
     ...realtimePost,
+    productReview: realtimePost.productReview
+      ? {
+          ...realtimePost.productReview,
+          claims: realtimePost.productReview.claims.map((c) => ({
+            ...c,
+            id: c.id.toString(),
+            review_id: c.review_id.toString(),
+          })),
+        }
+      : null,
     commentCount: realtimePost._count.children,
     x_coordinate: realtimePost.x_coordinate.toNumber(),
     y_coordinate: realtimePost.y_coordinate.toNumber(),


### PR DESCRIPTION
## Summary
- include product review details when fetching user realtime posts

## Testing
- `yarn install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6872ebe76c048329a1fe983c418701db