### PR TITLE
Fix server function usage

### DIFF
--- a/lib/actions/like.actions.ts
+++ b/lib/actions/like.actions.ts
@@ -1,5 +1,3 @@
-"use server";
-
 import { like_type } from "@prisma/client";
 import { prisma } from "../prismaclient";
 import { generateFriendSuggestions } from "./friend-suggestions.actions";
@@ -15,6 +13,7 @@ interface realtimeLikeParams {
 }
 
 export async function likePost({ userId, postId }: likePostParams) {
+  "use server";
   try {
     const uid = BigInt(userId);
     const pid = BigInt(postId);
@@ -85,6 +84,7 @@ export async function likePost({ userId, postId }: likePostParams) {
 }
 
 export async function unlikePost({ userId, postId }: likePostParams) {
+  "use server";
   try {
     const uid = BigInt(userId);
     const pid = BigInt(postId);
@@ -132,6 +132,7 @@ export async function unlikePost({ userId, postId }: likePostParams) {
 }
 
 export async function dislikePost({ userId, postId }: likePostParams) {
+  "use server";
   try {
     const uid = BigInt(userId);
     const pid = BigInt(postId);
@@ -225,6 +226,7 @@ export async function likeRealtimePost({
   userId,
   realtimePostId,
 }: realtimeLikeParams) {
+  "use server";
   try {
     const uid = BigInt(userId);
     const pid = BigInt(realtimePostId);
@@ -270,6 +272,7 @@ export async function unlikeRealtimePost({
   userId,
   realtimePostId,
 }: realtimeLikeParams) {
+  "use server";
   try {
     const uid = BigInt(userId);
     const pid = BigInt(realtimePostId);
@@ -304,6 +307,7 @@ export async function dislikeRealtimePost({
   userId,
   realtimePostId,
 }: realtimeLikeParams) {
+  "use server";
   try {
     const uid = BigInt(userId);
     const pid = BigInt(realtimePostId);

--- a/lib/actions/realtimepost.actions.ts
+++ b/lib/actions/realtimepost.actions.ts
@@ -1,5 +1,3 @@
-"use server";
-
 import { Prisma, realtime_post_type } from "@prisma/client";
 import { prisma } from "../prismaclient";
 import { revalidatePath } from "next/cache";
@@ -54,6 +52,7 @@ export async function createRealtimePost({
    pluginType,
    pluginData,
 }: CreateRealtimePostParams) {
+  "use server";
   const user = await getUserFromCookies();
   if (!user) {
     throw new Error("User not authenticated");
@@ -142,6 +141,7 @@ export async function updateRealtimePost({
   pluginType,
   pluginData,
 }: UpdateRealtimePostParams) {
+  "use server";
   const user = await getUserFromCookies();
   try {
     const originalPost = await prisma.realtimePost.findUniqueOrThrow({
@@ -209,6 +209,7 @@ export async function lockRealtimePost({
   lockState: boolean;
   path: string;
 }) {
+  "use server";
   const user = await getUserFromCookies();
   try {
     const originalPost = await prisma.realtimePost.findUniqueOrThrow({
@@ -344,6 +345,7 @@ export async function deleteRealtimePost({
   id: string;
   path?: string;
 }) {
+  "use server";
   const user = await getUserFromCookies();
   try {
     const originalPost = await prisma.realtimePost.findUniqueOrThrow({
@@ -468,6 +470,7 @@ export async function addCommentToRealtimePost({
   userId: bigint;
   path: string;
 }) {
+  "use server";
   try {
     const originalPost = await prisma.realtimePost.findUnique({
       where: { id: parentPostId },
@@ -550,6 +553,7 @@ export async function replicateRealtimePost({
   userId: string | number | bigint;
   path: string;
 }) {
+  "use server";
   try {
     const oid = BigInt(originalPostId);
     const uid = BigInt(userId);

--- a/lib/actions/thread.actions.ts
+++ b/lib/actions/thread.actions.ts
@@ -1,5 +1,3 @@
-"use server";
-
 import { prisma } from "../prismaclient";
 import { revalidatePath } from "next/cache";
 import { getUserFromCookies } from "../serverutils";
@@ -19,6 +17,7 @@ interface AddCommentToPostParams {
 }
 
 export async function createPost({ text, authorId, path, expirationDate }: CreatePostParams) {
+  "use server";
   try {
     const createdPost = await prisma.post.create({
       data: {
@@ -190,6 +189,7 @@ export async function addCommentToPost({
   userId,
   path,
 }: AddCommentToPostParams) {
+  "use server";
   try {
     const originalPost = await prisma.post.findUnique({
       where: {
@@ -233,6 +233,7 @@ export async function replicatePost({
   userId: string | number | bigint;
   path: string;
 }) {
+  "use server";
   try {
     const oid = BigInt(originalPostId);
     const uid = BigInt(userId);
@@ -266,6 +267,7 @@ export async function updatePostExpiration({
   postId: bigint;
   duration: string;
 }) {
+  "use server";
   const post = await prisma.post.findUnique({
     where: { id: postId },
   });
@@ -337,6 +339,7 @@ export async function archiveExpiredPosts() {
 }
 
 export async function deletePost({ id, path }: { id: bigint; path?: string }) {
+  "use server";
   const user = await getUserFromCookies();
   try {
     const originalPost = await prisma.post.findUniqueOrThrow({

--- a/lib/serverutils.ts
+++ b/lib/serverutils.ts
@@ -1,5 +1,3 @@
-"use server";
-
 import { getTokens } from "next-firebase-auth-edge";
 import { cookies } from "next/headers";
 import { User } from "./AuthContext";


### PR DESCRIPTION
## Summary
- avoid treating data fetching helpers as server actions
- mark mutation functions as `"use server"`
- call server-only utilities without server action overhead

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68741bbdea8c8329820e3061a3d43549