### PR TITLE
Add image resize handles

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -406,17 +406,17 @@
 /* ---- text‑box corner handles ---- */
 .resize-handle {
   position: absolute;
-  width: 10px;
-  height: 10px;
-  background: #3b82f6;            /* blue‑500 – tweak to taste */
-  border-radius: 2px;
-  z-index: 10;
+  width: 8px;
+  height: 8px;
+  background: #fff;
+  border: 1px solid #000;
+  z-index: 20;
 }
 
-.handle-nw { top:  -5px; left:  -5px;  cursor: nwse-resize; }
-.handle-ne { top:  -5px; right: -5px;  cursor: nesw-resize; }
-.handle-sw { bottom:-5px; left:  -5px;  cursor: nesw-resize; }
-.handle-se { bottom:-5px; right: -5px;  cursor: nwse-resize; }
+.handle-nw { left: -4px; top: -4px; cursor: nwse-resize; }
+.handle-ne { right: -4px; top: -4px; cursor: nesw-resize; }
+.handle-sw { left: -4px; bottom: -4px; cursor: nesw-resize; }
+.handle-se { right: -4px; bottom: -4px; cursor: nwse-resize; }
 
 .portal-node {
  display: grid;

--- a/app/portfolio/builder/page.tsx
+++ b/app/portfolio/builder/page.tsx
@@ -136,12 +136,13 @@ interface TextBox {
 }
 type Corner = "nw" | "ne" | "sw" | "se";
 
+type ResizeTarget = { id: string; kind: "text" | "image" };
 interface ResizeState {
-  id: string; // box being resized
+  target: ResizeTarget; // element being resized
   corner: Corner; // which corner is active
   startX: number; // pointer position at drag start
   startY: number;
-  startLeft: number; // box position/dimensions at drag start
+  startLeft: number; // element position/dimensions at drag start
   startTop: number;
   startWidth: number;
   startHeight: number;
@@ -307,26 +308,34 @@ function DroppableCanvas({
     setDraft(null);
   }
   /* ---------- resize helpers ------------ */
-  function handlePointerDown(
+  function handleResizeStart(
     e: React.PointerEvent,
-    b: TextBox,
+    target: ResizeTarget,
     corner: Corner
   ) {
     e.stopPropagation();
     const rect = ref.current!.getBoundingClientRect();
+    const startX = e.clientX - rect.left;
+    const startY = e.clientY - rect.top;
+
+    const obj =
+      target.kind === "text"
+        ? textBoxes.find((b) => b.id === target.id)!
+        : elements.find((el) => el.id === target.id)!;
+
     setResizing({
-      id: b.id,
+      target,
       corner,
-      startX: e.clientX - rect.left,
-      startY: e.clientY - rect.top,
-      startLeft: b.x,
-      startTop: b.y,
-      startWidth: b.width,
-      startHeight: b.height,
+      startX,
+      startY,
+      startLeft: obj.x,
+      startTop: obj.y,
+      startWidth: obj.width,
+      startHeight: obj.height,
     });
   }
   function handleBoxPointerDown(e: React.PointerEvent, b: TextBox) {
-    // Ignore if we’re clicking a resize handle – they call handlePointerDown.
+    // Ignore if we’re clicking a resize handle – they call handleResizeStart.
     if ((e.target as HTMLElement).classList.contains("resize-handle")) return;
 
     // Ignore if user clicks inside the text editor (it stops propagation).
@@ -355,6 +364,7 @@ function DroppableCanvas({
         startTop,
         startWidth,
         startHeight,
+        target,
       } = resizing;
       const rect = ref.current!.getBoundingClientRect();
       const x = ev.clientX - rect.left;
@@ -362,40 +372,47 @@ function DroppableCanvas({
       const dx = x - startX;
       const dy = y - startY;
 
-      setBoxes((bs) =>
-        bs.map((b) => {
-          if (b.id !== resizing.id) return b;
+      let left = startLeft;
+      let top = startTop;
+      let width = startWidth;
+      let height = startHeight;
 
-          let left = startLeft;
-          let top = startTop;
-          let width = startWidth;
-          let height = startHeight;
+      switch (corner) {
+        case "se":
+          width = Math.max(20, startWidth + dx);
+          height = Math.max(20, startHeight + dy);
+          break;
+        case "sw":
+          width = Math.max(20, startWidth - dx);
+          height = Math.max(20, startHeight + dy);
+          left = startLeft + dx;
+          break;
+        case "ne":
+          width = Math.max(20, startWidth + dx);
+          height = Math.max(20, startHeight - dy);
+          top = startTop + dy;
+          break;
+        case "nw":
+          width = Math.max(20, startWidth - dx);
+          height = Math.max(20, startHeight - dy);
+          left = startLeft + dx;
+          top = startTop + dy;
+          break;
+      }
 
-          switch (corner) {
-            case "se":
-              width = Math.max(20, startWidth + dx);
-              height = Math.max(20, startHeight + dy);
-              break;
-            case "sw":
-              width = Math.max(20, startWidth - dx);
-              height = Math.max(20, startHeight + dy);
-              left = startLeft + dx;
-              break;
-            case "ne":
-              width = Math.max(20, startWidth + dx);
-              height = Math.max(20, startHeight - dy);
-              top = startTop + dy;
-              break;
-            case "nw":
-              width = Math.max(20, startWidth - dx);
-              height = Math.max(20, startHeight - dy);
-              left = startLeft + dx;
-              top = startTop + dy;
-              break;
-          }
-          return { ...b, x: left, y: top, width, height };
-        })
-      );
+      if (target.kind === "text") {
+        setBoxes((bs) =>
+          bs.map((b) =>
+            b.id === target.id ? { ...b, x: left, y: top, width, height } : b
+          )
+        );
+      } else {
+        setElements((es) =>
+          es.map((el) =>
+            el.id === target.id ? { ...el, x: left, y: top, width, height } : el
+          )
+        );
+      }
     }
 
     function onUp() {
@@ -410,7 +427,7 @@ function DroppableCanvas({
         window.removeEventListener("pointerup", onUp);
       };
     }
-  }, [resizing, setBoxes]);
+  }, [resizing, setBoxes, setElements]);
 
   useEffect(() => {
     function onMove(ev: PointerEvent) {
@@ -487,7 +504,9 @@ function DroppableCanvas({
           {(["nw", "ne", "sw", "se"] as Corner[]).map((corner) => (
             <div
               key={corner}
-              onPointerDown={(e) => handlePointerDown(e, box, corner)}
+              onPointerDown={(e) =>
+                handleResizeStart(e, { id: box.id, kind: "text" }, corner)
+              }
               className={`resize-handle handle-${corner}`}
             />
           ))}
@@ -674,8 +693,8 @@ export default function PortfolioBuilder() {
       y: e.y ?? 0,
       natW: e.natW,
       natH: e.natH,
-      width: e.width ?? (e.type === "image" ? 300 : 200),
-      height: e.height ?? (e.type === "image" ? 300 : 32),
+      width: e.width,
+      height: e.height,
       content: e.content,
       src: e.src,
       href: e.href,
@@ -974,36 +993,47 @@ export default function PortfolioBuilder() {
                     </div>
                   )}
                   {el.type === "image" && (
-                    <div className="p-1 border-[1px] border-transparent ">
-                      {el.src ? (
-                        <Image
-                          src={el.src}
-                          alt="uploaded"
-                          width={el.width}
-                          height={el.height}
-                          className="object-cover portfolio-img-frame max-h-[400px]"
-                          crossOrigin="anonymous"
-                          onLoad={(e) =>
-                            recordNaturalSize(
-                              el.id,
-                              (e.target as HTMLImageElement).naturalWidth,
-                              (e.target as HTMLImageElement).naturalHeight
-                            )
-                          }
-                        />
-                      ) : (
-                        <input
-                          type="file"
-                          accept="image/*"
-                          className=" w-full p-1"
-                          onPointerDown={(e) => e.stopPropagation()}
-                          onChange={(e) => {
-                            const file = e.target.files?.[0];
-                            if (file) handleImageSelect(el.id, file);
-                          }}
-                        />
-                      )}
-                           <button
+                    <div className="p-1 border-[1px] border-transparent">
+                      <div className="relative inline-block">
+                        {el.src ? (
+                          <Image
+                            src={el.src}
+                            alt="uploaded"
+                            width={el.width}
+                            height={el.height}
+                            className="object-cover portfolio-img-frame max-h-[400px]"
+                            crossOrigin="anonymous"
+                            onLoad={(e) =>
+                              recordNaturalSize(
+                                el.id,
+                                (e.target as HTMLImageElement).naturalWidth,
+                                (e.target as HTMLImageElement).naturalHeight
+                              )
+                            }
+                          />
+                        ) : (
+                          <input
+                            type="file"
+                            accept="image/*"
+                            className="w-full h-full p-1"
+                            onPointerDown={(e) => e.stopPropagation()}
+                            onChange={(e) => {
+                              const file = e.target.files?.[0];
+                              if (file) handleImageSelect(el.id, file);
+                            }}
+                          />
+                        )}
+                        {(["nw", "ne", "sw", "se"] as Corner[]).map((corner) => (
+                          <div
+                            key={corner}
+                            onPointerDown={(e) =>
+                              handleResizeStart(e, { id: el.id, kind: "image" }, corner)
+                            }
+                            className={`resize-handle handle-${corner}`}
+                          />
+                        ))}
+                      </div>
+                      <button
                       className="rounded-md mt-5 lockbutton"
                       onPointerDown={(e) => e.stopPropagation()}   /* ⬅︎ PREVENT DRAG  */
                       onClick={(e) => {                            /* ⬅︎ ACTUAL DELETE */
@@ -1071,33 +1101,45 @@ export default function PortfolioBuilder() {
                   )}
                   {el.type === "image" && (
                     <div>
-                      {el.src ? (
-                        <Image
-                          src={el.src}
-                          alt="uploaded"
-                          width={el.width}
-                          height={el.height}
-                          className="object-cover portfolio-img-frame"
-                          crossOrigin="anonymous"
-                          onLoad={(e) =>
-                            recordNaturalSize(
-                              el.id,
-                              (e.target as HTMLImageElement).naturalWidth,
-                              (e.target as HTMLImageElement).naturalHeight
-                            )
-                          }
-                        />
-                      ) : (
-                        <input
-                          type="file"
-                          accept="image/*"
-                          onPointerDown={(e) => e.stopPropagation()}
-                          onChange={(e) => {
-                            const file = e.target.files?.[0];
-                            if (file) handleImageSelect(el.id, file);
-                          }}
-                        />
-                      )}
+                      <div className="relative inline-block">
+                        {el.src ? (
+                          <Image
+                            src={el.src}
+                            alt="uploaded"
+                            width={el.width}
+                            height={el.height}
+                            className="object-cover portfolio-img-frame"
+                            crossOrigin="anonymous"
+                            onLoad={(e) =>
+                              recordNaturalSize(
+                                el.id,
+                                (e.target as HTMLImageElement).naturalWidth,
+                                (e.target as HTMLImageElement).naturalHeight
+                              )
+                            }
+                          />
+                        ) : (
+                          <input
+                            type="file"
+                            accept="image/*"
+                            className="w-full h-full"
+                            onPointerDown={(e) => e.stopPropagation()}
+                            onChange={(e) => {
+                              const file = e.target.files?.[0];
+                              if (file) handleImageSelect(el.id, file);
+                            }}
+                          />
+                        )}
+                        {(["nw", "ne", "sw", "se"] as Corner[]).map((corner) => (
+                          <div
+                            key={corner}
+                            onPointerDown={(e) =>
+                              handleResizeStart(e, { id: el.id, kind: "image" }, corner)
+                            }
+                            className={`resize-handle handle-${corner}`}
+                          />
+                        ))}
+                      </div>
                     </div>
                   )}
                   {el.type === "box" && (


### PR DESCRIPTION
## Summary
- unify resize logic for text boxes and images
- expose resize handles for image elements
- use shared state to update appropriate element array
- tweak handle CSS styling

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68802f611d0c83299298dc8db4e7ae9a