### PR TITLE
Implement Room Canvas post option

### DIFF
--- a/components/forms/CreateFeedPost.tsx
+++ b/components/forms/CreateFeedPost.tsx
@@ -25,6 +25,8 @@ import PdfViewerNodeModal from "@/components/modals/PdfViewerNodeModal";
 import ProductReviewNodeModal from "../modals/ProductReviewNodeModal";
 import MusicNodeModal from "../modals/MusicNodeModal";
 import SplineViewerNodeModal from "../modals/SplineViewerNodeModal";
+import RoomCanvasModal from "../modals/RoomCanvasModal";
+import { exportRoomCanvas } from "@/lib/actions/realtimeroom.actions";
 import { uploadFileToSupabase, uploadAudioToSupabase } from "@/lib/utils";
 import { createRealtimePost } from "@/lib/actions/realtimepost.actions";
 import { fetchUserByUsername } from "@/lib/actions/user.actions";
@@ -357,6 +359,29 @@ const CreateFeedPost = ({ roomId = "global" }: Props) => {
                 realtimeRoomId: roomId,
                 pluginType: "SPLINE_VIEWER",
                 pluginData: { sceneUrl: vals.sceneUrl },
+              });
+              reset();
+              router.refresh();
+            }}
+          />
+        );
+      case "ROOM_CANVAS":
+        return (
+          <RoomCanvasModal
+            onSubmit={async (vals) => {
+              const canvas = await exportRoomCanvas(vals.roomId);
+              if (!canvas) return;
+              if (JSON.stringify(canvas).length > 1_000_000) {
+                alert("Canvas too large to share");
+                return;
+              }
+              await createRealtimePost({
+                text: vals.description,
+                path: "/",
+                coordinates: { x: 0, y: 0 },
+                type: "ROOM_CANVAS",
+                realtimeRoomId: vals.roomId,
+                roomPostContent: canvas,
               });
               reset();
               router.refresh();

--- a/components/forms/RoomCanvasForm.tsx
+++ b/components/forms/RoomCanvasForm.tsx
@@ -1,0 +1,42 @@
+import { RoomCanvasPostValidation } from "@/lib/validations/thread";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useForm } from "react-hook-form";
+import { z } from "zod";
+import { Button } from "../ui/button";
+import { Input } from "../ui/input";
+import { Textarea } from "../ui/textarea";
+
+interface Props {
+  onSubmit: (values: z.infer<typeof RoomCanvasPostValidation>) => void;
+  currentRoomId: string;
+  currentDescription: string;
+}
+
+export default function RoomCanvasForm({ onSubmit, currentRoomId, currentDescription }: Props) {
+  const form = useForm({
+    resolver: zodResolver(RoomCanvasPostValidation),
+    defaultValues: { roomId: currentRoomId, description: currentDescription },
+  });
+
+  return (
+    <form method="post" className="ml-3 mr-3" onSubmit={form.handleSubmit(onSubmit)}>
+      <hr />
+      <div className="py-4 grid gap-2">
+        <label className="flex flex-col text-white gap-3 text-[1rem]">
+          Room ID:
+          <Input type="text" {...form.register("roomId")} className="text-black" />
+        </label>
+        <label className="flex flex-col text-white gap-3 text-[1rem]">
+          Description:
+          <Textarea {...form.register("description")} className="text-black" />
+        </label>
+      </div>
+      <hr />
+      <div className="py-4 mb-0">
+        <Button type="submit" className="form-submit-button" size={"lg"}>
+          Share
+        </Button>
+      </div>
+    </form>
+  );
+}

--- a/components/modals/RoomCanvasModal.tsx
+++ b/components/modals/RoomCanvasModal.tsx
@@ -1,0 +1,22 @@
+"use client";
+import { z } from "zod";
+import { DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+import RoomCanvasForm from "../forms/RoomCanvasForm";
+import { RoomCanvasPostValidation } from "@/lib/validations/thread";
+
+interface Props {
+  onSubmit?: (values: z.infer<typeof RoomCanvasPostValidation>) => void;
+}
+
+export default function RoomCanvasModal({ onSubmit }: Props) {
+  return (
+    <div>
+      <DialogContent className="max-w-[40rem]">
+        <DialogHeader className="dialog-header text-white text-lg py-4 mt-[-2rem]">
+          <b>Share Room Canvas</b>
+        </DialogHeader>
+        <RoomCanvasForm onSubmit={onSubmit!} currentRoomId="" currentDescription="" />
+      </DialogContent>
+    </div>
+  );
+}

--- a/lib/actions/realtimeroom.actions.ts
+++ b/lib/actions/realtimeroom.actions.ts
@@ -5,6 +5,10 @@ import { prisma } from "../prismaclient";
 import { getUserFromCookies } from "../serverutils";
 import { nanoid } from "nanoid";
 import { generateFriendSuggestions } from "./friend-suggestions.actions";
+import {
+  convertPostToNode,
+  convertRealtimeEdgeToEdge,
+} from "@/lib/reactflow/reactflowutils";
 
 export async function fetchRealtimeRoom({
   realtimeRoomId,
@@ -281,5 +285,21 @@ export async function lookupInviteToken(inviteToken: string) {
     });
   } catch (error: any) {
     throw new Error(`Failed to lookup invite token: ${error.message}`);
+  }
+}
+
+export async function exportRoomCanvas(roomId: string) {
+  try {
+    const room = await fetchRealtimeRoom({ realtimeRoomId: roomId });
+    if (!room) return null;
+    const nodes = room.realtimeposts.map((post) =>
+      convertPostToNode(post, post.author)
+    );
+    const edges = room.realtimeedges.map((edge) =>
+      convertRealtimeEdgeToEdge(edge)
+    );
+    return { nodes, edges, roomId, viewport: { x: 0, y: 0, zoom: 1 } };
+  } catch (error: any) {
+    throw new Error(`Failed to export room canvas: ${error.message}`);
   }
 }

--- a/lib/validations/thread.ts
+++ b/lib/validations/thread.ts
@@ -182,3 +182,8 @@ export const MusicPostValidation = z.object({
   title: z.string().min(1),
 });
 
+export const RoomCanvasPostValidation = z.object({
+  roomId: z.string().min(1),
+  description: z.string().optional(),
+});
+


### PR DESCRIPTION
## Summary
- add RoomCanvasForm and RoomCanvasModal for selecting room and description
- support new ROOM_CANVAS case in CreateFeedPost
- expose exportRoomCanvas server action
- include RoomCanvasPostValidation schema

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68794206c96483299c065374c409d72e