### PR TITLE
Fix Spline import path

### DIFF
--- a/components/cards/PostCard.tsx
+++ b/components/cards/PostCard.tsx
@@ -25,7 +25,7 @@ const founders = localFont({ src: './NewEdgeTest-RegularRounded.otf' })
 const DrawCanvas = dynamic(() => import("./DrawCanvas"), { ssr: false })
 const LivechatCard = dynamic(() => import("./LivechatCard"), { ssr: false })
 const EntropyCard = dynamic(() => import("./EntropyCard"), { ssr: false })
-const Spline = dynamic(() => import("@splinetool/react-spline"), { ssr: false })
+const Spline = dynamic(() => import("@splinetool/react-spline/next"), { ssr: false })
 
 interface Props {
   id: bigint;


### PR DESCRIPTION
## Summary
- fix dynamic import path for `@splinetool/react-spline`

## Testing
- `yarn lint`
- `npm test` *(fails: Jest encountered unexpected token in nanoid)*

------
https://chatgpt.com/codex/tasks/task_e_687413c10c00832992854f469c53aee3