### PR TITLE
Implement follow and message notifications

### DIFF
--- a/app/(root)/(standard)/notifications/page.tsx
+++ b/app/(root)/(standard)/notifications/page.tsx
@@ -1,0 +1,54 @@
+import Image from "next/image";
+import Link from "next/link";
+import { fetchNotifications } from "@/lib/actions/notification.actions";
+import { getUserFromCookies } from "@/lib/serverutils";
+import { redirect } from "next/navigation";
+
+export default async function Page() {
+  const user = await getUserFromCookies();
+  if (!user?.userId) redirect("/login");
+
+  const notifications = await fetchNotifications({ userId: user.userId });
+
+  return (
+    <section>
+      <h1 className="head-text mb-5">Notifications</h1>
+      <section className="mt-9 flex flex-col gap-3">
+        {notifications.length > 0 ? (
+          <>
+            {notifications.map((n) => (
+              <div
+                key={n.id.toString()}
+                className="activity-card bg-slate-800 rounded-md border-[2px] border-slate-500 border-slate-200 hover:bg-slate-700"
+              >
+                <Image
+                  src={n.actor.image || "/assets/user-helsinki.svg"}
+                  alt="Profile Picture"
+                  width={24}
+                  height={24}
+                  className="rounded-md object-cover mr-2"
+                />
+                {n.type === "FOLLOW" && (
+                  <Link href={`/profile/${n.actor_id}`}>
+                    <p className="!text-base text-light-1">
+                      <span className="mr-2 text-blue">{n.actor.name}</span> followed you
+                    </p>
+                  </Link>
+                )}
+                {n.type === "MESSAGE" && (
+                  <Link href={`/messages/${n.conversation_id}`}>
+                    <p className="!text-base text-light-1">
+                      <span className="mr-2 text-blue">{n.actor.name}</span> sent you a message
+                    </p>
+                  </Link>
+                )}
+              </div>
+            ))}
+          </>
+        ) : (
+          <p className="!text-base-regular text-light-3">No notifications</p>
+        )}
+      </section>
+    </section>
+  );
+}

--- a/components/shared/LeftSidebar.tsx
+++ b/components/shared/LeftSidebar.tsx
@@ -65,6 +65,9 @@ function LeftSidebar({ userRooms }: Props) {
       router.push("/applications");
 
     }
+    function gotonotifications() {
+      router.push("/notifications");
+    }
   return (
     <section className="custom-scrollbar leftsidebar  bg-transparent">
       <div>
@@ -138,7 +141,7 @@ function LeftSidebar({ userRooms }: Props) {
           <Button
           variant={"outline"}
             className="likebutton leftsidebar-link  leftsidebar-item  items-start justify-start w-full h-fit rounded-md border-[1px] border-rose-300 border-opacity-80 "
-            onClick={gotoprofile}
+            onClick={gotonotifications}
           >
             <Image
               src="/assets/notifications-none.svg"

--- a/constants/index.ts
+++ b/constants/index.ts
@@ -11,8 +11,8 @@ export const sidebarLinks = [
   },
   {
     imgURL: "/assets/notifications-none.svg",
-    route: "/activity",
-    label: "Activity",
+    route: "/notifications",
+    label: "Notifications",
   },
   {
     imgURL: "/assets/user-helsinki.svg",

--- a/lib/actions/follow.actions.ts
+++ b/lib/actions/follow.actions.ts
@@ -1,6 +1,7 @@
 "use server";
 
 import { prisma } from "../prismaclient";
+import { createFollowNotification } from "./notification.actions";
 
 export async function followUser({ followerId, followingId }: { followerId: bigint; followingId: bigint; }) {
   try {
@@ -10,6 +11,7 @@ export async function followUser({ followerId, followingId }: { followerId: bigi
         following_id: followingId,
       },
     });
+    await createFollowNotification({ userId: followingId, actorId: followerId });
   } catch (error: any) {
     throw new Error(`Failed to follow user: ${error.message}`);
   }

--- a/lib/actions/message.actions.ts
+++ b/lib/actions/message.actions.ts
@@ -3,6 +3,7 @@
 import { prisma } from "../prismaclient";
 import { revalidatePath } from "next/cache";
 import { supabase } from "@/lib/supabaseclient";
+import { createMessageNotification } from "./notification.actions";
 
 export async function getOrCreateConversation({
   userId,
@@ -83,6 +84,7 @@ export async function sendMessage({
     },
     include: { sender: true },
   });
+  await createMessageNotification({ conversationId, messageId: message.id, senderId });
   await prisma.conversation.update({
     where: { id: conversationId },
     data: { updated_at: new Date() },

--- a/lib/actions/notification.actions.ts
+++ b/lib/actions/notification.actions.ts
@@ -1,0 +1,32 @@
+"use server";
+
+import { prisma } from "../prismaclient";
+
+export async function createFollowNotification({ userId, actorId }: { userId: bigint; actorId: bigint; }) {
+  await prisma.notification.create({
+    data: { user_id: userId, actor_id: actorId, type: "FOLLOW" },
+  });
+}
+
+export async function createMessageNotification({ conversationId, messageId, senderId }: { conversationId: bigint; messageId: bigint; senderId: bigint; }) {
+  const convo = await prisma.conversation.findUnique({ where: { id: conversationId } });
+  if (!convo) return;
+  const userId = convo.user1_id === senderId ? convo.user2_id : convo.user1_id;
+  await prisma.notification.create({
+    data: {
+      user_id: userId,
+      actor_id: senderId,
+      type: "MESSAGE",
+      conversation_id: conversationId,
+      message_id: messageId,
+    },
+  });
+}
+
+export async function fetchNotifications({ userId }: { userId: bigint }) {
+  return await prisma.notification.findMany({
+    where: { user_id: userId },
+    orderBy: { created_at: "desc" },
+    include: { actor: true },
+  });
+}

--- a/lib/models/migrations/20250916000000_add_notifications/migration.sql
+++ b/lib/models/migrations/20250916000000_add_notifications/migration.sql
@@ -1,0 +1,18 @@
+CREATE TYPE IF NOT EXISTS "notification_type" AS ENUM ('FOLLOW', 'MESSAGE');
+
+CREATE TABLE IF NOT EXISTS "notifications" (
+  "id" BIGSERIAL PRIMARY KEY,
+  "user_id" BIGINT NOT NULL,
+  "actor_id" BIGINT NOT NULL,
+  "type" notification_type NOT NULL,
+  "conversation_id" BIGINT,
+  "message_id" BIGINT,
+  "created_at" TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "read" BOOLEAN NOT NULL DEFAULT false,
+  CONSTRAINT "notifications_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "users"("id") ON DELETE CASCADE,
+  CONSTRAINT "notifications_actor_id_fkey" FOREIGN KEY ("actor_id") REFERENCES "users"("id") ON DELETE CASCADE,
+  CONSTRAINT "notifications_conversation_id_fkey" FOREIGN KEY ("conversation_id") REFERENCES "conversations"("id") ON DELETE CASCADE,
+  CONSTRAINT "notifications_message_id_fkey" FOREIGN KEY ("message_id") REFERENCES "messages"("id") ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS "notifications_user_id_idx" ON "notifications" ("user_id");

--- a/lib/models/schema.prisma
+++ b/lib/models/schema.prisma
@@ -518,6 +518,24 @@ model FavoriteItem {
   @@map("favorite_items")
 }
 
+model Notification {
+  id              BigInt          @id @default(autoincrement())
+  user_id         BigInt
+  actor_id        BigInt
+  type            notification_type
+  conversation_id BigInt?
+  message_id      BigInt?
+  created_at      DateTime        @default(now()) @db.Timestamptz(6)
+  read            Boolean         @default(false)
+  user            User            @relation("NotificationUser", fields: [user_id], references: [id], onDelete: Cascade)
+  actor           User            @relation("NotificationActor", fields: [actor_id], references: [id], onDelete: Cascade)
+  conversation    Conversation?   @relation(fields: [conversation_id], references: [id], onDelete: Cascade)
+  message         Message?        @relation(fields: [message_id], references: [id], onDelete: Cascade)
+
+  @@index([user_id])
+  @@map("notifications")
+}
+
 model PortfolioPage {
   id         BigInt   @id @default(autoincrement())
   slug       String   @unique
@@ -579,4 +597,9 @@ enum visibility {
   PUBLIC
   FOLLOWERS
   PRIVATE
+}
+
+enum notification_type {
+  FOLLOW
+  MESSAGE
 }


### PR DESCRIPTION
## Summary
- add Notification model and enum in prisma schema
- create migration for notifications table
- implement notification actions
- trigger notifications on follow and message
- add notifications page and sidebar link

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68780f1a15348329a071237e1542c3f7