### PR TITLE
Implement Spotify import skeleton

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+# Spotify OAuth configuration
+SPOTIFY_CLIENT_ID=
+SPOTIFY_CLIENT_SECRET=
+REDIRECT_URI=http://localhost:3000/api/v2/favorites/import/spotify/callback

--- a/app/api/v2/favorites/import/spotify/route.ts
+++ b/app/api/v2/favorites/import/spotify/route.ts
@@ -1,0 +1,33 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getUserFromCookies } from "@/lib/serverutils";
+import { prisma } from "@/lib/prismaclient";
+import { exchangeCode } from "@/lib/spotify";
+import { spotifyIngestQueue } from "@/lib/queue";
+
+export async function POST(req: NextRequest) {
+  const user = await getUserFromCookies();
+  if (!user?.userId) {
+    return NextResponse.redirect("https://accounts.spotify.com/authorize", 302);
+  }
+  const body = await req.json();
+  const code = body.code as string | undefined;
+  if (!code) return NextResponse.json({ error: "code required" }, { status: 400 });
+  const tokens = await exchangeCode(code);
+  await prisma.linkedAccount.upsert({
+    where: { user_id_provider: { user_id: user.userId, provider: "spotify" } },
+    update: {
+      access_token: tokens.access_token,
+      refresh_token: tokens.refresh_token,
+      expires_at: new Date(Date.now() + tokens.expires_in * 1000),
+    },
+    create: {
+      user_id: user.userId,
+      provider: "spotify",
+      access_token: tokens.access_token,
+      refresh_token: tokens.refresh_token,
+      expires_at: new Date(Date.now() + tokens.expires_in * 1000),
+    },
+  });
+  const job = await spotifyIngestQueue.add("ingest", { userId: user.userId });
+  return NextResponse.json({ jobId: job.id }, { status: 202 });
+}

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -3,7 +3,16 @@ import "@testing-library/jest-dom";
 (require as any).context = jest.fn(() => ({
   keys: () => [],
 }));
-jest.mock("@/lib/supabaseclient", () => ({ supabase: {} }));
+jest.mock("@/lib/supabaseclient", () => ({
+  supabase: {
+    storage: {
+      from: jest.fn(() => ({
+        createSignedUploadUrl: jest.fn(async () => ({ data: "https://example.com/upload" })),
+        upload: jest.fn(),
+      })),
+    },
+  },
+}));
 jest.mock("@supabase/supabase-js", () => ({}));
 jest.mock("@xyflow/react", () => {
   const React = require("react");

--- a/lib/models/migrations/20250901000000_add_linked_accounts.sql
+++ b/lib/models/migrations/20250901000000_add_linked_accounts.sql
@@ -1,0 +1,11 @@
+CREATE TABLE IF NOT EXISTS "linked_accounts" (
+  "id" BIGSERIAL PRIMARY KEY,
+  "user_id" BIGINT NOT NULL REFERENCES "users"("id") ON DELETE CASCADE,
+  "provider" TEXT NOT NULL,
+  "access_token" TEXT NOT NULL,
+  "refresh_token" TEXT NOT NULL,
+  "expires_at" TIMESTAMPTZ,
+  "created_at" TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  UNIQUE ("user_id", "provider")
+);
+CREATE INDEX IF NOT EXISTS "linked_accounts_user_id_idx" ON "linked_accounts"("user_id");

--- a/lib/models/schema.prisma
+++ b/lib/models/schema.prisma
@@ -411,6 +411,21 @@ model Integration {
   @@map("integrations")
 }
 
+model LinkedAccount {
+  id           BigInt   @id @default(autoincrement())
+  user_id      BigInt
+  provider     String
+  access_token String
+  refresh_token String
+  expires_at   DateTime? @db.Timestamptz(6)
+  created_at   DateTime @default(now()) @db.Timestamptz(6)
+  user         User     @relation(fields: [user_id], references: [id], onDelete: Cascade)
+
+  @@unique([user_id, provider])
+  @@index([user_id])
+  @@map("linked_accounts")
+}
+
 model ProductReview {
   id               BigInt               @id @default(autoincrement())
   realtime_post_id BigInt?              @unique

--- a/lib/queue.ts
+++ b/lib/queue.ts
@@ -1,0 +1,6 @@
+import { Queue } from "bullmq";
+import redis from "./redis";
+
+export const spotifyIngestQueue = new Queue("spotify:ingest", {
+  connection: redis,
+});

--- a/lib/redis.ts
+++ b/lib/redis.ts
@@ -1,0 +1,9 @@
+import Redis from "ioredis";
+
+const redis = new Redis(process.env.REDIS_URL || "redis://localhost:6379");
+
+export function setSyncStatus(userId: number, status: string) {
+  return redis.set(`fav:sync:${userId}`, status);
+}
+
+export default redis;

--- a/lib/spotify.ts
+++ b/lib/spotify.ts
@@ -1,0 +1,44 @@
+import axios from "axios";
+import { supabase } from "./supabaseclient";
+
+export interface TokenResponse {
+  access_token: string;
+  refresh_token: string;
+  expires_in: number;
+}
+
+export async function exchangeCode(code: string): Promise<TokenResponse> {
+  const params = new URLSearchParams({
+    grant_type: "authorization_code",
+    code,
+    redirect_uri: process.env.REDIRECT_URI!,
+    client_id: process.env.SPOTIFY_CLIENT_ID!,
+    client_secret: process.env.SPOTIFY_CLIENT_SECRET!,
+  });
+  const res = await axios.post("https://accounts.spotify.com/api/token", params.toString(), {
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+  });
+  return res.data;
+}
+
+export async function refreshToken(refresh_token: string): Promise<TokenResponse> {
+  const params = new URLSearchParams({
+    grant_type: "refresh_token",
+    refresh_token,
+    client_id: process.env.SPOTIFY_CLIENT_ID!,
+    client_secret: process.env.SPOTIFY_CLIENT_SECRET!,
+  });
+  const res = await axios.post("https://accounts.spotify.com/api/token", params.toString(), {
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+  });
+  return res.data;
+}
+
+export async function uploadRaw(userId: number, data: unknown) {
+  const key = `spotify/${userId}/${new Date().toISOString().split("T")[0]}.json`;
+  const bucket = supabase.storage.from("favorites_raw");
+  const { data: url } = await bucket.createSignedUploadUrl(key);
+  if (url) {
+    await fetch(url, { method: "PUT", body: JSON.stringify(data) });
+  }
+}

--- a/supabase/migrations/20250901000000_add_linked_accounts.sql
+++ b/supabase/migrations/20250901000000_add_linked_accounts.sql
@@ -1,0 +1,11 @@
+CREATE TABLE IF NOT EXISTS "linked_accounts" (
+  "id" BIGSERIAL PRIMARY KEY,
+  "user_id" BIGINT NOT NULL REFERENCES "users"("id") ON DELETE CASCADE,
+  "provider" TEXT NOT NULL,
+  "access_token" TEXT NOT NULL,
+  "refresh_token" TEXT NOT NULL,
+  "expires_at" TIMESTAMPTZ,
+  "created_at" TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  UNIQUE ("user_id", "provider")
+);
+CREATE INDEX IF NOT EXISTS "linked_accounts_user_id_idx" ON "linked_accounts"("user_id");

--- a/tests/spotify.test.ts
+++ b/tests/spotify.test.ts
@@ -1,0 +1,30 @@
+import { exchangeCode, refreshToken, uploadRaw } from "@/lib/spotify";
+import axios from "axios";
+import { supabase } from "@/lib/supabaseclient";
+
+jest.mock("axios");
+
+const mockFrom = supabase.storage.from as jest.Mock;
+
+beforeEach(() => {
+  jest.resetAllMocks();
+  global.fetch = jest.fn(async () => ({ ok: true })) as any;
+});
+
+test("exchangeCode returns tokens", async () => {
+  (axios.post as jest.Mock).mockResolvedValue({ data: { access_token: "a", refresh_token: "r", expires_in: 1 } });
+  const t = await exchangeCode("code");
+  expect(t.access_token).toBe("a");
+});
+
+test("refreshToken failure throws", async () => {
+  (axios.post as jest.Mock).mockRejectedValue(new Error("bad"));
+  await expect(refreshToken("x")).rejects.toThrow("bad");
+});
+
+test("uploadRaw uses storage path", async () => {
+  const upload = jest.fn();
+  mockFrom.mockReturnValue({ createSignedUploadUrl: jest.fn(async () => ({ data: "u" })), upload });
+  await uploadRaw(1, []);
+  expect(mockFrom).toHaveBeenCalledWith("favorites_raw");
+});

--- a/workers/index.ts
+++ b/workers/index.ts
@@ -1,0 +1,1 @@
+import "./spotifyIngest";

--- a/workers/spotifyIngest.ts
+++ b/workers/spotifyIngest.ts
@@ -1,0 +1,60 @@
+import { Worker } from "bullmq";
+import { spotifyIngestQueue } from "@/lib/queue";
+import { prisma } from "@/lib/prismaclient";
+import { refreshToken, uploadRaw } from "@/lib/spotify";
+import redis, { setSyncStatus } from "@/lib/redis";
+import axios from "axios";
+
+async function fetchTracks(access: string) {
+  let url: string | null = "https://api.spotify.com/v1/me/tracks?limit=50&offset=0";
+  const tracks: any[] = [];
+  while (url) {
+    const res = await axios.get(url, { headers: { Authorization: `Bearer ${access}` } });
+    tracks.push(...res.data.items);
+    url = res.data.next;
+  }
+  return tracks;
+}
+
+new Worker(
+  "spotify:ingest",
+  async (job) => {
+    const userId = job.data.userId as number;
+    await setSyncStatus(userId, "syncing");
+    const account = await prisma.linkedAccount.findFirst({
+      where: { user_id: userId, provider: "spotify" },
+    });
+    if (!account) {
+      await setSyncStatus(userId, "error:noaccount");
+      return;
+    }
+    let access = account.access_token;
+    try {
+      const tracks = await fetchTracks(access);
+      await uploadRaw(userId, tracks);
+      await setSyncStatus(userId, "done");
+    } catch (err: any) {
+      if (err.response?.status === 401 && account.refresh_token) {
+        try {
+          const t = await refreshToken(account.refresh_token);
+          access = t.access_token;
+          await prisma.linkedAccount.update({
+            where: { id: account.id },
+            data: {
+              access_token: t.access_token,
+              expires_at: new Date(Date.now() + t.expires_in * 1000),
+            },
+          });
+          const tracks = await fetchTracks(access);
+          await uploadRaw(userId, tracks);
+          await setSyncStatus(userId, "done");
+        } catch (e) {
+          await setSyncStatus(userId, "error:token");
+        }
+      } else {
+        await setSyncStatus(userId, `error:${err.message}`);
+      }
+    }
+  },
+  { connection: redis }
+);


### PR DESCRIPTION
## Summary
- add Spotify OAuth endpoint and ingest worker skeleton
- store linked account tokens via new migrations
- mock Supabase Storage in tests
- cover Spotify helpers with tests

## Testing
- `npm run test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68756c8a77c08329a94204aecf562039