### PR TITLE
Fix portfolio postcard creation

### DIFF
--- a/components/cards/PortfolioCard.tsx
+++ b/components/cards/PortfolioCard.tsx
@@ -24,7 +24,7 @@ interface PortfolioCardProps {
 /* ————————————————————————————————————————————— */
 /* ✨ Modal implemented with dynamic import so it   */
 /*    isn’t bundled on every feed page load.        */
-dynamic(() => import("@/components/modals/PortfolioModal"), { ssr: false });
+const Modal = dynamic(() => import("@/components/modals/PortfolioModal"), { ssr: false });
 /* ————————————————————————————————————————————— */
 
 export default function PortfolioCard({

--- a/lib/actions/realtimepost.actions.ts
+++ b/lib/actions/realtimepost.actions.ts
@@ -82,7 +82,10 @@ export async function createRealtimePost({
         ...(text && { content: text }),
         ...(imageUrl && { image_url: imageUrl }),
         ...(videoUrl && { video_url: videoUrl }),
-        ...[portfolio && { pageUrl: portfolio }],
+        ...(portfolio && {
+          content: JSON.stringify(portfolio),
+          ...(portfolio.snapshot && { image_url: portfolio.snapshot }),
+        }),
         author_id: user.userId!,
         x_coordinate: new Prisma.Decimal(coordinates.x),
         y_coordinate: new Prisma.Decimal(coordinates.y),
@@ -190,10 +193,14 @@ export async function updateRealtimePost({
     if (originalPost.locked && coordinates) {
       return;
     }
-    const updateData: Prisma.RealtimePostUpdateInput = {
+  const updateData: Prisma.RealtimePostUpdateInput = {
       ...(text && { content: text }),
       ...(imageUrl && { image_url: imageUrl }),
       ...(videoUrl && { video_url: videoUrl }),
+      ...(portfolio && {
+        content: JSON.stringify(portfolio),
+        ...(portfolio.snapshot && { image_url: portfolio.snapshot }),
+      }),
       ...(content && { content }),
       ...(collageLayoutStyle && { collageLayoutStyle }),
       ...(collageColumns !== undefined && { collageColumns }),


### PR DESCRIPTION
## Summary
- fix dynamic import in `PortfolioCard`
- store portfolio data correctly when creating or updating realtime posts

## Testing
- `npm run lint`
- `npm test` *(fails: explain_api, friend-suggestions, feature_store, discovery-candidates, explain_integration, spotify, favorites_builder, embed_worker)*

------
https://chatgpt.com/codex/tasks/task_e_687f095492288329ae95615d38541f57