### PR TITLE
Fix YouTube audio fetch

### DIFF
--- a/app/api/youtube-audio/route.ts
+++ b/app/api/youtube-audio/route.ts
@@ -8,7 +8,9 @@ export async function GET(req: NextRequest) {
   }
   process.env.YTDL_NO_UPDATE = "1";
   try {
-    const info = await ytdl.getInfo(url);
+    const info = await ytdl.getInfo(url, {
+      requestOptions: { family: 4 },
+    });
     const format = ytdl.chooseFormat(info.formats, { quality: "highestaudio" });
     return NextResponse.json({ audioUrl: format.url, title: info.videoDetails.title });
   } catch (e) {


### PR DESCRIPTION
## Summary
- force IPv4 when fetching YouTube info so the request succeeds in networks where IPv6 is blocked

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6873318381c48329bd2ed78d97cf7a41