### PR TITLE
feat/media-embedding-api

### DIFF
--- a/api/embed.py
+++ b/api/embed.py
@@ -1,4 +1,95 @@
-from services.embedding.main import app
+import os
+import json
+import asyncio
+import time
+from typing import Any, List
 
-# Vercel entrypoint
+import asyncpg
+import numpy as np
+import openai
+from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel
 
+app = FastAPI()
+
+
+async def get_db() -> asyncpg.Connection:
+    return await asyncpg.connect(os.environ.get("DATABASE_URL"))
+
+
+def remaining_budget() -> float:
+    try:
+        return float(os.environ.get("OPENAI_BUDGET_REMAINING", "10"))
+    except ValueError:
+        return 10.0
+
+
+async def create_embedding(text: str) -> List[float]:
+    resp = await asyncio.to_thread(
+        openai.embeddings.create,
+        input=[text],
+        model="text-embedding-3-large",
+    )
+    vec = resp.data[0].embedding
+    arr = np.array(vec, dtype=np.float32).reshape(768, 4)
+    down = arr.mean(axis=1).astype(np.float16)
+    return down.tolist()
+
+
+class EmbedRequest(BaseModel):
+    mediaId: str
+
+
+@app.post("/api/embed")
+async def handle(req: EmbedRequest) -> Any:
+    media_id = req.mediaId
+    db = await get_db()
+    try:
+        row = await db.fetchrow(
+            "SELECT title, description, tags, embedding FROM canonical_media WHERE id=$1",
+            media_id,
+        )
+        if not row:
+            raise HTTPException(status_code=404, detail="media not found")
+
+        if row["embedding"] is not None:
+            return {"embedding": row["embedding"], "cached": True}
+
+        if remaining_budget() < 5:
+            raise HTTPException(status_code=500, detail="budget exhausted")
+
+        text = " ".join(
+            filter(
+                None,
+                [
+                    row["title"],
+                    row.get("description") or "",
+                    " ".join((row.get("tags") or [])[:3]),
+                ],
+            )
+        )
+        try:
+            start = time.perf_counter()
+            vec = await create_embedding(text)
+            latency = time.perf_counter() - start
+        except openai.RateLimitError as e:
+            raise HTTPException(status_code=429, detail="rate limited") from e
+
+        await db.execute(
+            "UPDATE canonical_media SET embedding=$1 WHERE id=$2",
+            vec,
+            media_id,
+        )
+
+        print(
+            json.dumps(
+                {
+                    "mediaId": media_id,
+                    "cached": False,
+                    "latency_ms": int(latency * 1000),
+                }
+            )
+        )
+        return {"embedding": vec, "cached": False}
+    finally:
+        await db.close()

--- a/apps/builder/__tests__/embed.spec.ts
+++ b/apps/builder/__tests__/embed.spec.ts
@@ -1,0 +1,15 @@
+import { describe, it, expect, vi } from "vitest";
+
+describe("embed api", () => {
+  it("handles response", async () => {
+    const fetchMock = vi.fn(async () => ({
+      ok: true,
+      json: async () => ({ embedding: [0.1], cached: true }),
+    }));
+
+    const resp = await fetchMock("/api/embed", { method: "POST" });
+    expect(fetchMock).toHaveBeenCalledWith("/api/embed", expect.anything());
+    const data = await resp.json();
+    expect(data).toMatchObject({ embedding: expect.any(Array), cached: true });
+  });
+});

--- a/tests/api/test_embed.py
+++ b/tests/api/test_embed.py
@@ -1,0 +1,65 @@
+from fastapi.testclient import TestClient
+
+import api.embed as embed
+
+
+class DummyConn:
+    def __init__(self, row):
+        self.row = row
+        self.saved = None
+
+    async def fetchrow(self, *args, **kwargs):
+        return self.row
+
+    async def execute(self, *args):
+        self.saved = args[1]
+
+    async def close(self):
+        pass
+
+
+def test_embed_existing_returns_cached(monkeypatch):
+    row = {"title": "t", "description": "d", "tags": ["x"], "embedding": [1.0]}
+    conn = DummyConn(row)
+
+    async def get_db():
+        return conn
+
+    monkeypatch.setattr(embed, "get_db", get_db)
+
+    called = False
+
+    async def create_embedding(text: str):
+        nonlocal called
+        called = True
+        return [0.0]
+
+    monkeypatch.setattr(embed, "create_embedding", create_embedding)
+
+    client = TestClient(embed.app)
+    resp = client.post("/api/embed", json={"mediaId": "1"})
+    assert resp.status_code == 200
+    assert resp.json()["cached"] is True
+    assert resp.json()["embedding"] == [1.0]
+    assert called is False
+
+
+def test_embed_creates_and_saves(monkeypatch):
+    row = {"title": "t", "description": "d", "tags": ["a", "b", "c"], "embedding": None}
+    conn = DummyConn(row)
+
+    async def get_db():
+        return conn
+
+    monkeypatch.setattr(embed, "get_db", get_db)
+
+    async def create_embedding(text: str):
+        return [0.1] * 768
+
+    monkeypatch.setattr(embed, "create_embedding", create_embedding)
+
+    client = TestClient(embed.app)
+    resp = client.post("/api/embed", json={"mediaId": "1"})
+    assert resp.status_code == 200
+    assert resp.json()["cached"] is False
+    assert isinstance(conn.saved, list) and len(conn.saved) == 768


### PR DESCRIPTION
## Summary
- implement a Python /api/embed endpoint that caches embeddings
- add pytest covering cached and new embeddings
- add vitest stub test for builder app

## Testing
- `npm run lint`
- `PYTHONPATH=$PWD pytest -q --import-mode=importlib` *(fails: ConnectionError, missing async plugins)*

------
https://chatgpt.com/codex/tasks/task_e_6875de500eb08329a7474e1ed0bc5de8