### PR TITLE
Fix invalid date conversion in RealtimeFeed

### DIFF
--- a/components/shared/RealtimeFeed.tsx
+++ b/components/shared/RealtimeFeed.tsx
@@ -56,7 +56,7 @@ export default function RealtimeFeed({
           pluginData={(realtimePost as any).pluginData ?? null}
           type={realtimePost.type}
           author={realtimePost.author!}
-          createdAt={realtimePost.created_at.toDateString()}
+          createdAt={new Date(realtimePost.created_at).toDateString()}
           claimIds={realtimePost.productReview?.claims.map((c: any) => c.id.toString()) ?? []}
         />
       ))}


### PR DESCRIPTION
## Summary
- ensure the `created_at` field from API responses is parsed as a `Date` in `RealtimeFeed`

## Testing
- `yarn lint`


------
https://chatgpt.com/codex/tasks/task_e_68742f72fdfc8329baabaf27d8ead0ab