### PR TITLE
Fix feature store start command

### DIFF
--- a/services/feature-store/Dockerfile
+++ b/services/feature-store/Dockerfile
@@ -3,4 +3,4 @@ WORKDIR /app
 COPY requirements.txt ./
 RUN pip install --no-cache-dir -r requirements.txt
 COPY . .
-CMD ["feast", "serve", "--host", "0.0.0.0", "--ui-port", "8888"]
+CMD ["feast", "serve", "--host", "0.0.0.0", "--port", "8888"]


### PR DESCRIPTION
## Summary
- fix feature-store Dockerfile to use --port flag

## Testing
- `yarn install --frozen-lockfile`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68757f4045a8832991cfd0d41dce519b