### PR TITLE
Add feed spinner

### DIFF
--- a/components/shared/RealtimeFeed.tsx
+++ b/components/shared/RealtimeFeed.tsx
@@ -2,6 +2,7 @@
 
 import PostCard from "@/components/cards/PostCard";
 import { useInfiniteRealtimePosts } from "@/lib/hooks/useInfiniteRealtimePosts";
+import Spinner from "@/components/ui/spinner";
 import { realtime_post_type } from "@prisma/client";
 import { useMemo } from "react";
 
@@ -33,7 +34,7 @@ export default function RealtimeFeed({
     [roomId, postTypes]
   );
 
-  const { posts, loaderRef } = useInfiniteRealtimePosts(
+  const { posts, loaderRef, loading } = useInfiniteRealtimePosts(
     fetchPage,
     initialPosts,
     initialIsNext
@@ -61,6 +62,11 @@ export default function RealtimeFeed({
         />
       ))}
       <div ref={loaderRef} className="h-1" />
+      {loading && (
+        <div className="flex justify-center py-4">
+          <Spinner />
+        </div>
+      )}
     </section>
   );
 }

--- a/lib/hooks/useInfiniteRealtimePosts.ts
+++ b/lib/hooks/useInfiniteRealtimePosts.ts
@@ -10,14 +10,18 @@ export function useInfiniteRealtimePosts(
   const [page, setPage] = useState(1);
   const [posts, setPosts] = useState(initialPosts);
   const [hasMore, setHasMore] = useState(initialIsNext);
+  const [loading, setLoading] = useState(false);
   const loaderRef = useRef<HTMLDivElement | null>(null);
 
   useEffect(() => {
     if (page === 1) return;
-    fetchPage(page).then((data) => {
-      setPosts((prev) => [...prev, ...data.posts]);
-      setHasMore(data.isNext);
-    });
+    setLoading(true);
+    fetchPage(page)
+      .then((data) => {
+        setPosts((prev) => [...prev, ...data.posts]);
+        setHasMore(data.isNext);
+      })
+      .finally(() => setLoading(false));
   }, [page, fetchPage]);
 
   useEffect(() => {
@@ -32,5 +36,5 @@ export function useInfiniteRealtimePosts(
     return () => observer.disconnect();
   }, [loaderRef, hasMore]);
 
-  return { posts, loaderRef };
+  return { posts, loaderRef, loading };
 }


### PR DESCRIPTION
## Summary
- display a spinner while infinite-scroll posts load
- track loading state in `useInfiniteRealtimePosts`

## Testing
- `npm run lint`
- `npm test` *(fails: SyntaxError in workflowRunner.test.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_687430f2b22083298b1722bcdc20f091