### PR TITLE
Implement metadata fetcher

### DIFF
--- a/database/migrations/20250716_edge_logs.sql
+++ b/database/migrations/20250716_edge_logs.sql
@@ -1,0 +1,7 @@
+CREATE SCHEMA IF NOT EXISTS edge_logs;
+CREATE TABLE IF NOT EXISTS edge_logs.external_meta (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  provider TEXT NOT NULL,
+  ms INT NOT NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);

--- a/services/meta/cache.ts
+++ b/services/meta/cache.ts
@@ -1,0 +1,14 @@
+import Redis from "ioredis";
+
+const redis = new Redis(process.env.REDIS_URL || "redis://localhost:6379");
+export const TTL_SECONDS = 86400;
+
+export async function getCached(key: string): Promise<string | null> {
+  return redis.get(key);
+}
+
+export async function setCached(key: string, value: string): Promise<void> {
+  await redis.set(key, value, "EX", 86400);
+}
+
+export default redis;

--- a/services/meta/index.ts
+++ b/services/meta/index.ts
@@ -1,0 +1,38 @@
+import { fetchFromTMDb } from "./tmdb";
+import { fetchFromMusicBrainz } from "./musicbrainz";
+import { fetchFromOpenLibrary } from "./openlibrary";
+import { Meta, ProviderType } from "./types";
+import { getCached, setCached } from "./cache";
+import type { SupabaseClient } from "@supabase/supabase-js";
+
+export async function fetchMetaAndUpsert(
+  db: SupabaseClient,
+  id: string,
+  type: ProviderType,
+  externalId: string,
+): Promise<Meta | null> {
+  const cacheKey = `meta:${type}:${externalId}`;
+  const cached = await getCached(cacheKey);
+  if (cached) return JSON.parse(cached) as Meta;
+
+  let meta: Meta | null = null;
+  const start = Date.now();
+  if (type === "movie" || type === "tv") meta = await fetchFromTMDb(externalId);
+  else if (type === "music") meta = await fetchFromMusicBrainz(externalId);
+  else meta = await fetchFromOpenLibrary(externalId);
+  const ms = Date.now() - start;
+  if (!meta) return null;
+
+  await setCached(cacheKey, JSON.stringify(meta));
+  await db.from("canonical_media").update({
+    metadata: meta,
+    updated_at: new Date().toISOString(),
+  }).eq("id", id);
+
+  await db.from("edge_logs.external_meta").insert({
+    provider: type,
+    ms,
+  });
+
+  return meta;
+}

--- a/services/meta/musicbrainz.ts
+++ b/services/meta/musicbrainz.ts
@@ -1,0 +1,30 @@
+import { Meta } from "./types";
+
+async function request(url: string, retries = 3): Promise<any> {
+  for (let i = 0; i < retries; i++) {
+    const res = await fetch(url, { headers: { Accept: "application/json" } });
+    if (res.status === 429 && i < retries - 1) {
+      const wait = Number(res.headers.get("retry-after")) || 0.5;
+      await new Promise((r) => setTimeout(r, wait * 1000));
+      continue;
+    }
+    if (res.status === 404) return null;
+    if (!res.ok) throw new Error(`mb ${res.status}`);
+    return res.json();
+  }
+  throw new Error("mb failed after retries");
+}
+
+export async function fetchFromMusicBrainz(id: string): Promise<Meta | null> {
+  const data = await request(
+    `https://musicbrainz.org/ws/2/recording/${id}?inc=artists+releases+tags&fmt=json`,
+  );
+  if (!data) return null;
+  const release = data.releases && data.releases[0];
+  const date = release?.date || "";
+  return {
+    genres: (data.tags || []).map((t: any) => t.name),
+    year: date ? Number(date.slice(0, 4)) : NaN,
+    synopsis: "",
+  };
+}

--- a/services/meta/openlibrary.ts
+++ b/services/meta/openlibrary.ts
@@ -1,0 +1,31 @@
+import { Meta } from "./types";
+
+async function request(url: string, retries = 3): Promise<any> {
+  for (let i = 0; i < retries; i++) {
+    const res = await fetch(url);
+    if (res.status === 429 && i < retries - 1) {
+      const wait = Number(res.headers.get("retry-after")) || 0.5;
+      await new Promise((r) => setTimeout(r, wait * 1000));
+      continue;
+    }
+    if (res.status === 404) return null;
+    if (!res.ok) throw new Error(`ol ${res.status}`);
+    return res.json();
+  }
+  throw new Error("ol failed after retries");
+}
+
+export async function fetchFromOpenLibrary(id: string): Promise<Meta | null> {
+  const data = await request(`https://openlibrary.org/works/${id}.json`);
+  if (!data) return null;
+  const desc = typeof data.description === "string"
+    ? data.description
+    : data.description?.value || "";
+  return {
+    genres: data.subjects || [],
+    year: data.first_publish_date
+      ? Number(String(data.first_publish_date).slice(0, 4))
+      : NaN,
+    synopsis: desc,
+  };
+}

--- a/services/meta/tmdb.ts
+++ b/services/meta/tmdb.ts
@@ -1,0 +1,33 @@
+import { Meta } from "./types";
+
+const API_KEY = process.env.TMDB_API_KEY || "";
+
+async function request(url: string, retries = 3): Promise<any> {
+  for (let i = 0; i < retries; i++) {
+    const res = await fetch(url);
+    if (res.status === 429 && i < retries - 1) {
+      const wait = Number(res.headers.get("retry-after")) || 0.5;
+      await new Promise((r) => setTimeout(r, wait * 1000));
+      continue;
+    }
+    if (res.status === 404) return null;
+    if (!res.ok) throw new Error(`tmdb ${res.status}`);
+    return res.json();
+  }
+  throw new Error("tmdb failed after retries");
+}
+
+export async function fetchFromTMDb(id: string): Promise<Meta | null> {
+  const data = await request(
+    `https://api.themoviedb.org/3/movie/${id}?language=en-US&api_key=${API_KEY}`,
+  );
+  if (!data) return null;
+  return {
+    genres: (data.genres || []).map((g: any) => g.name),
+    year: data.release_date ? Number(data.release_date.slice(0, 4)) : NaN,
+    synopsis: data.overview || "",
+    poster_url: data.poster_path
+      ? `https://image.tmdb.org/t/p/w500${data.poster_path}`
+      : undefined,
+  };
+}

--- a/services/meta/types.ts
+++ b/services/meta/types.ts
@@ -1,0 +1,8 @@
+export interface Meta {
+  genres: string[];
+  year: number;
+  synopsis: string;
+  poster_url?: string;
+}
+
+export type ProviderType = "movie" | "tv" | "music" | "book";

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -11,6 +11,7 @@ port = 54321
 # Schemas to expose in your API. Tables, views and stored procedures in this schema will get API
 # endpoints. `public` and `graphql_public` schemas are included by default.
 schemas = ["public", "graphql_public"]
+excluded_paths = ["/fetch_meta"]
 # Extra schemas to add to the search_path of every request.
 extra_search_path = ["public", "extensions"]
 # The maximum number of rows returns from a view, table, or stored procedure. Limits payload size

--- a/supabase/functions/fetch_meta/index.ts
+++ b/supabase/functions/fetch_meta/index.ts
@@ -1,0 +1,79 @@
+// deno-lint-ignore-file
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+import { object, string, parse } from "https://esm.sh/valibot@0.15.0";
+import { fetchFromTMDb } from "../../../services/meta/tmdb.ts";
+import { fetchFromMusicBrainz } from "../../../services/meta/musicbrainz.ts";
+import { fetchFromOpenLibrary } from "../../../services/meta/openlibrary.ts";
+import { createClient as createRedis } from "https://deno.land/x/redis@v0.29.4/mod.ts";
+
+const schema = object({
+  id: string(),
+  type: string(),
+  external_id: string(),
+});
+
+const supabase = createClient(
+  Deno.env.get("SUPABASE_URL")!,
+  Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!,
+);
+
+const redis = await createRedis({
+  hostname: Deno.env.get("REDIS_HOST") || "127.0.0.1",
+  port: Number(Deno.env.get("REDIS_PORT") || 6379),
+  password: Deno.env.get("REDIS_PASSWORD") || undefined,
+});
+
+async function getCached(key: string) {
+  const value = await redis.get(key);
+  return value ? JSON.parse(value) : null;
+}
+
+async function setCached(key: string, value: unknown) {
+  await redis.setex(key, 86400, JSON.stringify(value));
+}
+
+Deno.serve(async (req: Request) => {
+  const url = new URL(req.url);
+  const params = parse(schema, {
+    id: url.searchParams.get("id"),
+    type: url.searchParams.get("type"),
+    external_id: url.searchParams.get("external_id"),
+  });
+
+  const cacheKey = `meta:${params.type}:${params.external_id}`;
+  const cached = await getCached(cacheKey);
+  if (cached) {
+    return new Response(JSON.stringify(cached), {
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
+  let meta = null;
+  const start = Date.now();
+  if (params.type === "movie" || params.type === "tv") {
+    meta = await fetchFromTMDb(params.external_id);
+  } else if (params.type === "music") {
+    meta = await fetchFromMusicBrainz(params.external_id);
+  } else {
+    meta = await fetchFromOpenLibrary(params.external_id);
+  }
+  const ms = Date.now() - start;
+
+  if (!meta) return new Response("not found", { status: 404 });
+
+  await setCached(cacheKey, meta);
+
+  await supabase.from("canonical_media").update({
+    metadata: meta,
+    updated_at: new Date().toISOString(),
+  }).eq("id", params.id);
+
+  await supabase.from("edge_logs.external_meta").insert({
+    provider: params.type,
+    ms,
+  });
+
+  return new Response(JSON.stringify(meta), {
+    headers: { "Content-Type": "application/json" },
+  });
+});

--- a/tests/adapters.contract.spec.ts
+++ b/tests/adapters.contract.spec.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect, afterAll, beforeAll, vi } from "vitest";
+import { setupServer } from "msw/node";
+import { rest } from "msw";
+import { fetchMetaAndUpsert } from "../services/meta";
+
+const server = setupServer();
+
+beforeAll(() => server.listen());
+afterAll(() => server.close());
+
+const update = vi.fn();
+const insert = vi.fn();
+const mockDb = { from: vi.fn(() => ({ update, insert })) } as any;
+
+it("tmdb adapter maps fields", async () => {
+  server.use(
+    rest.get("https://api.themoviedb.org/3/movie/603", (_req, res, ctx) =>
+      res(
+        ctx.json({
+          genres: [{ name: "Action" }],
+          release_date: "1999-03-31",
+          overview: "desc",
+          poster_path: "/p.jpg",
+        }),
+      ),
+    ),
+  );
+  const data = await fetchMetaAndUpsert(mockDb, "id", "movie", "603");
+  expect(data).toEqual({
+    genres: ["Action"],
+    year: 1999,
+    synopsis: "desc",
+    poster_url: "https://image.tmdb.org/t/p/w500/p.jpg",
+  });
+  expect(update).toHaveBeenCalledTimes(1);
+});
+
+it("musicbrainz adapter maps fields", async () => {
+  server.use(
+    rest.get(
+      "https://musicbrainz.org/ws/2/recording/mbid",
+      (_req, res, ctx) =>
+        res(
+          ctx.json({
+            tags: [{ name: "rock" }],
+            releases: [{ date: "2001-01-01" }],
+          }),
+        ),
+    ),
+  );
+  const data = await fetchMetaAndUpsert(mockDb, "id", "music", "mbid");
+  expect(data).toEqual({ genres: ["rock"], year: 2001, synopsis: "" });
+  expect(update).toHaveBeenCalledTimes(2);
+});
+
+it("openlibrary adapter maps fields", async () => {
+  server.use(
+    rest.get("https://openlibrary.org/works/olid.json", (_req, res, ctx) =>
+      res(
+        ctx.json({
+          subjects: ["s1"],
+          first_publish_date: "1984",
+          description: { value: "d" },
+        }),
+      ),
+    ),
+  );
+  const data = await fetchMetaAndUpsert(mockDb, "id", "book", "olid");
+  expect(data).toEqual({ genres: ["s1"], year: 1984, synopsis: "d" });
+  expect(update).toHaveBeenCalledTimes(3);
+});

--- a/tests/fetch_meta.unit.spec.ts
+++ b/tests/fetch_meta.unit.spec.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect, vi } from "vitest";
+import { fetchMetaAndUpsert } from "../services/meta";
+import { TTL_SECONDS } from "../services/meta/cache";
+
+let cacheValue: string | null = null;
+let setArgs: any[] | null = null;
+
+vi.mock("ioredis", () => ({
+  default: class {
+    get = vi.fn(async () => cacheValue);
+    set = vi.fn((...args: any[]) => {
+      setArgs = args;
+    });
+  },
+}));
+
+vi.mock("../services/meta/tmdb", () => ({
+  fetchFromTMDb: vi.fn(async () => ({ genres: ["A"], year: 2020, synopsis: "" })),
+}));
+
+const mockDb = { from: vi.fn(() => ({ update: vi.fn(), insert: vi.fn() })) } as any;
+
+describe("cache logic", () => {
+  it("cacheHit returns cached JSON, no HTTP", async () => {
+    cacheValue = JSON.stringify({ genres: [], year: 2000, synopsis: "cached" });
+    setArgs = null;
+    const result = await fetchMetaAndUpsert(mockDb, "1", "movie", "5");
+    expect(result?.synopsis).toBe("cached");
+    expect(setArgs).toBeNull();
+  });
+
+  it("cacheMiss stores value with TTL \u2248 24 h", async () => {
+    cacheValue = null;
+    setArgs = null;
+    await fetchMetaAndUpsert(mockDb, "1", "movie", "5");
+    expect(setArgs).toEqual([
+      "meta:movie:5",
+      JSON.stringify({ genres: ["A"], year: 2020, synopsis: "" }),
+      "EX",
+      TTL_SECONDS,
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary
- create `/fetch_meta` edge function
- add provider adapters and cache helpers
- log external meta events
- exclude `/fetch_meta` from PostgREST
- add unit and contract tests for caching and adapters

## Testing
- `npm run lint`
- `npm run vitest` *(fails: Failed to load modules and other errors)*

------
https://chatgpt.com/codex/tasks/task_e_6875850cc8788329a41009600318232e