### PR TITLE
Add pagination for realtime posts

### DIFF
--- a/app/(root)/(standard)/page.tsx
+++ b/app/(root)/(standard)/page.tsx
@@ -13,7 +13,7 @@ export const metadata = {
 export const dynamic = "force-dynamic";
 
 export default async function Home() {
-  const result = await fetchRealtimePosts({
+  const { posts } = await fetchRealtimePosts({
     realtimeRoomId: "global",
     postTypes: [
       "TEXT",
@@ -39,11 +39,11 @@ export default async function Home() {
     <div >
       <Modal />
       <section className="mt-[0rem] flex flex-col gap-12">
-        {result.length === 0 ? (
+        {posts.length === 0 ? (
           <p className="no-result">Nothing found</p>
         ) : (
           <>
-            {result.map((realtimePost) => (
+            {posts.map((realtimePost) => (
               <PostCard
                 key={realtimePost.id.toString()}
                 currentUserId={user?.userId}


### PR DESCRIPTION
## Summary
- add pageNumber and pageSize parameters to `fetchRealtimePosts`
- update the home page to use the new pagination API

## Testing
- `npm run lint`
- `npm test` *(fails: Jest encountered an unexpected token in nanoid)*

------
https://chatgpt.com/codex/tasks/task_e_6873eedb77ac83299cc2e8632844b212