### PR TITLE
Add grid background and inline text editing

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -1254,3 +1254,11 @@ html:before{
   stroke: #bbb;
   stroke-dasharray: 5 5;
 }
+
+/* Canvas grid background */
+.canvas-grid {
+  background-image: linear-gradient(to right, rgba(0,0,0,0.05) 1px, transparent 1px),
+    linear-gradient(to bottom, rgba(0,0,0,0.05) 1px, transparent 1px);
+  background-size: 20px 20px;
+}
+

--- a/components/nodes/TextInputNode.tsx
+++ b/components/nodes/TextInputNode.tsx
@@ -60,6 +60,27 @@ function TextInputNode({ id, data }: NodeProps<TextNode>) {
     ? Number(currentActiveUser!.userId) === Number(data.author.id)
     : false;
 
+  const handleInput = (e: React.FormEvent<HTMLDivElement>) => {
+    if (!isOwned) return;
+    const value = e.currentTarget.textContent || "";
+    setText(value);
+    const ytext = docRef.current.getText("content");
+    ytext.delete(0, ytext.length);
+    ytext.insert(0, value);
+    const update = Y.encodeStateAsUpdate(docRef.current);
+    channelRef.current?.send({
+      type: "broadcast",
+      event: TEXT_UPDATE_EVENT,
+      payload: { update: Buffer.from(update).toString("base64") },
+    });
+  };
+
+  const handleBlur = () => {
+    if (isOwned) {
+      updateRealtimePost({ id, text, path });
+    }
+  };
+
   async function onSubmit(values: z.infer<typeof TextPostValidation>) {
     const ytext = docRef.current.getText("content");
     ytext.delete(0, ytext.length);
@@ -91,7 +112,15 @@ function TextInputNode({ id, data }: NodeProps<TextNode>) {
       isLocked={data.locked}
     >
       <div className="text-updater-node mt-2">
-        <div className="text-node-block h-full px-2 py-2">{ text}</div>
+        <div
+          className="text-node-block h-full px-2 py-2 outline-none"
+          contentEditable={isOwned}
+          suppressContentEditableWarning
+          onInput={handleInput}
+          onBlur={handleBlur}
+        >
+          {text}
+        </div>
       </div>
     </BaseNode>
   );

--- a/components/reactflow/Room.tsx
+++ b/components/reactflow/Room.tsx
@@ -374,7 +374,7 @@ function Room({ roomId, initialNodes, initialEdges }: Props) {
   };
 
   return (
-    <div className="absolute inset-x-0 inset-y-0 cursor-none bg-white z-0">
+    <div className="absolute inset-x-0 inset-y-0 cursor-none canvas-grid bg-white z-0">
       <ReactFlow
         style={{ cursor: "none" }}
         ref={reactFlowRef}


### PR DESCRIPTION
## Summary
- add canvas grid background style
- use grid background for room canvas
- allow inline editing of text nodes

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_687dada5961c8329b65a479c1dcbf5f7