### PR TITLE
Implement basic portfolio page builder

### DIFF
--- a/app/(pages)/settings/integrations/page.tsx
+++ b/app/(pages)/settings/integrations/page.tsx
@@ -1,5 +1,6 @@
 // app/(pages)/settings/integrations/page.tsx
-import SpotifyButton from './SpotifyButton';
+import SpotifyButton from "./SpotifyButton";
+import Image from "next/image";
 
 export const metadata = { title: 'Integrations' };
 
@@ -11,7 +12,7 @@ export default function IntegrationsPage() {
       {/* --- Spotify -------------------------------------------------- */}
       <section className="space-y-2">
         <h2 className="text-xl font-medium flex items-center gap-2">
-          <img src="/logo/spotify.svg" className="h-5 w-5" /> Spotify
+          <Image src="/logo/spotify.svg" alt="Spotify" width={20} height={20} /> Spotify
         </h2>
         <p className="text-sm text-gray-500">
           Import your liked songs to personalise recommendations.

--- a/app/portfolio/builder/page.tsx
+++ b/app/portfolio/builder/page.tsx
@@ -5,10 +5,17 @@ import { useDraggable, useDroppable } from "@dnd-kit/core";
 import { CSS } from "@dnd-kit/utilities";
 import { nanoid } from "nanoid";
 import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { uploadFileToSupabase } from "@/lib/utils";
+import { PortfolioExportData } from "@/lib/portfolio/export";
+import Image from "next/image";
 
 interface Element {
   id: string;
-  type: "text" | "image" | "box";
+  type: "text" | "image" | "box" | "link";
+  content?: string;
+  src?: string;
+  href?: string;
 }
 
 function DraggableItem({ id, children, fromSidebar }: { id: string; children: React.ReactNode; fromSidebar?: boolean }) {
@@ -32,11 +39,53 @@ function DroppableCanvas({ children }: { children: React.ReactNode }) {
 
 export default function PortfolioBuilder() {
   const [elements, setElements] = useState<Element[]>([]);
+  const [color, setColor] = useState("bg-white");
+  const [layout, setLayout] = useState<"column" | "grid">("column");
+  const router = useRouter();
 
   function handleDragEnd(event: DragEndEvent) {
     const { over, active } = event;
     if (over?.id === "canvas" && active.data.current?.fromSidebar) {
-      setElements((els) => [...els, { id: nanoid(), type: active.id as Element["type"] }]);
+      setElements((els) => [
+        ...els,
+        { id: nanoid(), type: active.id as Element["type"], content: "", src: "" },
+      ]);
+    }
+  }
+
+  async function handleImageSelect(id: string, file: File) {
+    const res = await uploadFileToSupabase(file);
+    if (!res.error) {
+      setElements((els) =>
+        els.map((el) => (el.id === id ? { ...el, src: res.fileURL } : el))
+      );
+    }
+  }
+
+  function serialize(): PortfolioExportData {
+    const text = elements
+      .filter((e) => e.type === "text" && e.content)
+      .map((e) => e.content)
+      .join("\n");
+    const images = elements
+      .filter((e) => e.type === "image" && e.src)
+      .map((e) => e.src as string);
+    const links = elements
+      .filter((e) => e.type === "link" && e.href)
+      .map((e) => e.href as string);
+    return { text, images, links, layout, color };
+  }
+
+  async function handlePublish() {
+    const data = serialize();
+    const res = await fetch("/api/portfolio/export", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(data),
+    });
+    if (res.ok) {
+      const { url } = await res.json();
+      router.push(url);
     }
   }
 
@@ -53,14 +102,103 @@ export default function PortfolioBuilder() {
           <DraggableItem id="box" fromSidebar>
             Box
           </DraggableItem>
+          <DraggableItem id="link" fromSidebar>
+            Link
+          </DraggableItem>
         </div>
         <DroppableCanvas>
           {elements.map((el) => (
-            <div key={el.id} className="p-2 border bg-white" >{el.type}</div>
+            <div key={el.id} className="p-2 border bg-white space-y-2">
+              {el.type === "text" && (
+                <div
+                  contentEditable
+                  suppressContentEditableWarning
+                  className="text-block outline-none"
+                  onInput={(e) =>
+                    setElements((els) =>
+                      els.map((it) =>
+                        it.id === el.id
+                          ? { ...it, content: (e.target as HTMLElement).innerText }
+                          : it
+                      )
+                    )
+                  }
+                >
+                  {el.content || "Edit text"}
+                </div>
+              )}
+              {el.type === "image" && (
+                <div>
+                  {el.src ? (
+                    <Image
+                      src={el.src}
+                      alt="uploaded"
+                      width={200}
+                      height={200}
+                      className="object-cover portfolio-img-frame"
+                    />
+                  ) : (
+                    <input
+                      type="file"
+                      accept="image/*"
+                      onChange={(e) => {
+                        const file = e.target.files?.[0];
+                        if (file) handleImageSelect(el.id, file);
+                      }}
+                    />
+                  )}
+                </div>
+              )}
+              {el.type === "box" && (
+                <div className="w-20 h-20 border bg-gray-200" />
+              )}
+              {el.type === "link" && (
+                <input
+                  className="border p-1 text-sm"
+                  placeholder="https://example.com"
+                  value={el.href || ""}
+                  onChange={(e) =>
+                    setElements((els) =>
+                      els.map((it) =>
+                        it.id === el.id ? { ...it, href: e.target.value } : it
+                      )
+                    )
+                  }
+                />
+              )}
+            </div>
           ))}
         </DroppableCanvas>
-        <div className="w-40 border-l p-2 bg-gray-100">
-          <p className="text-sm text-gray-600">Style options coming soon...</p>
+        <div className="w-40 border-l p-2 bg-gray-100 space-y-4">
+          <div>
+            <p className="text-sm mb-1">Background</p>
+            <select
+              className="w-full border p-1"
+              value={color}
+              onChange={(e) => setColor(e.target.value)}
+            >
+              <option value="bg-white">White</option>
+              <option value="bg-gray-200">Gray</option>
+              <option value="bg-blue-200">Blue</option>
+            </select>
+          </div>
+          <div>
+            <p className="text-sm mb-1">Layout</p>
+            <select
+              className="w-full border p-1"
+              value={layout}
+              onChange={(e) => setLayout(e.target.value as "column" | "grid")}
+            >
+              <option value="column">Column</option>
+              <option value="grid">Grid</option>
+            </select>
+          </div>
+          <button
+            className="w-full mt-4 bg-blue-500 text-white py-1 rounded"
+            onClick={handlePublish}
+          >
+            Publish
+          </button>
         </div>
       </div>
     </DndContext>


### PR DESCRIPTION
## Summary
- allow uploading and publishing from Portfolio builder
- offer simple style sidebar and link tool
- fix lint warnings in integrations page

## Testing
- `npm run lint`
- `npm test` *(fails: index.query is not a function, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_687d84960e0c8329899b0c3d5e2bf7f5