### PR TITLE
Feat: trait chip explainability

### DIFF
--- a/components/ui/Chip.tsx
+++ b/components/ui/Chip.tsx
@@ -1,0 +1,25 @@
+"use client";
+
+import * as React from "react";
+
+export interface ChipProps {
+  chip?: { en: string; es: string };
+}
+
+function getLocale() {
+  if (typeof window === "undefined") return "en";
+  const i18n = (window as any).i18next?.language || (window as any).__nextIntlLocale;
+  if (typeof i18n === "string" && i18n.startsWith("es")) return "es";
+  return "en";
+}
+
+export default function Chip({ chip }: ChipProps) {
+  if (!chip) return null;
+  const locale = getLocale();
+  const text = locale === "es" ? chip.es : chip.en;
+  return (
+    <span className="px-2 py-1 rounded-full text-xs" style={{ background: "var(--color-secondary)" }}>
+      {text}
+    </span>
+  );
+}

--- a/config/chip_templates.json
+++ b/config/chip_templates.json
@@ -1,0 +1,6 @@
+{
+  "both_appreciate": {
+    "en": "Both appreciate %{term}",
+    "es": "Ambos disfrutan de %{term}"
+  }
+}

--- a/docs/explainability.md
+++ b/docs/explainability.md
@@ -13,5 +13,17 @@ GET /api/v2/discovery/why/:targetId?viewerId=123
 
 Response body:
 ```
-{ "reason_en": "Because you liked…", "reason_es": "Porque te gustó…" }
+{ "reason_en": "Because you liked…", "reason_es": "Porque te gustó…", "chip": { "en": "Both appreciate sci-fi", "es": "Ambos disfrutan de la ciencia ficción" } }
 ```
+
+### Trait Chip
+
+When the viewer and content creator share at least one genre in `user_taste_vectors.traits.genres`,
+the response includes a small chip object:
+
+```json
+{
+  "chip": { "en": "Both appreciate sci-fi", "es": "Ambos disfrutan de la ciencia ficción" }
+}
+```
+If no overlap is found, the `chip` field is omitted.

--- a/tests/chip.test.tsx
+++ b/tests/chip.test.tsx
@@ -1,0 +1,9 @@
+/** @jest-environment jsdom */
+import { render, screen } from "@testing-library/react";
+import Chip from "@/components/ui/Chip";
+
+it("renders spanish chip", () => {
+  (window as any).i18next = { language: "es" };
+  render(<Chip chip={{ en: "Both appreciate sci-fi", es: "Ambos disfrutan de la ciencia ficcion" }} />);
+  expect(screen.getByText(/Ambos disfrutan/)).toBeInTheDocument();
+});

--- a/tests/explain_api.test.ts
+++ b/tests/explain_api.test.ts
@@ -3,10 +3,11 @@ import { NextRequest } from "next/server";
 process.env.UPSTASH_REDIS_REST_URL = "http://localhost";
 process.env.UPSTASH_REDIS_REST_TOKEN = "token";
 
+let mockPrisma: any;
+
 describe("why api", () => {
   let store: Record<string, string>;
   beforeEach(() => {
-    jest.resetModules();
     store = {};
     jest.doMock("child_process", () => ({
       execFile: (_cmd: string, _args: string[], cb: any) => cb(null, JSON.stringify({ FAV_ARTIST_OVERLAP: 0.9, RECENT_SWIPE_RIGHT: 0.1 }), "")
@@ -18,13 +19,25 @@ describe("why api", () => {
         setex: jest.fn(async (k: string, _t: number, v: string) => { store[k] = v; }),
       },
     }));
+    jest.doMock("@/lib/prismaclient", () => {
+      mockPrisma = {
+        user_taste_vectors: {
+          findUnique: jest.fn(async ({ where }: any) => {
+            if (where.user_id === BigInt(1)) return { traits: { genres: ["sci-fi"] } };
+            if (where.user_id === BigInt(2)) return { traits: { genres: ["sci-fi", "rock"] } };
+            return null;
+          }),
+        },
+        post: { findUnique: jest.fn(async () => ({ author_id: BigInt(2) })) },
+      };
+      return { prisma: mockPrisma };
+    });
     jest.doMock("@upstash/ratelimit", () => ({
       Ratelimit: class { limit = jest.fn(async () => ({ success: true })); constructor(){} static tokenBucket(){ return null; } },
     }));
   });
 
   afterEach(() => {
-    jest.resetModules();
   });
 
   test("explainReturnsBothLocales", async () => {
@@ -43,5 +56,28 @@ describe("why api", () => {
     await GET(req, { params: { targetId: "abc" } });
     const cp = await import("child_process");
     expect((cp.execFile as jest.Mock).mock.calls.length).toBe(1);
+  });
+
+  test("returnsChipWhenOverlap", async () => {
+    const { GET } = await import("@/app/api/v2/discovery/why/[targetId]/route");
+    const req = new NextRequest(new URL("http://localhost/api/v2/discovery/why/abc?viewerId=1"));
+    const res = await GET(req, { params: { targetId: "abc" } });
+    const body = await res.json();
+    expect(body.chip.en).toBe("Both appreciate sci-fi");
+    expect(body.chip.es).toBe("Ambos disfrutan de sci-fi");
+  });
+
+  test("omitsChipWhenNoOverlap", async () => {
+    mockPrisma.user_taste_vectors.findUnique.mockImplementation(async ({ where }: any) => {
+      if (where.user_id === BigInt(1)) return { traits: { genres: ["romance"] } };
+      if (where.user_id === BigInt(2)) return { traits: { genres: ["sci-fi"] } };
+      return null;
+    });
+    mockPrisma.post.findUnique.mockResolvedValue({ author_id: BigInt(2) });
+    const { GET: GET2 } = await import("@/app/api/v2/discovery/why/[targetId]/route");
+    const req = new NextRequest(new URL("http://localhost/api/v2/discovery/why/def?viewerId=1"));
+    const res = await GET2(req, { params: { targetId: "def" } });
+    const body = await res.json();
+    expect(body.chip).toBeUndefined();
   });
 });


### PR DESCRIPTION
## Summary
- extend `why` route with trait-based chip logic
- add trait chip templates
- document new chip response
- implement `<Chip>` UI component
- add Jest & RTL tests for chip behaviour

## Testing
- `npm test tests/chip.test.tsx`
- `npm test tests/explain_api.test.ts tests/chip.test.tsx` *(fails: Cannot read properties of undefined (reading 'user_taste_vectors'))*

------
https://chatgpt.com/codex/tasks/task_e_6876efbd07dc8329ac1f193100f3ba8c