### PR TITLE
Fix wavesurfer cleanup

### DIFF
--- a/components/players/SoundCloudPlayer.tsx
+++ b/components/players/SoundCloudPlayer.tsx
@@ -22,9 +22,16 @@ const SoundCloudPlayer = ({ src, title }: Props) => {
       height: 64,
       responsive: true,
     });
-    if (src) waveRef.current.load(src);
+    if (src)
+      waveRef.current
+        .load(src)
+        .catch(() => null);
     return () => {
-      waveRef.current?.destroy();
+      try {
+        waveRef.current?.destroy();
+      } catch (err) {
+        console.error("WaveSurfer destroy failed", err);
+      }
     };
   }, [src]);
 


### PR DESCRIPTION
## Summary
- handle errors when destroying WaveSurfer
- catch aborted load errors

## Testing
- `npm run lint`
- `npm test` *(fails: Jest encountered an unexpected token)*

------
https://chatgpt.com/codex/tasks/task_e_6873995fbc94832997f063fb61e982d7