### PR TITLE
Fix replicated post fetch

### DIFF
--- a/app/api/replicated-post/route.ts
+++ b/app/api/replicated-post/route.ts
@@ -1,0 +1,47 @@
+import { NextRequest, NextResponse } from "next/server";
+import { fetchPostById } from "@/lib/actions/thread.actions";
+import { fetchRealtimePostById } from "@/lib/actions/realtimepost.actions";
+import {
+  fetchLikeForCurrentUser,
+  fetchRealtimeLikeForCurrentUser,
+} from "@/lib/actions/like.actions";
+
+export async function GET(req: NextRequest) {
+  const params = req.nextUrl.searchParams;
+  const id = params.get("id");
+  const originalId = params.get("originalId");
+  const userId = params.get("userId");
+  const isRealtime = params.get("isRealtime") === "true";
+
+  if (!id || !originalId) {
+    return NextResponse.json({ error: "Missing id or originalId" }, { status: 400 });
+  }
+
+  const original = isRealtime
+    ? await fetchRealtimePostById({ id: originalId })
+    : await fetchPostById(BigInt(originalId));
+
+  if (!original) {
+    return NextResponse.json({ original: null });
+  }
+
+  const currentUserLike = userId
+    ? isRealtime
+      ? await fetchRealtimeLikeForCurrentUser({
+          realtimePostId: BigInt(id),
+          userId: BigInt(userId),
+        })
+      : await fetchLikeForCurrentUser({ postId: BigInt(id), userId: BigInt(userId) })
+    : null;
+
+  const originalUserLike = userId
+    ? isRealtime
+      ? await fetchRealtimeLikeForCurrentUser({
+          realtimePostId: original.id,
+          userId: BigInt(userId),
+        })
+      : await fetchLikeForCurrentUser({ postId: original.id, userId: BigInt(userId) })
+    : null;
+
+  return NextResponse.json({ original, currentUserLike, originalUserLike });
+}


### PR DESCRIPTION
## Summary
- refactor `ReplicatedPostCard` into a client component that fetches data via API
- add `/api/replicated-post` endpoint to return original post and like info

## Testing
- `npm run lint`
- `npm test` *(fails: workflowBuilder.test.tsx, workflowRunner.test.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_687426bfda748329b6bffb5e258bc2c4