### PR TITLE
Enable images in product reviews

### DIFF
--- a/components/forms/CreateFeedPost.tsx
+++ b/components/forms/CreateFeedPost.tsx
@@ -340,14 +340,22 @@ const CreateFeedPost = () => {
             currentSummary=""
             currentProductLink=""
             currentClaims={[]}
+            currentImages={[]}
             onSubmit={async (vals) => {
+              const uploads = await Promise.all(
+                (vals.images || []).map((img) => uploadFileToSupabase(img))
+              );
+              const urls = uploads
+                .filter((r) => !r.error)
+                .map((r) => r.fileURL);
               const filtered = vals.claims.filter((c) => c.trim() !== "");
               await createRealtimePost({
-                text: JSON.stringify({ ...vals, claims: filtered }),
+                text: JSON.stringify({ ...vals, images: urls, claims: filtered }),
                 path: "/",
                 coordinates: { x: 0, y: 0 },
                 type: "PRODUCT_REVIEW",
                 realtimeRoomId: "global",
+                ...(urls.length > 0 && { imageUrl: urls[0] }),
               });
               reset();
               router.refresh();

--- a/components/modals/ProductPhotoGalleryModal.tsx
+++ b/components/modals/ProductPhotoGalleryModal.tsx
@@ -1,0 +1,66 @@
+import Image from "next/image";
+import { useState } from "react";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogClose,
+} from "@/components/ui/dialog";
+
+interface Props {
+  images: string[];
+  open: boolean;
+  onOpenChange: (o: boolean) => void;
+}
+
+const ProductPhotoGalleryModal = ({ images, open, onOpenChange }: Props) => {
+  const [currentIndex, setCurrentIndex] = useState(0);
+  const handlePrev = () =>
+    setCurrentIndex((prev) => (prev - 1 + images.length) % images.length);
+  const handleNext = () =>
+    setCurrentIndex((prev) => (prev + 1) % images.length);
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-[40rem]">
+        <DialogHeader>
+          <DialogTitle>Photos</DialogTitle>
+        </DialogHeader>
+        {images.length > 0 && (
+          <div className="relative flex justify-center">
+            <Image
+              src={images[currentIndex]}
+              alt={`photo-${currentIndex}`}
+              width={0}
+              height={0}
+              sizes="200vw"
+              className="max-h-[30rem] w-auto"
+            />
+            {images.length > 1 && (
+              <>
+                <button
+                  className="absolute left-0 top-1/2 -translate-y-1/2 bg-black/50 text-white px-2"
+                  onClick={handlePrev}
+                >
+                  ‹
+                </button>
+                <button
+                  className="absolute right-0 top-1/2 -translate-y-1/2 bg-black/50 text-white px-2"
+                  onClick={handleNext}
+                >
+                  ›
+                </button>
+              </>
+            )}
+          </div>
+        )}
+        <div className="pt-4 text-right">
+          <DialogClose className="px-4 py-2 border border-blue rounded-md">Close</DialogClose>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+};
+
+export default ProductPhotoGalleryModal;

--- a/components/modals/ProductReviewNodeModal.tsx
+++ b/components/modals/ProductReviewNodeModal.tsx
@@ -17,9 +17,10 @@ interface Props {
   currentSummary: string;
   currentProductLink: string;
   currentClaims: string[];
+  currentImages: string[];
 }
 
-const renderCreate = ({ onSubmit, currentProductName, currentRating, currentSummary, currentProductLink, currentClaims }: Omit<Props, "id" | "isOwned">) => (
+const renderCreate = ({ onSubmit, currentProductName, currentRating, currentSummary, currentProductLink, currentClaims, currentImages }: Omit<Props, "id" | "isOwned">) => (
   <div >
     <DialogHeader className="dialog-header  text-black text-lg py-3 mt-[-4rem]">
       <b>Create Review</b>
@@ -31,11 +32,12 @@ const renderCreate = ({ onSubmit, currentProductName, currentRating, currentSumm
         currentSummary={currentSummary}
         currentProductLink={currentProductLink}
         currentClaims={currentClaims}
+        currentImages={currentImages}
       />
   </div>
 );
 
-const renderEdit = ({ onSubmit, currentProductName, currentRating, currentSummary, currentProductLink, currentClaims }: Omit<Props, "id" | "isOwned">) => (
+const renderEdit = ({ onSubmit, currentProductName, currentRating, currentSummary, currentProductLink, currentClaims, currentImages }: Omit<Props, "id" | "isOwned">) => (
   <div>
     <DialogHeader className="dialog-header text-white text-lg py-4 mt-[-4rem]">
       <b>Edit Review</b>
@@ -47,6 +49,7 @@ const renderEdit = ({ onSubmit, currentProductName, currentRating, currentSummar
         currentSummary={currentSummary}
         currentProductLink={currentProductLink}
         currentClaims={currentClaims}
+        currentImages={currentImages}
       />
   </div>
   
@@ -61,6 +64,7 @@ const ProductReviewNodeModal = ({
   currentSummary,
   currentProductLink,
   currentClaims,
+  currentImages,
 }: Props) => {
   const isCreate = !id && isOwned;
   const isEdit = id && isOwned;
@@ -70,9 +74,9 @@ const ProductReviewNodeModal = ({
         <DialogTitle hidden>ProductReviewNodeModal</DialogTitle>
         <div className="grid rounded-md px-4 py-2 mt-10">
           {isCreate &&
-            renderCreate({ onSubmit, currentProductName, currentRating, currentSummary, currentProductLink, currentClaims })}
+            renderCreate({ onSubmit, currentProductName, currentRating, currentSummary, currentProductLink, currentClaims, currentImages })}
           {isEdit &&
-            renderEdit({ onSubmit, currentProductName, currentRating, currentSummary, currentProductLink, currentClaims })}
+            renderEdit({ onSubmit, currentProductName, currentRating, currentSummary, currentProductLink, currentClaims, currentImages })}
           {!isOwned && (
             <DialogClose id="animateButton" className={`form-submit-button pl-2 py-2 pr-[1rem]`}>
               <> Close </>

--- a/components/shared/NodeSidebar.tsx
+++ b/components/shared/NodeSidebar.tsx
@@ -406,14 +406,22 @@ export default function NodeSidebar({
               currentSummary=""
               currentProductLink=""
               currentClaims={[]}
-              onSubmit={(vals: z.infer<typeof ProductReviewValidation>) => {
+              currentImages={[]}
+              onSubmit={async (vals: z.infer<typeof ProductReviewValidation>) => {
+                const uploads = await Promise.all(
+                  (vals.images || []).map((img) => uploadFileToSupabase(img))
+                );
+                const urls = uploads
+                  .filter((r) => !r.error)
+                  .map((r) => r.fileURL);
                 const filtered = vals.claims.filter((c) => c.trim() !== "");
                 createPostAndAddToCanvas({
-                  text: JSON.stringify({ ...vals, claims: filtered }),
+                  text: JSON.stringify({ ...vals, images: urls, claims: filtered }),
                   path: pathname,
                   coordinates: centerPosition,
                   type: "PRODUCT_REVIEW",
                   realtimeRoomId: roomId,
+                  ...(urls.length > 0 && { imageUrl: urls[0] }),
                 });
               }}
             />

--- a/lib/actions/productreview.actions.ts
+++ b/lib/actions/productreview.actions.ts
@@ -122,6 +122,7 @@ export async function createProductReview({
   summary,
   productLink,
   claims,
+  images,
 }: {
   realtimePostId: string | number | bigint;
   authorId: string | number | bigint;
@@ -130,6 +131,7 @@ export async function createProductReview({
   summary?: string;
   productLink?: string;
   claims: string[];
+  images: string[];
 }) {
   const pid = BigInt(realtimePostId);
   const uid = BigInt(authorId);
@@ -143,6 +145,7 @@ export async function createProductReview({
         rating,
         ...(summary && { summary }),
         ...(productLink && { product_link: productLink }),
+        image_urls: images,
         claims: {
           create: claims.map((text) => ({ text })),
         },

--- a/lib/actions/realtimepost.actions.ts
+++ b/lib/actions/realtimepost.actions.ts
@@ -92,6 +92,7 @@ export async function createRealtimePost({
           summary: parsed.summary || "",
           productLink: parsed.productLink || "",
           claims: (parsed.claims || []).filter((c: string) => c.trim() !== ""),
+          images: parsed.images || [],
         });
       } catch {
         // ignore JSON parse errors

--- a/lib/models/schema.prisma
+++ b/lib/models/schema.prisma
@@ -388,6 +388,7 @@ model ProductReview {
   rating           Int
   summary          String?
   product_link     String?
+  image_urls       String[]
   created_at       DateTime             @default(now()) @db.Timestamptz(6)
   updated_at       DateTime             @default(now()) @updatedAt @db.Timestamptz(6)
   author           User                 @relation(fields: [author_id], references: [id], onDelete: Cascade)

--- a/lib/reactflow/reactflowutils.ts
+++ b/lib/reactflow/reactflowutils.ts
@@ -343,6 +343,7 @@ export function convertPostToNode(
         let summary = "";
         let productLink = "";
         let claims: string[] = [];
+        let images: string[] = [];
         if (realtimePost.content) {
           try {
             const parsed = JSON.parse(realtimePost.content);
@@ -351,6 +352,7 @@ export function convertPostToNode(
             summary = parsed.summary || "";
             productLink = parsed.productLink || "";
             claims = parsed.claims || [];
+            images = parsed.images || [];
           } catch {}
         }
         return {
@@ -361,6 +363,7 @@ export function convertPostToNode(
             rating,
             summary,
             productLink,
+            images,
             claims,
             author: authorToSet,
             locked: realtimePost.locked,

--- a/lib/reactflow/types.ts
+++ b/lib/reactflow/types.ts
@@ -198,6 +198,7 @@ export type ProductReviewNodeData = Node<
     rating: number;
     summary: string;
     productLink: string;
+    images: string[];
     claims: string[];
     author: AuthorOrAuthorId;
     locked: boolean;

--- a/lib/validations/thread.ts
+++ b/lib/validations/thread.ts
@@ -128,6 +128,17 @@ export const ProductReviewValidation = z.object({
   summary: z.string().min(1),
   productLink: z.string().url(),
   claims: z.array(z.string().min(1)).max(5),
+  images: z
+    .array(
+      z
+        .any()
+        .refine((file) => file?.size <= MAX_FILE_SIZE, `Max image size is 5MB.`)
+        .refine(
+          (file) => isAcceptedImage(file),
+          "Only .jpg, .jpeg, .png and .webp formats are supported."
+        )
+    )
+    .optional(),
 });
 
 export const SplineViewerPostValidation = z.object({


### PR DESCRIPTION
## Summary
- store product review images in `image_urls` column
- validate optional image array for product reviews
- allow image uploads in `ProductReviewNodeForm`
- pass images through `ProductReviewNodeModal`
- add `ProductPhotoGalleryModal` and viewer logic
- support images in review node, sidebar creation, and feed post creation
- update product review creation and node conversion logic

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_687302528d408329a198a27377a299e9