### PR TITLE
Implement lounge feed groups

### DIFF
--- a/app/(root)/(standard)/create-lounge/page.tsx
+++ b/app/(root)/(standard)/create-lounge/page.tsx
@@ -1,0 +1,14 @@
+import CreateLounge from "@/components/forms/CreateLounge";
+
+export const dynamic = "force-dynamic";
+
+async function Page() {
+  return (
+    <div className="items-center justify-center">
+      <h1 className="head-text items-center justify-center mx-auto text-nowrap ml-[32%] mb-4 ">Create New Lounge</h1>
+      <CreateLounge />
+    </div>
+  );
+}
+
+export default Page;

--- a/app/(root)/(standard)/lounges/[id]/page.tsx
+++ b/app/(root)/(standard)/lounges/[id]/page.tsx
@@ -1,0 +1,66 @@
+import Modal from "@/components/modals/Modal";
+import RealtimeFeed from "@/components/shared/RealtimeFeed";
+import { fetchRealtimePosts } from "@/lib/actions/realtimepost.actions";
+import { fetchRealtimeRoom } from "@/lib/actions/realtimeroom.actions";
+import { getUserFromCookies } from "@/lib/serverutils";
+import { notFound, redirect } from "next/navigation";
+
+export const dynamic = "force-dynamic";
+
+export default async function Page({ params }: { params: { id: string } }) {
+  const lounge = await fetchRealtimeRoom({ realtimeRoomId: params.id });
+  if (!lounge || !lounge.isLounge) notFound();
+  const user = await getUserFromCookies();
+  if (!lounge.isPublic) {
+    if (!user) redirect("/login");
+    if (!lounge.members.map((m) => m.user_id).includes(user.userId)) {
+      notFound();
+    }
+  }
+  const result = await fetchRealtimePosts({
+    realtimeRoomId: params.id,
+    postTypes: [
+      "TEXT",
+      "VIDEO",
+      "IMAGE",
+      "IMAGE_COMPUTE",
+      "GALLERY",
+      "DRAW",
+      "LIVECHAT",
+      "MUSIC",
+      "ENTROPY",
+      "PORTFOLIO",
+      "PLUGIN",
+      "PRODUCT_REVIEW",
+    ],
+  });
+  return (
+    <div>
+      <Modal />
+      {result.posts.length === 0 ? (
+        <p className="no-result">Nothing found</p>
+      ) : (
+        <RealtimeFeed
+          initialPosts={result.posts}
+          initialIsNext={result.isNext}
+          roomId={params.id}
+          postTypes={[
+            "TEXT",
+            "VIDEO",
+            "IMAGE",
+            "IMAGE_COMPUTE",
+            "GALLERY",
+            "DRAW",
+            "LIVECHAT",
+            "MUSIC",
+            "ENTROPY",
+            "PORTFOLIO",
+            "PLUGIN",
+            "PRODUCT_REVIEW",
+          ]}
+          currentUserId={user?.userId}
+        />
+      )}
+    </div>
+  );
+}

--- a/components/forms/CreateLounge.tsx
+++ b/components/forms/CreateLounge.tsx
@@ -1,0 +1,174 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import Image from "next/image";
+import { ChangeEvent, useState } from "react";
+import { useForm } from "react-hook-form";
+import { z } from "zod";
+import { createAndJoinLounge } from "@/lib/actions/realtimeroom.actions";
+import { useAuth } from "@/lib/AuthContext";
+import { uploadFileToSupabase } from "@/lib/utils";
+import { LoungeValidation } from "@/lib/validations/thread";
+import { redirect, usePathname, useRouter } from "next/navigation";
+import { Input } from "../ui/input";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "../ui/select";
+
+function CreateLounge() {
+  const pathname = usePathname();
+  const router = useRouter();
+  const user = useAuth().user;
+  if (!user?.onboarded) redirect("/onboarding");
+  const [imageURL, setImageURL] = useState("");
+  const form = useForm({
+    resolver: zodResolver(LoungeValidation),
+    defaultValues: {
+      roomName: "",
+      userId: user.userId!,
+      roomIcon: "",
+      isPublic: true,
+    },
+  });
+
+  const onSubmit = async (values: z.infer<typeof LoungeValidation>) => {
+    const result = await uploadFileToSupabase(values.roomIcon);
+    if (result.error) {
+      return;
+    }
+    const lounge = await createAndJoinLounge({
+      loungeName: values.roomName,
+      roomIcon: result.fileURL,
+      isPublic: values.isPublic,
+      path: pathname,
+    });
+
+    router.push(`/lounges/${lounge.id}`);
+  };
+
+  const handleImage = (
+    e: ChangeEvent<HTMLInputElement>,
+    fieldChange: (value: File) => void
+  ) => {
+    e.preventDefault();
+    const fileReader = new FileReader();
+    if (e.target.files && e.target.files.length > 0) {
+      const uploadedFile = e.target.files[0];
+      if (!uploadedFile.type.includes("image")) return;
+      fileReader.onload = async (event) => {
+        const imageDataUrl = event.target?.result?.toString() || "";
+        setImageURL(imageDataUrl);
+        fieldChange(uploadedFile);
+      };
+      fileReader.readAsDataURL(uploadedFile);
+    }
+  };
+
+  return (
+    <div className="justify-center items-center">
+      <Form {...form}>
+        <form
+          onSubmit={form.handleSubmit(onSubmit)}
+          className="mt-0 flex flex-col justify-center  gap-0  "
+        >
+          <FormField
+            control={form.control}
+            name="roomIcon"
+            render={({ field }) => (
+              <FormItem className="flex items-center gap-4 ml-[26%] mt-4">
+                <FormLabel className="rounded_icon_container h-24 w-24">
+                  {imageURL != "" ? (
+                    <Image
+                      src={imageURL}
+                      alt="profile photo"
+                      width={96}
+                      height={96}
+                      priority
+                      className="object-cover"
+                    />
+                  ) : (
+                    <Image
+                      src="/assets/profile.svg"
+                      alt="profile photo"
+                      width={24}
+                      height={24}
+                      priority
+                      className="object-cover"
+                    />
+                  )}
+                </FormLabel>
+                <FormControl className=" items-center justify-center  grid flex flex-col w-[50%] text-base-semibold text-gray-200">
+                  <Input
+                    type="file"
+                    accept="image/*"
+                    placeholder="Upload a photo"
+                    className="account-form_image-input "
+                    onChange={(e) => handleImage(e, field.onChange)}
+                  />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+          <FormField
+            control={form.control}
+            name="roomName"
+            render={({ field }) => (
+              <FormItem className="flex flex-col w-full ml-[26%] mt-2 ">
+                <FormLabel className="text-header-semibold text-dark-2"></FormLabel>
+                <FormControl className="border-2 border-slate-500  bg-white text-black hover:border-black focus:border-black">
+                  <Input
+                    type="text"
+                    className="border border-dark-4 text-dark-1  w-[52%] no-focus"
+                    placeholder="Enter lounge name"
+                    {...field}
+                  />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+          <FormField
+            control={form.control}
+            name="isPublic"
+            render={({ field }) => (
+              <FormItem className="flex flex-col w-full ml-[26%] mt-2">
+                <FormLabel>Visibility</FormLabel>
+                <FormControl>
+                  <Select
+                    onValueChange={(v) => field.onChange(v === "public")}
+                    value={field.value ? "public" : "private"}
+                  >
+                    <SelectTrigger>
+                      <SelectValue placeholder="Select visibility" />
+                    </SelectTrigger>
+                    <SelectContent className="max-h-[8rem] border-blue rounded-xl">
+                      <SelectItem value="public">Public</SelectItem>
+                      <SelectItem value="private">Invite Only</SelectItem>
+                    </SelectContent>
+                  </Select>
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+          <Button
+            type="submit"
+            className=" h-fit w-fit ml-[27%] mt-4 py-1 px-4 text-[1.15rem] bg-transparent outline-blue hover:bg-transparent rounded-md "
+          >
+            Create
+          </Button>
+        </form>
+      </Form>
+    </div>
+  );
+}
+
+export default CreateLounge;

--- a/lib/models/schema.prisma
+++ b/lib/models/schema.prisma
@@ -129,6 +129,8 @@ model RealtimeRoom {
   id                       String                    @id
   created_at               DateTime                  @default(now()) @db.Timestamptz(6)
   room_icon                String
+  isPublic                 Boolean                   @default(true)
+  isLounge                 Boolean                   @default(false)
   realtimeedges            RealtimeEdge[]
   realtimeposts            RealtimePost[]
   realtimeRoomInviteTokens RealtimeRoomInviteToken[]

--- a/lib/validations/thread.ts
+++ b/lib/validations/thread.ts
@@ -49,6 +49,19 @@ export const RoomValidation = z.object({
     ),
 });
 
+export const LoungeValidation = z.object({
+  roomName: z.string().min(3, { message: "Minimum of 3 characters" }),
+  userId: z.bigint(),
+  roomIcon: z
+    .any()
+    .refine((file) => file?.size <= MAX_FILE_SIZE, `Max image size is 5MB.`)
+    .refine(
+      (file) => isAcceptedImage(file),
+      "Only .jpg, .jpeg, .png and .webp formats are supported."
+    ),
+  isPublic: z.boolean().default(true),
+});
+
 export const TextPostValidation = z.object({
   postContent: z.string().min(3, { message: "Minimum of 3 characters" }),
 });


### PR DESCRIPTION
## Summary
- add isPublic and isLounge fields to `RealtimeRoom`
- allow lounge creation via `createAndJoinLounge`
- validate lounge creation with `LoungeValidation`
- add `CreateLounge` form and creation page
- add lounge feed page that reuses `RealtimeFeed`

## Testing
- `npx prisma generate`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68784260df188329bd522a3d8dd274d8