### PR TITLE
Handle music uploads

### DIFF
--- a/components/cards/PostCard.tsx
+++ b/components/cards/PostCard.tsx
@@ -12,6 +12,7 @@ import PortfolioCard from "./PortfolioCard";
 import DeleteCardButton from "../buttons/DeleteCardButton";
 import ImageCard from "./ImageCard";
 import GalleryCarousel from "./GalleryCarousel";
+import SoundCloudPlayer from "../players/SoundCloudPlayer";
 import dynamic from "next/dynamic";
 import {
   fetchLikeForCurrentUser,
@@ -156,12 +157,7 @@ const PostCard = async ({
             )}
             {type === "MUSIC" && video_url && (
               <div className="mt-2 mb-2 w-full">
-                {content && (
-                  <p className="mb-2 text-[1.08rem] text-black tracking-[.05rem]">
-                    {content}
-                  </p>
-                )}
-                <audio controls src={video_url} className="w-full" />
+                <SoundCloudPlayer src={video_url} title={content || undefined} />
               </div>
             )}
             {type === "GALLERY" && content && (

--- a/components/forms/CreateFeedPost.tsx
+++ b/components/forms/CreateFeedPost.tsx
@@ -25,7 +25,7 @@ import PdfViewerNodeModal from "@/components/modals/PdfViewerNodeModal";
 import ProductReviewNodeModal from "../modals/ProductReviewNodeModal";
 import MusicNodeModal from "../modals/MusicNodeModal";
 import SplineViewerNodeModal from "../modals/SplineViewerNodeModal";
-import { uploadFileToSupabase } from "@/lib/utils";
+import { uploadFileToSupabase, uploadAudioToSupabase } from "@/lib/utils";
 import { createRealtimePost } from "@/lib/actions/realtimepost.actions";
 import { fetchUserByUsername } from "@/lib/actions/user.actions";
 import { useRouter } from "next/navigation";
@@ -113,9 +113,11 @@ const CreateFeedPost = () => {
     router.refresh();
   }
 
-  async function handleMusicSubmit(values: { audioUrl: string; title: string }) {
+  async function handleMusicSubmit(values: { audioFile: File; title: string }) {
+    const result = await uploadAudioToSupabase(values.audioFile);
+    if (result.error) return;
     await createRealtimePost({
-      videoUrl: values.audioUrl,
+      videoUrl: result.fileURL,
       text: values.title,
       path: "/",
       coordinates: { x: 0, y: 0 },

--- a/components/forms/MusicNodeForm.tsx
+++ b/components/forms/MusicNodeForm.tsx
@@ -2,7 +2,7 @@ import { MusicPostValidation } from "@/lib/validations/thread";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useForm } from "react-hook-form";
 import { z } from "zod";
-import { useState } from "react";
+import { ChangeEvent, useState } from "react";
 import { Button } from "../ui/button";
 import {
   Form,
@@ -15,14 +15,14 @@ import {
 import { Input } from "../ui/input";
 
 interface Props {
-  onSubmit: (values: { audioUrl: string; title: string }) => void;
+  onSubmit: (values: { audioFile: File; title: string }) => void;
 }
 
 const MusicNodeForm = ({ onSubmit }: Props) => {
   const form = useForm({
     resolver: zodResolver(MusicPostValidation),
     defaultValues: {
-      youtubeUrl: "",
+      audio: new File([""], "filename"),
       title: "",
     },
   });
@@ -31,16 +31,7 @@ const MusicNodeForm = ({ onSubmit }: Props) => {
   async function handleSubmit(values: z.infer<typeof MusicPostValidation>) {
     setLoading(true);
     try {
-      const res = await fetch(
-        `/api/youtube-audio?url=${encodeURIComponent(values.youtubeUrl)}`
-      );
-      if (res.ok) {
-        const data = await res.json();
-        onSubmit({
-          audioUrl: data.audioUrl,
-          title: values.title || data.title,
-        });
-      }
+      onSubmit({ audioFile: values.audio, title: values.title });
     } finally {
       setLoading(false);
     }
@@ -54,12 +45,19 @@ const MusicNodeForm = ({ onSubmit }: Props) => {
       >
         <FormField
           control={form.control}
-          name="youtubeUrl"
+          name="audio"
           render={({ field }) => (
             <FormItem>
-              <FormLabel>YouTube URL</FormLabel>
+              <FormLabel>Audio File</FormLabel>
               <FormControl>
-                <Input type="text" placeholder="Enter a YouTube URL" {...field} />
+                <Input
+                  type="file"
+                  accept="audio/mpeg, audio/mp3, audio/wav"
+                  onChange={(e: ChangeEvent<HTMLInputElement>) => {
+                    const file = e.target.files && e.target.files[0];
+                    if (file) field.onChange(file);
+                  }}
+                />
               </FormControl>
               <FormMessage />
             </FormItem>

--- a/components/modals/MusicNodeModal.tsx
+++ b/components/modals/MusicNodeModal.tsx
@@ -8,12 +8,12 @@ import {
 interface Props {
   id?: string;
   isOwned: boolean;
-  onSubmit?: (values: { audioUrl: string; title: string }) => void;
+  onSubmit?: (values: { audioFile: File; title: string }) => void;
   currentUrl: string;
   currentTitle: string;
 }
 
-const renderCreate = ({ onSubmit }: { onSubmit?: (values: { audioUrl: string; title: string }) => void }) => (
+const renderCreate = ({ onSubmit }: { onSubmit?: (values: { audioFile: File; title: string }) => void }) => (
   <div>
     <DialogHeader className="dialog-header text-white text-lg py-4 mt-[-3rem]">
       <b>Create Post</b>

--- a/components/players/SoundCloudPlayer.tsx
+++ b/components/players/SoundCloudPlayer.tsx
@@ -1,0 +1,55 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import WaveSurfer from "wavesurfer.js";
+
+interface Props {
+  src: string;
+  title?: string;
+}
+
+const SoundCloudPlayer = ({ src, title }: Props) => {
+  const waveRef = useRef<WaveSurfer | null>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [isPlaying, setIsPlaying] = useState(false);
+
+  useEffect(() => {
+    if (!containerRef.current) return;
+    waveRef.current = WaveSurfer.create({
+      container: containerRef.current,
+      waveColor: "#d1d5db",
+      progressColor: "#f97316",
+      height: 64,
+      responsive: true,
+    });
+    if (src) waveRef.current.load(src);
+    return () => {
+      waveRef.current?.destroy();
+    };
+  }, [src]);
+
+  const togglePlay = () => {
+    if (!waveRef.current) return;
+    waveRef.current.playPause();
+    setIsPlaying(waveRef.current.isPlaying());
+  };
+
+  return (
+    <div className="w-full">
+      <div className="flex items-center gap-2 w-full">
+        <button
+          onClick={togglePlay}
+          className="likebutton text-[1rem] button p-2 rounded-full"
+        >
+          {isPlaying ? "Pause" : "Play"}
+        </button>
+        <div className="flex flex-col w-full">
+          {title && <div className="font-semibold text-sm mb-1">{title}</div>}
+          <div ref={containerRef} className="w-full" />
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default SoundCloudPlayer;

--- a/components/shared/NodeSidebar.tsx
+++ b/components/shared/NodeSidebar.tsx
@@ -29,7 +29,7 @@ import {
 } from "@/lib/actions/realtimepost.actions";
 import { convertPostToNode } from "@/lib/reactflow/reactflowutils";
 import { useReactFlow } from "@xyflow/react";
-import { uploadFileToSupabase } from "@/lib/utils";
+import { uploadFileToSupabase, uploadAudioToSupabase } from "@/lib/utils";
 import { useShallow } from "zustand/react/shallow";
 import { useAuth } from "@/lib/AuthContext";
 import { useRouter } from "next/navigation";
@@ -445,13 +445,15 @@ export default function NodeSidebar({
             isOwned={true}
             currentUrl=""
             currentTitle=""
-            onSubmit={(vals) => {
+            onSubmit={async (vals) => {
+              const result = await uploadAudioToSupabase(vals.audioFile);
+              if (result.error) return;
               createPostAndAddToCanvas({
                 path: pathname,
                 coordinates: centerPosition,
                 type: "MUSIC",
                 realtimeRoomId: roomId,
-                videoUrl: vals.audioUrl,
+                videoUrl: result.fileURL,
                 text: vals.title,
               });
             }}

--- a/lib/validations/thread.ts
+++ b/lib/validations/thread.ts
@@ -9,6 +9,19 @@ const ACCEPTED_IMAGE_TYPES = [
 ];
 const ACCEPTED_IMAGE_EXTENSIONS = [".jpeg", ".jpg", ".png", ".webp"];
 
+const ACCEPTED_AUDIO_TYPES = ["audio/mpeg", "audio/mp3", "audio/wav", "audio/x-wav"];
+const ACCEPTED_AUDIO_EXTENSIONS = [".mp3", ".wav"];
+
+function isAcceptedAudio(file: File) {
+  if (!file) return false;
+  const type = file.type?.toLowerCase();
+  const ext = file.name?.split(".").pop()?.toLowerCase();
+  return (
+    (type && ACCEPTED_AUDIO_TYPES.includes(type)) ||
+    (ext && ACCEPTED_AUDIO_EXTENSIONS.includes(`.${ext}`))
+  );
+}
+
 function isAcceptedImage(file: File) {
   if (!file) return false;
   const type = file.type?.toLowerCase();
@@ -146,7 +159,13 @@ export const SplineViewerPostValidation = z.object({
 });
 
 export const MusicPostValidation = z.object({
-  youtubeUrl: z.string().url(),
-  title: z.string().min(1).optional(),
+  audio: z
+    .any()
+    .refine((file) => file?.size <= MAX_FILE_SIZE, `Max audio size is 5MB.`)
+    .refine(
+      (file) => isAcceptedAudio(file),
+      "Only .mp3 and .wav formats are supported."
+    ),
+  title: z.string().min(1),
 });
 


### PR DESCRIPTION
## Summary
- allow audio file uploads instead of YouTube links
- validate MP3/WAV files
- upload music to Supabase
- play back posts with SoundCloud-like waveform player

## Testing
- `npm run lint`
- `npx jest --runInBand` *(fails: Can't reach database server)*

------
https://chatgpt.com/codex/tasks/task_e_687335c0c56c8329a456da3fef7b0c0c