### PR TITLE
Implement text input for replicate posts

### DIFF
--- a/components/buttons/ReplicateButton.tsx
+++ b/components/buttons/ReplicateButton.tsx
@@ -3,9 +3,18 @@
 import { replicatePost } from "@/lib/actions/thread.actions";
 import { replicateRealtimePost } from "@/lib/actions/realtimepost.actions";
 import { useAuth } from "@/lib/AuthContext";
-import { Like } from "@prisma/client";
 import Image from "next/image";
 import { useRouter, usePathname } from "next/navigation";
+import { useState } from "react";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import { Textarea } from "@/components/ui/textarea";
+import { Button } from "@/components/ui/button";
 
 
 interface Props {
@@ -16,12 +25,15 @@ interface Props {
 const ReplicateButton = ({ postId, realtimePostId }: Props) => {
   const user = useAuth();
   const router = useRouter();
-    const pathname = usePathname();
+  const pathname = usePathname();
+
+  const [open, setOpen] = useState(false);
+  const [text, setText] = useState("");
 
   const isUserSignedIn = !!user.user;
   const userObjectId = user?.user?.userId;
-  
-  async function handleClick() {
+
+  async function handleSubmit() {
     if (!isUserSignedIn) {
       router.push("/login");
       return;
@@ -34,30 +46,51 @@ const ReplicateButton = ({ postId, realtimePostId }: Props) => {
         originalPostId: realtimePostId.toString(),
         userId: userObjectId.toString(),
         path: pathname,
+        text,
       });
     } else if (postId) {
       await replicatePost({
         originalPostId: postId.toString(),
         userId: userObjectId.toString(),
         path: pathname,
+        text,
       });
     } else {
       return;
     }
+    setText("");
+    setOpen(false);
     router.refresh();
   }
- 
+
   return (
-    <button onClick={handleClick}>
-    <Image
-      src="/assets/replicate.svg"
-      alt="replicate"
-      width={28}
-      height={28}
-      className="cursor-pointer object-contain likebutton"
-    />
-  </button>
-);
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger asChild>
+        <button>
+          <Image
+            src="/assets/replicate.svg"
+            alt="replicate"
+            width={28}
+            height={28}
+            className="cursor-pointer object-contain likebutton"
+          />
+        </button>
+      </DialogTrigger>
+      <DialogContent className="max-w-[30rem]">
+        <DialogHeader>
+          <DialogTitle className="text-white">Replicate Post</DialogTitle>
+        </DialogHeader>
+        <Textarea
+          placeholder="Add text"
+          value={text}
+          onChange={(e) => setText(e.target.value)}
+        />
+        <Button onClick={handleSubmit} className="mt-2">
+          Replicate
+        </Button>
+      </DialogContent>
+    </Dialog>
+  );
   
 };
 

--- a/components/cards/PostCard.tsx
+++ b/components/cards/PostCard.tsx
@@ -85,7 +85,23 @@ const PostCard = ({
   claimIds,
   }: Props) => {
   if (content && content.startsWith("REPLICATE:")) {
-    const originalId = BigInt(content.split(":" )[1]);
+    const dataStr = content.slice("REPLICATE:".length);
+    let originalId: bigint | null = null;
+    let replicateText = "Replicated";
+    try {
+      const parsed = JSON.parse(dataStr);
+      originalId = BigInt(parsed.id);
+      replicateText = parsed.text || replicateText;
+    } catch (e) {
+      try {
+        originalId = BigInt(dataStr);
+      } catch {
+        originalId = null;
+      }
+    }
+
+    if (!originalId) return null;
+
     return (
       <ReplicatedPostCard
         id={id}
@@ -96,6 +112,7 @@ const PostCard = ({
         createdAt={createdAt}
         likeCount={likeCount}
         expirationDate={expirationDate ?? undefined}
+        text={replicateText}
       />
     );
   }

--- a/components/cards/ReplicatedPostCard.tsx
+++ b/components/cards/ReplicatedPostCard.tsx
@@ -16,6 +16,7 @@ interface Props {
   createdAt: string;
   likeCount: number;
   expirationDate?: string | null;
+  text?: string;
 }
 
 const ReplicatedPostCard = ({
@@ -27,6 +28,7 @@ const ReplicatedPostCard = ({
   createdAt,
   likeCount,
   expirationDate,
+  text = "Replicated",
 }: Props) => {
   const [original, setOriginal] = useState<any | null>(null);
   const [currentUserLike, setCurrentUserLike] = useState<any | null>(null);
@@ -57,7 +59,7 @@ const ReplicatedPostCard = ({
       id={id}
       currentUserId={currentUserId}
       currentUserLike={currentUserLike}
-      content="Replicated"
+      content={text}
       type="TEXT"
       isRealtimePost={isRealtimePost}
       author={author}

--- a/lib/actions/realtimepost.actions.ts
+++ b/lib/actions/realtimepost.actions.ts
@@ -566,10 +566,12 @@ export async function replicateRealtimePost({
   originalPostId,
   userId,
   path,
+  text,
 }: {
   originalPostId: string | number | bigint;
   userId: string | number | bigint;
   path: string;
+  text?: string;
 }) {
   try {
     const oid = BigInt(originalPostId);
@@ -578,9 +580,10 @@ export async function replicateRealtimePost({
       where: { id: oid },
     });
     if (!original) throw new Error("Real-time post not found");
+    const payload = JSON.stringify({ id: oid.toString(), text });
     const newPost = await prisma.realtimePost.create({
       data: {
-        content: `REPLICATE:${oid.toString()}`,
+        content: `REPLICATE:${payload}`,
         author_id: uid,
         x_coordinate: original.x_coordinate,
         y_coordinate: original.y_coordinate,

--- a/lib/actions/thread.actions.ts
+++ b/lib/actions/thread.actions.ts
@@ -229,10 +229,12 @@ export async function replicatePost({
   originalPostId,
   userId,
   path,
+  text,
 }: {
   originalPostId: string | number | bigint;
   userId: string | number | bigint;
   path: string;
+  text?: string;
 }) {
   try {
     const oid = BigInt(originalPostId);
@@ -242,9 +244,10 @@ export async function replicatePost({
       include: { author: true },
     });
     if (!original) throw new Error("Post not found");
+    const payload = JSON.stringify({ id: oid.toString(), text });
     const newPost = await prisma.post.create({
       data: {
-        content: `REPLICATE:${oid.toString()}`,
+        content: `REPLICATE:${payload}`,
         author_id: uid,
       },
     });


### PR DESCRIPTION
## Summary
- open a modal when replicating a post so users can add text
- parse replicate metadata in `PostCard`
- display custom text in `ReplicatedPostCard`
- store replicate text in `replicatePost` and `replicateRealtimePost`

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6879db351f188329956bbea876d3da7b