### PR TITLE
Improve youtube-audio error message

### DIFF
--- a/app/api/youtube-audio/route.ts
+++ b/app/api/youtube-audio/route.ts
@@ -6,11 +6,13 @@ export async function GET(req: NextRequest) {
   if (!url) {
     return NextResponse.json({ error: "Missing url" }, { status: 400 });
   }
+  process.env.YTDL_NO_UPDATE = "1";
   try {
     const info = await ytdl.getInfo(url);
     const format = ytdl.chooseFormat(info.formats, { quality: "highestaudio" });
     return NextResponse.json({ audioUrl: format.url, title: info.videoDetails.title });
   } catch (e) {
-    return NextResponse.json({ error: "Failed to fetch" }, { status: 500 });
+    const message = e instanceof Error ? e.message : "Failed to fetch";
+    return NextResponse.json({ error: message }, { status: 500 });
   }
 }


### PR DESCRIPTION
## Summary
- improve error reporting for youtube-audio API
- skip ytdl-core update check

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68732d3b6f708329853c2a919140390b