### PR TITLE
Add ROOM_CANVAS post type

### DIFF
--- a/components/cards/EmbeddedCanvas.tsx
+++ b/components/cards/EmbeddedCanvas.tsx
@@ -1,0 +1,34 @@
+"use client";
+import { useMemo } from "react";
+import { ReactFlow, Background } from "@xyflow/react";
+import "@xyflow/react/dist/style.css";
+
+interface Props {
+  canvas: { nodes: any[]; edges: any[]; viewport?: { x: number; y: number; zoom: number } };
+  roomId: string;
+}
+
+export default function EmbeddedCanvas({ canvas, roomId }: Props) {
+  const { nodes, edges, viewport } = canvas;
+  const defaultViewport = useMemo(
+    () => viewport || { x: 0, y: 0, zoom: 1 },
+    [viewport]
+  );
+  const handleNodeClick = (_: any, node: any) => {
+    window.open(`/room/${roomId}`, "_blank");
+  };
+  return (
+    <ReactFlow
+      nodes={nodes}
+      edges={edges}
+      defaultViewport={defaultViewport}
+      nodesDraggable={false}
+      nodesConnectable={false}
+      nodesFocusable={false}
+      onNodeClick={handleNodeClick}
+      fitView
+    >
+      <Background />
+    </ReactFlow>
+  );
+}

--- a/components/cards/PostCard.tsx
+++ b/components/cards/PostCard.tsx
@@ -16,6 +16,7 @@ import GalleryCarousel from "./GalleryCarousel";
 import SoundCloudPlayer from "../players/SoundCloudPlayer";
 import Spline from "@splinetool/react-spline";
 import dynamic from "next/dynamic";
+import EmbeddedCanvas from "./EmbeddedCanvas";
 import type { Like, RealtimeLike } from "@prisma/client";
 import React from "react";
 import localFont from 'next/font/local'
@@ -198,6 +199,23 @@ const PostCard = ({
               <div className="mt-2 mb-2 flex justify-center items-center">
                 <DrawCanvas id={id.toString()} content={content} />
               </div>
+            )}
+            {type === "ROOM_CANVAS" && content && (
+              (() => {
+                let canvas: any = null;
+                try {
+                  canvas = JSON.parse(content);
+                } catch (e) {
+                  canvas = null;
+                }
+                return (
+                  canvas && (
+                    <div className="mt-2 mb-2 flex justify-center items-center">
+                      <EmbeddedCanvas canvas={canvas} roomId={canvas.roomId || "global"} />
+                    </div>
+                  )
+                );
+              })()
             )}
             {type === "PORTFOLIO" && content && (
               (() => {

--- a/components/nodes/RoomCanvasNode.tsx
+++ b/components/nodes/RoomCanvasNode.tsx
@@ -1,0 +1,31 @@
+"use client";
+
+import { NodeProps } from "@xyflow/react";
+import { useEffect, useState } from "react";
+import { useAuth } from "@/lib/AuthContext";
+import { fetchUser } from "@/lib/actions/user.actions";
+import { RoomCanvasNodeData } from "@/lib/reactflow/types";
+import BaseNode from "./BaseNode";
+import EmbeddedCanvas from "../cards/EmbeddedCanvas";
+
+function RoomCanvasNode({ id, data }: NodeProps<RoomCanvasNodeData>) {
+  const currentUser = useAuth().user;
+  const [author, setAuthor] = useState(data.author);
+
+  useEffect(() => {
+    if ("username" in author) return;
+    fetchUser(data.author.id).then((user) => user && setAuthor(user));
+  }, [author, data.author.id]);
+
+  const isOwned = currentUser ? Number(currentUser.userId) === Number(data.author.id) : false;
+
+  return (
+    <BaseNode id={id} author={author} isOwned={isOwned} type="ROOM_CANVAS" isLocked={data.locked}>
+      <div className="w-[400px] h-[400px]">
+        <EmbeddedCanvas canvas={data.canvas} roomId={data.roomId} />
+      </div>
+    </BaseNode>
+  );
+}
+
+export default RoomCanvasNode;

--- a/components/reactflow/Room.tsx
+++ b/components/reactflow/Room.tsx
@@ -364,6 +364,7 @@ function Room({ roomId, initialNodes, initialEdges }: Props) {
     CODE: CodeNode,
     PORTFOLIO: PortfolioNode,
     PRODUCT_REVIEW: ProductReviewNode,
+    ROOM_CANVAS: dynamic(() => import("../nodes/RoomCanvasNode"), { ssr: false }),
   };
   pluginDescriptors.forEach((p) => {
     (nodeTypes as any)[p.type] = p.component as any;

--- a/lib/models/migrations/20250926000000_add_room_canvas/migration.sql
+++ b/lib/models/migrations/20250926000000_add_room_canvas/migration.sql
@@ -1,0 +1,2 @@
+ALTER TYPE "realtime_post_type" ADD VALUE IF NOT EXISTS 'ROOM_CANVAS';
+ALTER TABLE "realtime_posts" ADD COLUMN IF NOT EXISTS "room_post_content" JSONB;

--- a/lib/models/schema.prisma
+++ b/lib/models/schema.prisma
@@ -156,6 +156,7 @@ model RealtimePost {
   collageLayoutStyle String?
   collageColumns     Int?
   collageGap         Int?
+  room_post_content  Json?
   isPublic           Boolean            @default(false)
   parent_id          BigInt?
   pluginData         Json?
@@ -597,6 +598,7 @@ enum realtime_post_type {
   PRODUCT_REVIEW
   ENTROPY
   MUSIC
+  ROOM_CANVAS
 }
 
 enum visibility {

--- a/lib/reactflow/reactflowutils.ts
+++ b/lib/reactflow/reactflowutils.ts
@@ -422,6 +422,22 @@ export function convertPostToNode(
         } as AppNode;
       }
 
+      case "ROOM_CANVAS": {
+        const canvas = (realtimePost as any).room_post_content ||
+          (realtimePost.content ? JSON.parse(realtimePost.content) : { nodes: [], edges: [] });
+        return {
+          id: realtimePost.id.toString(),
+          type: realtimePost.type,
+          data: {
+            canvas,
+            roomId: realtimePost.realtime_room_id,
+            author: authorToSet,
+            locked: realtimePost.locked,
+          },
+          position: { x: realtimePost.x_coordinate, y: realtimePost.y_coordinate },
+        } as AppNode;
+      }
+
       default:
         throw new Error("Unsupported real-time post type");
       }

--- a/lib/reactflow/types.ts
+++ b/lib/reactflow/types.ts
@@ -217,6 +217,16 @@ export type ProductReviewNodeData = Node<
   "PRODUCT_REVIEW"
 >;
 
+export type RoomCanvasNodeData = Node<
+  {
+    canvas: { nodes: any[]; edges: any[]; viewport?: { x: number; y: number; zoom: number } };
+    roomId: string;
+    author: AuthorOrAuthorId;
+    locked: boolean;
+  },
+  "ROOM_CANVAS"
+>;
+
 
 
 export type DefaultEdge = Edge<{}, "DEFAULT">;
@@ -241,6 +251,7 @@ export const NodeTypeMap = {
   PORTFOLIO: {} as PortfolioNodeData,
   LLM_INSTRUCTION: {} as LLMInstructionNode,
   PRODUCT_REVIEW: {} as ProductReviewNodeData,
+  ROOM_CANVAS: {} as RoomCanvasNodeData,
   PLUGIN: {} as PluginDescriptor,
 };
 
@@ -285,6 +296,7 @@ export type AppNode =
   | PortfolioNodeData
   | LLMInstructionNode
   | ProductReviewNodeData
+  | RoomCanvasNodeData
   | PluginDescriptor;
 
 export type AppEdgeType = keyof AppEdgeMapping;
@@ -312,6 +324,7 @@ export const DEFAULT_NODE_VALUES: Record<AppNodeType, string> = {
   ["PORTFOLIO"]: "",
   ["LLM_INSTRUCTION"]: "",
   ["PRODUCT_REVIEW"]: "",
+  ["ROOM_CANVAS"]: "",
   ["PLUGIN"]: "",
 };
 


### PR DESCRIPTION
## Summary
- add `ROOM_CANVAS` to `realtime_post_type`
- store serialized canvas in new `room_post_content` column
- show room canvases in `PostCard`
- embed canvas view component
- add node component and update room node map
- support new type in React Flow utils
- migration for schema changes

## Testing
- `yarn install` *(fails: YAMLException)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68789e75070c8329a346b37e104747ce