### PR TITLE
Improve portfolio builder drag and text

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -1257,7 +1257,7 @@ html:before{
 
 .grid-background {
   background-image:
-    linear-gradient(to right, rgba(0, 0, 0, 0.1) 1px, transparent 1px),
-    linear-gradient(to bottom, rgba(0, 0, 0, 0.1) 1px, transparent 1px);
+    linear-gradient(to right, rgba(0, 0, 0, 0.08) 1px, transparent 1px),
+    linear-gradient(to bottom, rgba(0, 0, 0, 0.08) 1px, transparent 1px);
   background-size: 20px 20px;
 }

--- a/lib/portfolio/templates.ts
+++ b/lib/portfolio/templates.ts
@@ -4,6 +4,8 @@ export interface BuilderElement {
   content?: string;
   src?: string;
   href?: string;
+  x?: number;
+  y?: number;
 }
 
 export interface PortfolioTemplate {


### PR DESCRIPTION
## Summary
- tweak grid background lines
- allow draggable elements with coordinates
- support drawing text boxes on canvas

## Testing
- `npm run lint`
- `npx tsc -p tsconfig.json --noEmit` *(fails: Could not find a declaration file for module 'stream-json')*

------
https://chatgpt.com/codex/tasks/task_e_687dc22e40908329a05aad6c68ce4241