### PR TITLE
Fix likes in client components

### DIFF
--- a/app/(root)/(realtime)/post/[id]/page.tsx
+++ b/app/(root)/(realtime)/post/[id]/page.tsx
@@ -2,6 +2,7 @@ import { fetchRealtimePostTreeById } from "@/lib/actions/realtimepost.actions";
 import { redirect, notFound } from "next/navigation";
 import { getUserFromCookies } from "@/lib/serverutils";
 import PostCard from "@/components/cards/PostCard";
+import { fetchRealtimeLikeForCurrentUser } from "@/lib/actions/like.actions";
 import Modal from "@/components/modals/Modal";
 import Comment from "@/components/forms/Comment";
 import CommentTree from "@/components/shared/CommentTree";
@@ -12,6 +13,12 @@ const Page = async ({ params }: { params: { id: string } }) => {
   if (!user?.onboarded) redirect("/onboarding");
   const post = await fetchRealtimePostTreeById({ id: params.id });
   if (!post) notFound();
+  const currentUserLike = user
+    ? await fetchRealtimeLikeForCurrentUser({
+        realtimePostId: post.id,
+        userId: user.userId,
+      })
+    : null;
 
   return (
     <section className="relative">
@@ -20,6 +27,7 @@ const Page = async ({ params }: { params: { id: string } }) => {
         <PostCard
           key={post.id.toString()}
           currentUserId={user?.userId}
+          currentUserLike={currentUserLike}
           id={post.id}
           isRealtimePost
           likeCount={post.like_count}

--- a/app/(root)/(standard)/thread/[id]/page.tsx
+++ b/app/(root)/(standard)/thread/[id]/page.tsx
@@ -4,6 +4,7 @@ import CommentTree from "@/components/shared/CommentTree";
 import { redirect, notFound } from "next/navigation";
 import { getUserFromCookies } from "@/lib/serverutils";
 import PostCard from "@/components/cards/PostCard";
+import { fetchLikeForCurrentUser } from "@/lib/actions/like.actions";
 import Modal from "@/components/modals/Modal";
 
 const Page = async ({ params }: { params: { id: string } }) => {
@@ -12,6 +13,9 @@ const Page = async ({ params }: { params: { id: string } }) => {
   if (!user?.onboarded) redirect("/onboarding");
   const post = await fetchPostTreeById(BigInt(params.id));
   if (!post) notFound();
+  const currentUserLike = user
+    ? await fetchLikeForCurrentUser({ postId: post.id, userId: user.userId })
+    : null;
   
   return (
     <section className="sticky ">
@@ -23,8 +27,8 @@ const Page = async ({ params }: { params: { id: string } }) => {
         <PostCard
           key={post.id.toString()}
           currentUserId={user?.userId}
+          currentUserLike={currentUserLike}
           id={post.id}
-          parentId={post.parent_id}
           content={post.content ?? undefined}
           image_url={post.image_url ?? undefined}
           video_url={post.video_url ?? undefined}

--- a/components/buttons/LikeButton.tsx
+++ b/components/buttons/LikeButton.tsx
@@ -18,7 +18,7 @@ interface Props {
   postId?: bigint;
   realtimePostId?: string;
   likeCount: number;
-  initialLikeState: Like | RealtimeLike | null;
+  initialLikeState?: Like | RealtimeLike | null;
 }
 
 const LikeButton = ({ postId, realtimePostId, likeCount, initialLikeState }: Props) => {

--- a/components/cards/PostCard.tsx
+++ b/components/cards/PostCard.tsx
@@ -1,3 +1,4 @@
+"use client";
 
 import Image from "next/image";
 import Link from "next/link";
@@ -15,11 +16,7 @@ import GalleryCarousel from "./GalleryCarousel";
 import SoundCloudPlayer from "../players/SoundCloudPlayer";
 import Spline from "@splinetool/react-spline";
 import dynamic from "next/dynamic";
-import {
-  fetchLikeForCurrentUser,
-  fetchRealtimeLikeForCurrentUser,
-} from "@/lib/actions/like.actions";
-import { Like, RealtimeLike } from "@prisma/client";
+import type { Like, RealtimeLike } from "@prisma/client";
 import React from "react";
 import localFont from 'next/font/local'
 const founders = localFont({ src: './NewEdgeTest-RegularRounded.otf' })
@@ -30,6 +27,7 @@ const EntropyCard = dynamic(() => import("./EntropyCard"), { ssr: false })
 interface Props {
   id: bigint;
   currentUserId?: bigint | null;
+  currentUserLike?: Like | RealtimeLike | null;
   image_url?: string;
   video_url?: string;
 
@@ -52,9 +50,10 @@ interface Props {
   claimIds?: (string | number | bigint)[];
 }
 
-const PostCard = async ({
+const PostCard = ({
   id,
   currentUserId,
+  currentUserLike = null,
   content,
   author,
   image_url,
@@ -70,15 +69,6 @@ const PostCard = async ({
   pluginData = null,
   claimIds,
   }: Props) => {
-  let currentUserLike: Like | RealtimeLike | null = null;
-  if (currentUserId) {
-    currentUserLike = isRealtimePost
-      ? await fetchRealtimeLikeForCurrentUser({
-          realtimePostId: id,
-          userId: currentUserId,
-        })
-      : await fetchLikeForCurrentUser({ postId: id, userId: currentUserId });
-  }
   if (content && content.startsWith("REPLICATE:")) {
     const originalId = BigInt(content.split(":" )[1]);
     return (

--- a/components/cards/ReplicatedPostCard.tsx
+++ b/components/cards/ReplicatedPostCard.tsx
@@ -1,6 +1,10 @@
 import PostCard from "./PostCard";
 import { fetchPostById } from "@/lib/actions/thread.actions";
 import { fetchRealtimePostById } from "@/lib/actions/realtimepost.actions";
+import {
+  fetchLikeForCurrentUser,
+  fetchRealtimeLikeForCurrentUser,
+} from "@/lib/actions/like.actions";
 
 interface Props {
   id: bigint;
@@ -32,10 +36,29 @@ const ReplicatedPostCard = async ({
     : await fetchPostById(originalPostId);
   if (!original) return null;
 
+  const currentUserLike = currentUserId
+    ? isRealtimePost
+      ? await fetchRealtimeLikeForCurrentUser({
+          realtimePostId: id,
+          userId: currentUserId,
+        })
+      : await fetchLikeForCurrentUser({ postId: id, userId: currentUserId })
+    : null;
+
+  const originalUserLike = currentUserId
+    ? isRealtimePost
+      ? await fetchRealtimeLikeForCurrentUser({
+          realtimePostId: original.id,
+          userId: currentUserId,
+        })
+      : await fetchLikeForCurrentUser({ postId: original.id, userId: currentUserId })
+    : null;
+
   return (
     <PostCard
       id={id}
       currentUserId={currentUserId}
+      currentUserLike={currentUserLike}
       content="Replicated"
       type="TEXT"
       isRealtimePost={isRealtimePost}
@@ -47,6 +70,7 @@ const ReplicatedPostCard = async ({
         <PostCard
           id={original.id}
           currentUserId={currentUserId}
+          currentUserLike={originalUserLike}
           content={original.content ?? undefined}
           image_url={(original as any).image_url ?? undefined}
           video_url={(original as any).video_url ?? undefined}

--- a/components/cards/ThreadCard.tsx
+++ b/components/cards/ThreadCard.tsx
@@ -1,11 +1,8 @@
-"use client";
-
-
 import Image from "next/image";
 import Link from "next/link";
 import LikeButton from "@/components/buttons/LikeButton";
 import { fetchLikeForCurrentUser } from "@/lib/actions/like.actions";
-import { Like } from "@prisma/client";
+import type { Like } from "@prisma/client";
 import { Comfortaa } from "next/font/google";
 import { Nunito } from "next/font/google";
 import ShareButton from "../buttons/ShareButton";
@@ -45,7 +42,6 @@ interface Props {
   pluginData?: Record<string, any> | null;
 }
 
-/* eslint-disable-next-line @next/next/no-async-client-component */
 const ThreadCard = async ({
   id,
   currentUserId,

--- a/components/shared/ThreadsTab.tsx
+++ b/components/shared/ThreadsTab.tsx
@@ -1,7 +1,6 @@
 import { fetchUserThreads } from "@/lib/actions/user.actions";
 import { redirect } from "next/navigation";
 import ThreadCard from "@/components/cards/ThreadCard";
-import PostCard from "../cards/PostCard";
 interface Props {
   currentUserId: bigint;
   accountId: bigint;


### PR DESCRIPTION
## Summary
- mark `PostCard` as a client component and remove server fetches
- let `LikeButton` accept optional `initialLikeState`
- fetch like state in server routes and pass via `currentUserLike` prop
- update replicated and realtime components to provide like info
- convert `ThreadCard` back to a server component
- clean up unused import in `ThreadsTab`

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6874175c1cec8329a985e14b56005bed