### PR TITLE
Fix ROOM_CANVAS post rendering

### DIFF
--- a/components/cards/PostCard.tsx
+++ b/components/cards/PostCard.tsx
@@ -33,6 +33,7 @@ interface Props {
   video_url?: string;
 
   content?: string;
+  roomPostContent?: Record<string, any> | null;
   type: string;
 
   author: {
@@ -56,6 +57,7 @@ const PostCard = ({
   currentUserId,
   currentUserLike = null,
   content,
+  roomPostContent = null,
   author,
   image_url,
   video_url,
@@ -200,22 +202,13 @@ const PostCard = ({
                 <DrawCanvas id={id.toString()} content={content} />
               </div>
             )}
+            {type === "ROOM_CANVAS" && roomPostContent && (
+              <div className="mt-2 mb-2 flex flex-col items-center justify-center">
+                <EmbeddedCanvas canvas={roomPostContent} roomId={roomPostContent.roomId || "global"} />
+              </div>
+            )}
             {type === "ROOM_CANVAS" && content && (
-              (() => {
-                let canvas: any = null;
-                try {
-                  canvas = JSON.parse(content);
-                } catch (e) {
-                  canvas = null;
-                }
-                return (
-                  canvas && (
-                    <div className="mt-2 mb-2 flex justify-center items-center">
-                      <EmbeddedCanvas canvas={canvas} roomId={canvas.roomId || "global"} />
-                    </div>
-                  )
-                );
-              })()
+              <p className="mt-2 text-[1.08rem] text-black tracking-[.05rem]">{content}</p>
             )}
             {type === "PORTFOLIO" && content && (
               (() => {

--- a/components/shared/RealtimeFeed.tsx
+++ b/components/shared/RealtimeFeed.tsx
@@ -51,6 +51,7 @@ export default function RealtimeFeed({
           likeCount={realtimePost.like_count}
           commentCount={realtimePost.commentCount}
           content={realtimePost.content ? realtimePost.content : undefined}
+          roomPostContent={(realtimePost as any).room_post_content}
           image_url={realtimePost.image_url ? realtimePost.image_url : undefined}
           video_url={realtimePost.video_url ? realtimePost.video_url : undefined}
           pluginType={(realtimePost as any).pluginType ?? null}


### PR DESCRIPTION
## Summary
- pass serialized canvas data from RealtimeFeed
- display room canvas data in PostCard using new prop

## Testing
- `npm run lint` *(fails: next not found)*
- `npx tsc --noEmit` *(fails: missing modules)*

------
https://chatgpt.com/codex/tasks/task_e_6879479358808329852096dbfa5d40c4