### PR TITLE
Fix Prisma auth schema

### DIFF
--- a/lib/models/schema.prisma
+++ b/lib/models/schema.prisma
@@ -1,12 +1,14 @@
 generator client {
   provider   = "prisma-client-js"
   engineType = "library"
+  previewFeatures = ["multiSchema"]
 }
 
 datasource db {
   provider  = "postgresql"
   url       = env("DATABASE_URL")
   directUrl = env("DIRECT_URL")
+  schemas   = ["public", "auth"]
 }
 
 /// This model contains row level security and requires additional setup for migrations. Visit https://pris.ly/d/row-level-security for more info.


### PR DESCRIPTION
## Summary
- enable multiSchema preview feature
- specify public and auth schemas in datasource

## Testing
- `npm run lint`
- `yarn install` *(fails: ephemera couldn't be built)*

------
https://chatgpt.com/codex/tasks/task_e_68759848c1a4832996baf209dbcb6bea