### PR TITLE
Add About Me persistence

### DIFF
--- a/app/(root)/(standard)/profile/[id]/customize/customize-components.tsx
+++ b/app/(root)/(standard)/profile/[id]/customize/customize-components.tsx
@@ -25,6 +25,7 @@ import {
   fetchTracks,
   submitEdits,
   submitFieldEdits,
+  submitBioEdit,
 } from "@/lib/MultiSelectFunctions";
 import { UserAttributes } from "@prisma/client";
 import { usePathname } from "next/navigation";
@@ -33,10 +34,11 @@ import React, { useState } from 'react';
 
 interface Props {
   userAttributes: UserAttributes;
+  currentBio: string;
   initialOpen?: boolean;
 }
 
-export default function CustomButtons({ userAttributes, initialOpen }: Props) {
+export default function CustomButtons({ userAttributes, currentBio, initialOpen }: Props) {
   const [isAboutOpen, setAboutOpen] = useState(false);
   const [isBirthdayOpen, setBirthdayOpen] = useState(false);
   const [isLocationOpen, setLocationOpen] = useState(false);
@@ -58,7 +60,7 @@ export default function CustomButtons({ userAttributes, initialOpen }: Props) {
       : ""
   );
   const path = usePathname();
-  const [message, setMessage] = useState('');
+  const [message, setMessage] = useState(currentBio);
   const handleChange = (event) => {
     setMessage(event.target.value);
   };
@@ -102,6 +104,7 @@ export default function CustomButtons({ userAttributes, initialOpen }: Props) {
                 id="aboutme"
                 type="submit"
                 className={`likebutton text-[1.2rem] tracking-[2px] text-center px-4 py-1 border-blue border-[.5px]`}
+                onClick={() => submitBioEdit(message, path)}
               >
                 Enter
               </DialogClose>

--- a/app/(root)/(standard)/profile/[id]/customize/page.tsx
+++ b/app/(root)/(standard)/profile/[id]/customize/page.tsx
@@ -20,7 +20,7 @@ async function Page({ params }: { params: { id: string } }) {
       <h1 className="text-[2.5rem] text-center">Customize Profile</h1>
       <hr></hr>
       <div className ="px-0 items-start justify-start">
-      <CustomButtons  userAttributes={userAttributes} />
+      <CustomButtons  userAttributes={userAttributes} currentBio={profilePageUser.bio || ""} />
       </div>
     </main>
   );

--- a/components/shared/AboutTab.tsx
+++ b/components/shared/AboutTab.tsx
@@ -2,6 +2,7 @@ import { getUserFromCookies } from "@/lib/serverutils";
 import { Button } from "../ui/button";
 import Link from "next/link";
 import { fetchUserAttributes } from "@/lib/actions/userattributes.actions";
+import { fetchUser } from "@/lib/actions/user.actions";
 import { format } from "date-fns";
 
 
@@ -17,6 +18,7 @@ const AboutTab = async ({ currentUserId, accountId }: Props) => {
 
   const attributes =
     (await fetchUserAttributes({ userId: accountId })) || null;
+  const profile = await fetchUser(accountId);
 
   const categories = [
 
@@ -86,6 +88,10 @@ const AboutTab = async ({ currentUserId, accountId }: Props) => {
     </div>
   );
 
+  const bioSection = profile?.bio ? (
+    <p className="mt-4 text-left text-black whitespace-pre-wrap">{profile.bio}</p>
+  ) : null;
+
   if (BigInt(currentUserId) === BigInt(accountId)) {
     return (
       <main className="items-center justify-center text-center">
@@ -94,12 +100,13 @@ const AboutTab = async ({ currentUserId, accountId }: Props) => {
             Customize Profile
           </button>
         </Link>
+        {bioSection}
         {grid}
       </main>
     );
   }
 
-  return <main className="text-center">{grid}</main>;
+  return <main className="text-center">{bioSection}{grid}</main>;
 };
 
 

--- a/lib/MultiSelectFunctions.ts
+++ b/lib/MultiSelectFunctions.ts
@@ -1,5 +1,6 @@
 import { UserAttributes } from "@prisma/client";
 import { upsertUserAttributes } from "./actions/userattributes.actions";
+import { updateUserBio } from "./actions/user.actions";
 
 const OMDB_API_KEY = "c971c02c";
 const discogsToken = "cuqwVeLuoiKZsMfpWDLDPeTIjviOBgJnlvHELjse";
@@ -453,4 +454,8 @@ export function submitFieldEdits(
     default:
       console.error("Nothing to update");
   }
+}
+
+export function submitBioEdit(bio: string, path: string) {
+  return updateUserBio({ bio, path });
 }

--- a/lib/actions/user.actions.ts
+++ b/lib/actions/user.actions.ts
@@ -68,6 +68,24 @@ export async function updateUser({
   }
 }
 
+export async function updateUserBio({ bio, path }: { bio: string; path: string }) {
+  const user = await getUserFromCookies();
+  if (!user) {
+    throw new Error("User not authenticated");
+  }
+  try {
+    await prisma.user.update({
+      where: {
+        id: user.userId!,
+      },
+      data: { bio },
+    });
+    revalidatePath(path);
+  } catch (error: any) {
+    throw new Error(`Failed to update bio: ${error.message}`);
+  }
+}
+
 export async function fetchUserByAuthId(userAuthId: string) {
   if (userCacheByAuthId.has(userAuthId)) {
     return userCacheByAuthId.get(userAuthId) ?? null;


### PR DESCRIPTION
## Summary
- allow editing user bio in profile customization
- persist bio with new `updateUserBio` action
- expose submitBioEdit helper
- show About Me text in About tab

## Testing
- `yarn install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_687e9586e42083299449d7bd5c926c95