### PR TITLE
Fix Supabase config parsing error

### DIFF
--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -63,11 +63,9 @@ sql_paths = ["./seed.sql"]
 
 
 
+# Realtime configuration
 [realtime]
 enabled = true
-# Tables to emit change events for
-[realtime.tables]
-"public.scroll_events" = { replica_identity = "full" }
 # Bind realtime via either IPv4 or IPv6. (default: IPv4)
 # ip_version = "IPv6"
 # The maximum length in bytes of HTTP request headers. (default: 4096)


### PR DESCRIPTION
## Summary
- remove outdated `[realtime.tables]` from `supabase/config.toml`

## Testing
- `yarn install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6876bb8ca274832981263bb9fd8b1eaf