### PR TITLE
Add user similarity recommendation worker

### DIFF
--- a/app/api/v2/people/candidates/route.ts
+++ b/app/api/v2/people/candidates/route.ts
@@ -1,0 +1,36 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getUserFromCookies } from "@/lib/serverutils";
+import { prisma } from "@/lib/prismaclient";
+import redis from "@/lib/redis";
+
+export const runtime = "nodejs";
+
+export async function GET(req: NextRequest) {
+  const user = await getUserFromCookies();
+  if (!user?.userId) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const k = Math.min(Number(req.nextUrl.searchParams.get("k") ?? "50"), 200);
+  const uid = Number(user.userId);
+
+  let ids: number[];
+  const cached = await redis.get(`friendSuggest:${uid}`);
+  if (cached) ids = JSON.parse(cached) as number[];
+  else {
+    const r = await prisma.userSimilarityKnn.findMany({
+      where: { user_id: uid },
+      orderBy: { sim: "desc" },
+      take: k,
+      select: { neighbour_id: true },
+    });
+    ids = r.map((x) => Number(x.neighbour_id));
+  }
+
+  const profiles = await prisma.user.findMany({
+    where: { id: { in: ids.slice(0, k) } },
+    select: { id: true, username: true, name: true, image: true },
+  });
+
+  return NextResponse.json(profiles);
+}

--- a/lib/models/schema.prisma
+++ b/lib/models/schema.prisma
@@ -582,6 +582,16 @@ model track_embedding {
   @@map("track_embedding")
 }
 
+model UserSimilarityKnn {
+  user_id      BigInt
+  neighbour_id BigInt
+  sim          Float
+  created_at   DateTime @default(now()) @db.Timestamptz(6)
+
+  @@id([user_id, neighbour_id])
+  @@map("user_similarity_knn")
+}
+
 enum like_type {
   LIKE
   DISLIKE

--- a/lib/queue.ts
+++ b/lib/queue.ts
@@ -19,6 +19,7 @@ export const spotifyIngestQueue = new Queue('spotify-ingest', { connection }); /
 export const reembedQueue       = new Queue('reembed',       { connection });
 export const tasteVectorQueue   = new Queue('taste-vector',   { connection });
 export const candidateBuilderQueue = new Queue('candidate-builder', { connection });
+export const userKnnQueue       = new Queue('user-knn',      { connection });
 // export const tasteVectorEvents  = new QueueEvents('taste-vector',   { connection });
 
 

--- a/supabase/migrations/20251017000000_create_user_similarity_knn.sql
+++ b/supabase/migrations/20251017000000_create_user_similarity_knn.sql
@@ -1,0 +1,12 @@
+CREATE TABLE IF NOT EXISTS user_similarity_knn (
+  user_id      BIGINT    NOT NULL,
+  neighbour_id BIGINT    NOT NULL,
+  sim          REAL      NOT NULL,
+  created_at   TIMESTAMPTZ DEFAULT NOW(),
+  PRIMARY KEY (user_id, neighbour_id)
+);
+
+CREATE INDEX IF NOT EXISTS user_taste_vectors_ivfflat
+  ON user_taste_vectors
+  USING ivfflat (taste vector_cosine_ops)
+  WITH (lists = 100);

--- a/workers/index.ts
+++ b/workers/index.ts
@@ -7,6 +7,7 @@ import '@/workers/reembed';
 import "@/workers/scrollRealtime";
 import '@/workers/tasteVector';
 import "@/workers/candidate-builder";
+import "@/workers/user-knn-builder";
 
 
 console.log('All workers bootstrapped');

--- a/workers/tasteVector.ts
+++ b/workers/tasteVector.ts
@@ -10,7 +10,7 @@
 
 
 import { Worker }                 from 'bullmq';
-import { connection, candidateBuilderQueue } from '@/lib/queue';
+import { connection, candidateBuilderQueue, userKnnQueue } from '@/lib/queue';
 import { prisma }                 from '@/lib/prismaclient';
 import redis                      from '@/lib/redis';
 import { createClient }           from '@supabase/supabase-js';
@@ -91,6 +91,7 @@ new Worker(
     await redis.del(`candCache:${userId}`);
     await redis.del(`friendSuggest:${userId}`);
     await candidateBuilderQueue.add('build', { userId });
+    await userKnnQueue.add('build-knn', { userId });
     console.log('[taste‑vector] done', userId);
   },
   { connection, concurrency: 2 },

--- a/workers/user-knn-builder.ts
+++ b/workers/user-knn-builder.ts
@@ -1,0 +1,41 @@
+import { Worker } from "bullmq";
+import { connection } from "@/lib/queue";
+import { prisma } from "@/lib/prismaclient";
+import redis from "@/lib/redis";
+
+new Worker(
+  "user-knn",
+  async (job) => {
+    const uid = Number(job.data.userId);
+
+    const rows: { neighbour_id: bigint; sim: number }[] = await prisma.$queryRaw`
+      SELECT  u2.user_id  AS neighbour_id,
+              1 - (u1.taste <#> u2.taste) AS sim
+      FROM    user_taste_vectors u1,
+              user_taste_vectors u2
+      WHERE   u1.user_id = ${uid}
+        AND   u2.user_id <> ${uid}
+      ORDER BY u1.taste <#> u2.taste
+      LIMIT  200
+    `;
+
+    await prisma.$transaction(async (tx) => {
+      await tx.$executeRaw`DELETE FROM user_similarity_knn WHERE user_id = ${uid}`;
+      if (rows.length)
+        await tx.$executeRawUnsafe(
+          `INSERT INTO user_similarity_knn (user_id, neighbour_id, sim)
+           SELECT * FROM jsonb_to_recordset($1::jsonb)
+                  AS x(user_id bigint, neighbour_id bigint, sim float4)`,
+          JSON.stringify(rows.map((r) => ({ user_id: uid, ...r }))),
+        );
+    });
+
+    await redis.set(
+      `friendSuggest:${uid}`,
+      JSON.stringify(rows.map((r) => Number(r.neighbour_id))),
+      "EX",
+      300,
+    );
+  },
+  { connection, concurrency: 2 },
+);


### PR DESCRIPTION
## Summary
- define `UserSimilarityKnn` model for storing neighbour users
- create migration for `user_similarity_knn` and ANN index
- expose `userKnnQueue` in the queue library
- add worker to compute nearest users
- trigger worker after taste vectors are built
- serve friend suggestions via `/api/v2/people/candidates`
- register new worker bootstrap

## Testing
- `yarn install`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_687c0531e6a883299fd67b1433416e46