### PR TITLE
Fix portfolio image sizing

### DIFF
--- a/app/portfolio/builder/page.tsx
+++ b/app/portfolio/builder/page.tsx
@@ -386,8 +386,24 @@ export default function PortfolioBuilder() {
         setElements((els) => [
           ...els,
           template === ""
-            ? { id: nanoid(), type: active.id as Element["type"], content: "", src: "", x, y }
-            : { id: nanoid(), type: active.id as Element["type"], content: "", src: "" },
+            ? {
+                id: nanoid(),
+                type: active.id as Element["type"],
+                content: "",
+                src: "",
+                x,
+                y,
+                width: active.id === "image" ? 300 : 200,
+                height: active.id === "image" ? 300 : 32,
+              }
+            : {
+                id: nanoid(),
+                type: active.id as Element["type"],
+                content: "",
+                src: "",
+                width: active.id === "image" ? 200 : 200,
+                height: active.id === "image" ? 200 : 32,
+              },
         ]);
       }
       return;
@@ -416,21 +432,27 @@ export default function PortfolioBuilder() {
       );
     }
   }
+
+  function recordNaturalSize(id: string, w: number, h: number) {
+    setElements((els) =>
+      els.map((el) => (el.id === id ? { ...el, natW: w, natH: h } : el))
+    );
+  }
   function buildAbsoluteExport() {
     // 1️⃣  From drag‑dropped template elements
-    const absoluteElems = elements
-      .filter(e => typeof e.x === "number" && typeof e.y === "number")
-      .map(e => ({
-        id: e.id,
-        type: e.type,
-        x: e.x!,
-        y: e.y!,
-        width:  e.type === "image" ? 300 : 200, // you could store width/height too
-        height: e.type === "image" ? 300 : 32,
-        content: e.content,
-        src: e.src,
-        href: e.href,
-      }));
+    const absoluteElems = elements.map((e) => ({
+      id: e.id,
+      type: e.type,
+      x: e.x ?? 0,
+      y: e.y ?? 0,
+      width: e.width ?? (e.type === "image" ? 300 : 200),
+      height: e.height ?? (e.type === "image" ? 300 : 32),
+      natW: e.natW,
+      natH: e.natH,
+      content: e.content,
+      src: e.src,
+      href: e.href,
+    }));
   
     // 2️⃣  From text boxes we drew
     const absoluteText = textBoxes.map(b => ({
@@ -586,7 +608,16 @@ const { url } = data;            // “/portfolio/abc123”
     setTemplate(name);
     setLayout(tpl.layout);
     setColor(tpl.color);
-    setElements(tpl.elements.map((e) => ({ ...e, id: nanoid(), x: 0, y: 0 })));
+    setElements(
+      tpl.elements.map((e) => ({
+        ...e,
+        id: nanoid(),
+        x: 0,
+        y: 0,
+        width: e.type === "image" ? 200 : 200,
+        height: e.type === "image" ? 200 : 32,
+      }))
+    );
   }
 
   const sensors = useSensors(useSensor(PointerSensor));
@@ -679,11 +710,17 @@ const { url } = data;            // “/portfolio/abc123”
                           <Image
                             src={el.src}
                             alt="uploaded"
-                            width={300}
-                            height={300}
-                            sizes="(max-height: 200px) 50vw, 33vw"
+                            width={el.width}
+                            height={el.height}
                             className="object-cover w-fit h-fit portfolio-img-frame"
                             crossOrigin="anonymous"
+                            onLoad={(e) =>
+                              recordNaturalSize(
+                                el.id,
+                                (e.target as HTMLImageElement).naturalWidth,
+                                (e.target as HTMLImageElement).naturalHeight,
+                              )
+                            }
                           />
                         ) : (
                           <input
@@ -762,10 +799,17 @@ const { url } = data;            // “/portfolio/abc123”
                           <Image
                             src={el.src}
                             alt="uploaded"
-                            width={200}
-                            height={200}
+                            width={el.width}
+                            height={el.height}
                             className="object-cover portfolio-img-frame"
                             crossOrigin="anonymous"
+                            onLoad={(e) =>
+                              recordNaturalSize(
+                                el.id,
+                                (e.target as HTMLImageElement).naturalWidth,
+                                (e.target as HTMLImageElement).naturalHeight,
+                              )
+                            }
                           />
                         ) : (
                           <input

--- a/lib/components/CanvasRenderer.tsx
+++ b/lib/components/CanvasRenderer.tsx
@@ -7,6 +7,8 @@ export interface AbsoluteElement {
   y: number;
   width: number;
   height: number;
+  natW?: number;
+  natH?: number;
   content?: string;
   src?: string;
   href?: string;
@@ -52,9 +54,9 @@ export default function CanvasRenderer({
                   key={el.id}
                   src={el.src!}
                   alt=""
-                  fill
-                  style={style}
-                  className="object-cover"
+                  width={el.width}
+                  height={el.height}
+                  style={{ ...style, objectFit: "cover" }}
                 />
               );
 

--- a/lib/portfolio/export.ts
+++ b/lib/portfolio/export.ts
@@ -21,6 +21,8 @@ export interface AbsoluteElement {
   y: number;
   width: number;
   height: number;
+  natW?: number;
+  natH?: number;
   content?: string;
   src?: string;
   href?: string;
@@ -39,10 +41,10 @@ export function generatePortfolioTemplates(
     /* ---------- 1‑A  plain HTML fallback ---------- */
     const itemsHtml = data.absolutes
       .map(a => {
-        const style = `style="position:absolute;left:${a.x}px;top:${a.y}px;width:${a.width}px;height:${a.height}px;"`;
+        const style = `style="position:absolute;left:${a.x}px;top:${a.y}px;width:${a.width}px;height:${a.height}px;object-fit:cover"`;
         switch (a.type) {
           case "image":
-            return `<img ${style} src="${escapeHtml(a.src)}" class="object-cover" />`;
+            return `<img ${style} src="${escapeHtml(a.src)}" />`;
           case "link":
             return `<a ${style} href="${escapeHtml(a.href)}" class="break-all underline text-blue-500" target="_blank" rel="noreferrer">${escapeHtml(a.href)}</a>`;
           default: // "text" | "text-box" | "box"
@@ -83,7 +85,7 @@ export function generatePortfolioTemplates(
 
         switch (a.type) {
           case "image":
-            return `<Image src="${escapeJSX(a.src)}" alt="" fill style={${styleJsx}} className="object-cover" />`;
+            return `<Image src="${escapeJSX(a.src)}" alt="" width={${a.width}} height={${a.height}} style={{ position: 'absolute', left: ${a.x}, top: ${a.y}, width: ${a.width}, height: ${a.height}, objectFit: 'cover' }} />`;
           case "link":
             return `<a href="${escapeJSX(a.href)}" style={${styleJsx}} className="break-all underline text-blue-500" target="_blank" rel="noreferrer">${escapeJSX(
               a.href,
@@ -154,10 +156,17 @@ export default function PortfolioCanvas() {
     ? `<div class="text-block flex flex-col max-h-[1000px] mb-1 mt-2 break-words">${data.text}</div>`
     : "";
 
-  const images = data.images
-    .map((src, idx) =>
-      `<img src="${src}" class="object-cover  portfolio-img-frame ${idx === 0 ? "flex flex-col max-h-[3000px] mb-1 mt-2 break-words" : ""}" />`
-    )
+  const absImgs = data.absolutes?.filter(a => a.type === "image") ?? [];
+  const images = (absImgs.length ? absImgs : data.images.map(src => ({ src })))
+    .map((img, idx) => {
+      const src = (img as any).src ?? img;
+      const w = (img as any).width;
+      const h = (img as any).height;
+      const style = w && h
+        ? `style="width:${w}px;height:${h}px;object-fit:cover"`
+        : "";
+      return `<img src="${src}" ${style} class="portfolio-img-frame ${idx === 0 ? "flex flex-col max-h-[3000px] mb-1 mt-2 break-words" : ""}" />`;
+    })
     .join("\n");
 
   const links = data.links

--- a/lib/portfolio/templates.ts
+++ b/lib/portfolio/templates.ts
@@ -4,6 +4,11 @@ export interface BuilderElement {
   content?: string;
   src?: string;
   href?: string;
+  width?: number;
+  height?: number;
+  /** natural dimensions for keeping aspect ratio */
+  natW?: number;
+  natH?: number;
   x?: number;
   y?: number;
 }

--- a/tests/__snapshots__/portfolio-export.test.ts.snap
+++ b/tests/__snapshots__/portfolio-export.test.ts.snap
@@ -12,7 +12,7 @@ exports[`portfolio export matches snapshot 1`] = `
   <div class="portfolio-container flex flex-col w-[34rem] max-h-[3000px]">
     <div class="flex flex-col gap-2 rounded-lg p-4 bg-white mt-4 max-h-[3000px]">
       <div class="text-block flex flex-col max-h-[1000px] mb-1 mt-2 break-words">Hello</div>
-      <img src="img.png" class="object-cover  portfolio-img-frame flex flex-col max-h-[3000px] mb-1 mt-2 break-words" />
+      <img src="img.png"  class="portfolio-img-frame flex flex-col max-h-[3000px] mb-1 mt-2 break-words" />
       <a href="https://example.com" class="text-blue-500 underline break-all" target="_blank" rel="noreferrer">https://example.com</a>
     </div>
   </div>


### PR DESCRIPTION
## Summary
- keep width/height & natural size for builder images
- export those dimensions for portfolio HTML and React
- render images with explicit sizes
- update snapshot

## Testing
- `npm run lint`
- `npm test` *(fails: TypeError: index.query is not a function, etc.)*
- `npm test -- -u tests/portfolio-export.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_687f3e3e36c48329b06d8cd9918ad9dc