### PR TITLE
Add skeletons for PostCard assets

### DIFF
--- a/components/cards/ImageCard.tsx
+++ b/components/cards/ImageCard.tsx
@@ -1,10 +1,8 @@
 "use client";
 
 import Image from "next/image";
-import { useEffect, useState } from "react";
-import { supabase } from "@/lib/supabaseclient";
-import { useAuth } from "@/lib/AuthContext";
-import { fetchUser } from "@/lib/actions/user.actions";
+import { useState } from "react";
+import { Skeleton } from "@/components/ui/skeleton";
 
 interface ImageCardProps {
   id: bigint;
@@ -12,25 +10,26 @@ interface ImageCardProps {
 }
 
 function ImageCard({ id, imageurl }: ImageCardProps) {
-  const { user: currentUser } = useAuth();
-  
+  const [isLoaded, setIsLoaded] = useState(false);
 
   return (
-
     <div className="flex justify-center px-24 w-fit items-center align-center h-fit">
-       <div className="mx-auto">
-
+      <div className="mx-auto relative w-full max-w-[500px]">
+        {!isLoaded && (
+          <Skeleton className="img-feed-frame mt-[1rem] mb-[1rem] w-full h-[300px]" />
+        )}
         <Image
-          className=" flex img-feed-frame  rounded-sm mt-[1rem] mb-[1rem] "
+          className={`flex img-feed-frame rounded-sm mt-[1rem] mb-[1rem] ${!isLoaded ? "hidden" : ""}`}
           src={imageurl}
           alt="image not found"
           width={0}
           height={0}
           sizes="200vw"
           layout="responsive"
+          onLoad={() => setIsLoaded(true)}
         />
-        </div>
-</div>
+      </div>
+    </div>
   );
 }
 

--- a/components/players/SoundCloudPlayer.tsx
+++ b/components/players/SoundCloudPlayer.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useRef, useState } from "react";
 import WaveSurfer from "wavesurfer.js";
 import Image from "next/image";
+import { Skeleton } from "@/components/ui/skeleton";
 
 interface Props {
   src: string;
@@ -13,6 +14,7 @@ const SoundCloudPlayer = ({ src, title }: Props) => {
   const waveRef = useRef<WaveSurfer | null>(null);
   const containerRef = useRef<HTMLDivElement>(null);
   const [isPlaying, setIsPlaying] = useState(false);
+  const [isReady, setIsReady] = useState(false);
 
   useEffect(() => {
     if (!containerRef.current) return;
@@ -49,6 +51,7 @@ const SoundCloudPlayer = ({ src, title }: Props) => {
 
     });
     if (src) waveRef.current.load(src).catch(() => null);
+    waveRef.current.on("ready", () => setIsReady(true));
     return () => {
       try {
         waveRef.current?.destroy();
@@ -66,9 +69,10 @@ const SoundCloudPlayer = ({ src, title }: Props) => {
 
   return (
     <div className="flex flex-1 w-[100%] flex-col">
-            <h1 className="text-center tracking-wide text-[1.4rem] font-semi-bold mt-0 w-full pb-2">{title}</h1>
-<hr></hr>
-      <div className="flex items-center gap-5 mt-2 py-2 w-full">
+      <h1 className="text-center tracking-wide text-[1.4rem] font-semi-bold mt-0 w-full pb-2">{title}</h1>
+      <hr />
+      {!isReady && <Skeleton className="w-full h-[100px] mt-2" />}
+      <div className={`flex items-center gap-5 mt-2 py-2 w-full ${!isReady ? "hidden" : ""}`}>
         {isPlaying ? (
           <button
             onClick={togglePlay}


### PR DESCRIPTION
## Summary
- show skeleton placeholder while images load
- show skeleton placeholder while SoundCloud wavesurfer initializes

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68785c7607108329a696da23e336cb0f