### PR TITLE
feat: batch trait inference

### DIFF
--- a/.github/actions/setup-python/action.yml
+++ b/.github/actions/setup-python/action.yml
@@ -1,0 +1,7 @@
+name: Setup Python
+runs:
+  using: "composite"
+  steps:
+    - uses: actions/setup-python@v5
+      with:
+        python-version: '3.11'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,3 +14,6 @@ jobs:
       - run: yarn install --frozen-lockfile
       - run: npm run lint
       - run: npm test -- --runInBand
+      - uses: ./.github/actions/setup-python
+      - run: pip install -r requirements.txt
+      - run: pytest -q

--- a/.github/workflows/trait_inference.yml
+++ b/.github/workflows/trait_inference.yml
@@ -1,0 +1,15 @@
+on:
+  schedule:
+    - cron: '0 3 * * 0'
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/setup-python
+      - name: Install deps
+        run: pip install -r requirements.txt
+      - name: Run batch_trait_inference
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+        run: python jobs/batch_trait_inference.py

--- a/config/trait_schema.json
+++ b/config/trait_schema.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "required": ["genres", "tone", "novelty_seek", "summary"],
+  "properties": {
+    "genres": { "type": "array", "items": { "type": "string" }, "maxItems": 5 },
+    "tone": { "type": "string", "enum": ["light", "serious", "mixed"] },
+    "novelty_seek": { "type": "number", "minimum": 0, "maximum": 1 },
+    "summary": { "type": "string", "maxLength": 140 }
+  },
+  "additionalProperties": false
+}

--- a/jobs/batch_trait_inference.py
+++ b/jobs/batch_trait_inference.py
@@ -1,0 +1,135 @@
+import os
+import sys
+import json
+import logging
+from pathlib import Path
+from typing import Any, List
+
+import psycopg2
+import openai
+from jsonschema import validate, ValidationError
+
+ACTIVE_USER_SQL = """
+  SELECT user_id
+  FROM users
+  WHERE last_login > now() - interval '30 days';
+"""
+
+BUDGET_PER_RUN = 0.005  # dollars / user
+SCHEMA_PATH = Path(__file__).resolve().parent.parent / "config" / "trait_schema.json"
+with open(SCHEMA_PATH) as f:
+    TRAIT_SCHEMA = json.load(f)
+
+PROMPT_SYSTEM = "You analyze user favorites and return traits JSON"
+
+logger = logging.getLogger(__name__)
+
+class TraitError(Exception):
+    pass
+
+
+class DB:
+    def __init__(self) -> None:
+        self.conn = psycopg2.connect(os.environ.get("DATABASE_URL"))
+
+    def fetch(self, query: str) -> List[Any]:
+        with self.conn.cursor() as cur:
+            cur.execute(query)
+            return [row[0] for row in cur.fetchall()]
+
+    def execute(self, query: str, params: tuple) -> None:
+        with self.conn.cursor() as cur:
+            cur.execute(query, params)
+        self.conn.commit()
+
+
+db = DB()
+
+
+def weekly_budget() -> float:
+    return float(os.environ.get("OPENAI_WEEKLY_BUDGET", "100"))
+
+
+def projected_cost(n_users: int) -> float:
+    return n_users * BUDGET_PER_RUN
+
+
+def fetch_top_favs(uid: Any, limit: int = 15) -> List[str]:
+    sql = (
+        "SELECT media_title FROM favorite_item WHERE user_id = %s "
+        "ORDER BY added_at DESC LIMIT %s"
+    )
+    with db.conn.cursor() as cur:
+        cur.execute(sql, (uid, limit))
+        return [r[0] for r in cur.fetchall()]
+
+
+def build_prompt(favs: List[str]) -> str:
+    joined = "\n".join(favs)
+    return f"User favorites:\n{joined}\nReturn JSON traits."
+
+
+def validate_json(data: dict) -> bool:
+    try:
+        validate(data, TRAIT_SCHEMA)
+        return True
+    except ValidationError:
+        return False
+
+
+def upsert_traits(uid: Any, traits: dict) -> None:
+    db.execute(
+        """
+        INSERT INTO user_taste_vectors (user_id, traits)
+        VALUES (%s, %s::jsonb)
+        ON CONFLICT (user_id) DO UPDATE SET traits = EXCLUDED.traits;
+        """,
+        (uid, json.dumps(traits)),
+    )
+
+
+def record_cost(uid: Any, tokens: int) -> None:
+    db.execute(
+        "INSERT INTO openai_costs(date, job, user_id, tokens) VALUES (CURRENT_DATE, 'trait_inference', %s, %s)",
+        (uid, tokens),
+    )
+
+
+def process_user(uid: Any) -> int:
+    favs = fetch_top_favs(uid, 15)
+    prompt = build_prompt(favs)
+    for _ in range(3):
+        resp = openai.chat.completions.create(
+            model="gpt-4o-mini",
+            messages=[
+                {"role": "system", "content": PROMPT_SYSTEM},
+                {"role": "user", "content": prompt},
+            ],
+            response_format={"type": "json_object"},
+        )
+        try:
+            traits = json.loads(resp.choices[0].message.content)
+        except json.JSONDecodeError:
+            continue
+        if validate_json(traits):
+            upsert_traits(uid, traits)
+            record_cost(uid, resp.usage.total_tokens)
+            return resp.usage.total_tokens
+    raise TraitError("Trait generation failed")
+
+
+def main() -> None:
+    users = db.fetch(ACTIVE_USER_SQL)
+    est_cost = projected_cost(len(users))
+    if est_cost > 0.8 * weekly_budget():
+        sys.exit("Would exceed budget")
+
+    for uid in users:
+        try:
+            process_user(uid)
+        except TraitError:
+            logger.error("Trait generation failed after retries", extra={"uid": uid})
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+openai
+psycopg2-binary
+jsonschema
+pytest
+vcrpy

--- a/tests/jobs/openai_success.yaml
+++ b/tests/jobs/openai_success.yaml
@@ -1,0 +1,17 @@
+interactions:
+- request:
+    method: POST
+    uri: https://api.openai.com/v1/chat/completions
+    body: '{}'
+    headers:
+      Authorization: ['Bearer test']
+      Content-Type: ['application/json']
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      content-type: ['application/json']
+    body:
+      string: '{"id":"chatcmpl-test","choices":[{"message":{"content":"{\"genres\":[\"drama\"],\"tone\":\"light\",\"novelty_seek\":0.5,\"summary\":\"ok\"}"}}],"usage":{"total_tokens":1}}'
+version: 1

--- a/tests/jobs/test_batch_trait_inference.py
+++ b/tests/jobs/test_batch_trait_inference.py
@@ -1,0 +1,41 @@
+import json
+import types
+import pytest
+import openai
+from jobs import batch_trait_inference as bt
+
+
+class DummyResp:
+    def __init__(self, content: str):
+        msg = types.SimpleNamespace(content=content)
+        choice = types.SimpleNamespace(message=msg)
+        self.choices = [choice]
+        self.usage = types.SimpleNamespace(total_tokens=10)
+
+
+def test_schema_validation(monkeypatch):
+    calls = []
+
+    def fake_create(*args, **kwargs):
+        calls.append(1)
+        return DummyResp("{")
+
+    monkeypatch.setattr(openai.chat.completions, "create", fake_create)
+    monkeypatch.setattr(bt, "fetch_top_favs", lambda uid, limit=15: ["x"])
+    monkeypatch.setattr(bt, "upsert_traits", lambda uid, t: None)
+    monkeypatch.setattr(bt, "record_cost", lambda uid, t: None)
+
+    with pytest.raises(bt.TraitError):
+        bt.process_user(1)
+    assert len(calls) == 3
+
+
+def test_budget_guard(monkeypatch):
+    monkeypatch.setattr(bt.db, "fetch", lambda q: [1, 2, 3])
+    monkeypatch.setattr(bt, "weekly_budget", lambda: 0.001)
+    with pytest.raises(SystemExit):
+        bt.main()
+
+
+def test_cost_projection():
+    assert bt.projected_cost(4) == 4 * bt.BUDGET_PER_RUN

--- a/tests/jobs/test_integration_vcr.py
+++ b/tests/jobs/test_integration_vcr.py
@@ -1,0 +1,34 @@
+import os
+import types
+import json
+import vcr
+import openai
+from jobs import batch_trait_inference as bt
+
+CASSETTE = os.path.join(os.path.dirname(__file__), "openai_success.yaml")
+
+
+@vcr.use_cassette(CASSETTE)
+def test_upsert_with_vcr(monkeypatch, tmp_path):
+    def fake_create(*args, **kwargs):
+        import requests
+        resp = requests.post(
+            "https://api.openai.com/v1/chat/completions",
+            json={},
+            headers={"Authorization": "Bearer test"},
+        )
+        data = json.loads(resp.text)
+        msg = types.SimpleNamespace(content=data["choices"][0]["message"]["content"])
+        choice = types.SimpleNamespace(message=msg)
+        usage = types.SimpleNamespace(total_tokens=data["usage"]["total_tokens"])
+        return types.SimpleNamespace(choices=[choice], usage=usage)
+
+    monkeypatch.setattr(bt.db, "fetch", lambda q: [1])
+    monkeypatch.setattr(bt, "weekly_budget", lambda: 10)
+    monkeypatch.setattr(bt, "fetch_top_favs", lambda uid, limit=15: ["title"])
+    monkeypatch.setattr(openai.chat.completions, "create", fake_create)
+    stored = {}
+    monkeypatch.setattr(bt, "upsert_traits", lambda uid, t: stored.setdefault("traits", t))
+    monkeypatch.setattr(bt, "record_cost", lambda uid, t: None)
+    bt.main()
+    assert bt.validate_json(stored["traits"])


### PR DESCRIPTION
## Summary
- schedule weekly trait inference workflow
- add batch_trait_inference job for GPT-driven traits
- define trait schema and tests
- setup Python action and integrate pytest in CI

## Testing
- `pip install -r requirements.txt`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*
- `yarn install` *(fails to fetch packages)*

------
https://chatgpt.com/codex/tasks/task_e_6876e8b13bb083299d7a4ada96db05ec