### PR TITLE
Include ROOM_CANVAS posts in lounge feed

### DIFF
--- a/app/(root)/(standard)/lounges/[id]/page.tsx
+++ b/app/(root)/(standard)/lounges/[id]/page.tsx
@@ -32,6 +32,7 @@ export default async function Page({ params }: { params: { id: string } }) {
       "PORTFOLIO",
       "PLUGIN",
       "PRODUCT_REVIEW",
+      "ROOM_CANVAS",
     ],
   });
   return (
@@ -55,11 +56,12 @@ export default async function Page({ params }: { params: { id: string } }) {
             "MUSIC",
             "ENTROPY",
             "PORTFOLIO",
-            "PLUGIN",
-            "PRODUCT_REVIEW",
-          ]}
-          currentUserId={user?.userId}
-        />
+          "PLUGIN",
+          "PRODUCT_REVIEW",
+          "ROOM_CANVAS",
+        ]}
+        currentUserId={user?.userId}
+      />
       )}
     </div>
   );


### PR DESCRIPTION
## Summary
- show ROOM_CANVAS posts in lounge timelines

## Testing
- `yarn install` *(fails: YAMLException: bad indentation of a mapping entry)*
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6879530451ac8329a934093e1488cefb