### PR TITLE
Remove FK dependency on auth schema

### DIFF
--- a/supabase/migrations/20250715_feature_store.sql
+++ b/supabase/migrations/20250715_feature_store.sql
@@ -1,5 +1,5 @@
 CREATE TABLE IF NOT EXISTS user_taste_vectors (
-  user_id BIGINT PRIMARY KEY REFERENCES auth.users(id),
+  user_id BIGINT PRIMARY KEY,
   taste vector(256) NOT NULL,
   traits jsonb DEFAULT '{}'::jsonb,
   updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()

--- a/supabase/migrations/20250717_create_scroll_events.sql
+++ b/supabase/migrations/20250717_create_scroll_events.sql
@@ -1,7 +1,7 @@
 -- Scroll events captured when a user lingers on a post or room
 create table if not exists scroll_events (
   id          bigserial primary key,
-  user_id     uuid        not null references auth.users(id),
+  user_id     uuid        not null,
   content_id  uuid,                     -- optional: post / room / media id
   dwell_ms    integer     not null,     -- how long the user stayed, ms
   created_at  timestamptz not null default now()

--- a/supabase/migrations/20250717_fix_uuid_types.sql
+++ b/supabase/migrations/20250717_fix_uuid_types.sql
@@ -5,7 +5,7 @@ CREATE EXTENSION IF NOT EXISTS pg_cron;
 
 -- 1. Taste vectors
 CREATE TABLE IF NOT EXISTS user_taste_vectors (
-  user_id     UUID PRIMARY KEY REFERENCES auth.users(id),
+  user_id     UUID PRIMARY KEY,
   taste       VECTOR(256)  NOT NULL,
   traits      JSONB        DEFAULT '{}'::jsonb,
   updated_at  TIMESTAMPTZ  NOT NULL DEFAULT NOW()
@@ -18,7 +18,7 @@ CREATE INDEX IF NOT EXISTS user_taste_vectors_ann
 -- 2. Scroll events
 CREATE TABLE IF NOT EXISTS scroll_events (
   id          BIGSERIAL    PRIMARY KEY,
-  user_id     UUID         NOT NULL REFERENCES auth.users(id),
+  user_id     UUID         NOT NULL,
   dwell_ms    INT          NOT NULL,
   created_at  TIMESTAMPTZ  NOT NULL DEFAULT NOW()
 );

--- a/tests/feature_store.test.ts
+++ b/tests/feature_store.test.ts
@@ -5,13 +5,11 @@ let client: Client;
 beforeAll(async () => {
   client = new Client({ user: "root", host: "/var/run/postgresql", database: "postgres" });
   await client.connect();
-  await client.query("CREATE SCHEMA IF NOT EXISTS auth");
-  await client.query("CREATE TABLE IF NOT EXISTS auth.users(id BIGINT PRIMARY KEY)");
   await client.query("CREATE TABLE IF NOT EXISTS scroll_events(user_id BIGINT, dwell_ms INT)");
   await client.query("DROP MATERIALIZED VIEW IF EXISTS user_dwell_avg");
   await client.query("DROP TABLE IF EXISTS user_taste_vectors CASCADE");
   await client.query(`CREATE TABLE user_taste_vectors (
-    user_id BIGINT PRIMARY KEY REFERENCES auth.users(id),
+    user_id BIGINT PRIMARY KEY,
     taste vector(256) NOT NULL,
     traits JSONB DEFAULT '{}'::jsonb,
     updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
@@ -29,7 +27,6 @@ describe("feature store", () => {
     const vec = Array(256).fill(0);
     vec[0] = 1;
     const vectorStr = `[${vec.join(",")}]`;
-    await client.query("INSERT INTO auth.users(id) VALUES (1) ON CONFLICT DO NOTHING");
     await client.query("INSERT INTO user_taste_vectors(user_id, taste) VALUES ($1, $2::vector)", [1, vectorStr]);
     const { rows } = await client.query("SELECT user_id FROM user_taste_vectors ORDER BY taste <-> $1::vector LIMIT 1", [vectorStr]);
     expect(Number(rows[0].user_id)).toBe(1);


### PR DESCRIPTION
## Summary
- drop foreign key references to `auth.users`
- update feature store test to work without `auth` schema

## Testing
- `npm run lint`
- `yarn test` *(fails: feature_store.test.ts, discovery-candidates.integration.test.ts, redisCache.test.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68759d47140c8329b51797e92e65d9dd