### PR TITLE
Fix BigInt API serialization

### DIFF
--- a/app/api/realtime-posts/route.ts
+++ b/app/api/realtime-posts/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { fetchRealtimePosts } from "@/lib/actions/realtimepost.actions";
 import { realtime_post_type } from "@prisma/client";
+import { serializeBigInt } from "@/lib/utils";
 
 export async function GET(req: NextRequest) {
   const params = req.nextUrl.searchParams;
@@ -31,5 +32,5 @@ export async function GET(req: NextRequest) {
     pageNumber: page,
     pageSize,
   });
-  return NextResponse.json(data);
+  return NextResponse.json(serializeBigInt(data));
 }

--- a/app/api/replicated-post/route.ts
+++ b/app/api/replicated-post/route.ts
@@ -5,6 +5,7 @@ import {
   fetchLikeForCurrentUser,
   fetchRealtimeLikeForCurrentUser,
 } from "@/lib/actions/like.actions";
+import { serializeBigInt } from "@/lib/utils";
 
 export async function GET(req: NextRequest) {
   const params = req.nextUrl.searchParams;
@@ -43,5 +44,7 @@ export async function GET(req: NextRequest) {
       : await fetchLikeForCurrentUser({ postId: original.id, userId: BigInt(userId) })
     : null;
 
-  return NextResponse.json({ original, currentUserLike, originalUserLike });
+  return NextResponse.json(
+    serializeBigInt({ original, currentUserLike, originalUserLike })
+  );
 }

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -296,3 +296,20 @@ export async function uploadAudioToSupabase(file: File) {
     return { fileURL: "", error: error };
   }
 }
+
+export function serializeBigInt(value: unknown): any {
+  if (typeof value === "bigint") {
+    return value.toString();
+  }
+  if (Array.isArray(value)) {
+    return value.map(serializeBigInt);
+  }
+  if (value && typeof value === "object") {
+    const result: Record<string, any> = {};
+    for (const [k, v] of Object.entries(value)) {
+      result[k] = serializeBigInt(v);
+    }
+    return result;
+  }
+  return value;
+}


### PR DESCRIPTION
## Summary
- add a `serializeBigInt` helper
- use `serializeBigInt` in `realtime-posts` and `replicated-post` routes to avoid JSON errors

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68742bbf43c88329aee70cc35e51af8f