### PR TITLE
Add Supabase setup info

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,16 @@ created in the global rooms and by friends and rooms that are subscribed to.
 
 The app/(root)/(realtime)/ folder contains the code for the reactflow canvas rooms.
 
+## Setup
+
+To avoid missing-bucket errors when uploading audio posts, create the `realtime_post_audio` bucket in Supabase:
+
+1. Navigate to **Storage** → **Create a new bucket**.
+2. Name it `realtime_post_audio` and set it to **public** (or adjust policies).
+3. Ensure public read access and upload permissions are allowed.
+
+Apply the same steps to create a `realtime_post_images` bucket if it does not already exist.
+
 ## Development
 
 1. Install dependencies


### PR DESCRIPTION
## Summary
- document creating the `realtime_post_audio` bucket in Supabase
- note to create `realtime_post_images` similarly

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_687349f662f88329b16d90ecde3ec44b