### PR TITLE
Add prediction market post type

### DIFF
--- a/app/(root)/(standard)/lounges/[id]/page.tsx
+++ b/app/(root)/(standard)/lounges/[id]/page.tsx
@@ -58,6 +58,7 @@ export default async function Page({ params }: { params: { id: string } }) {
             "PORTFOLIO",
           "PLUGIN",
           "PRODUCT_REVIEW",
+          "PREDICTION",
           "ROOM_CANVAS",
         ]}
         currentUserId={user?.userId}

--- a/app/(root)/(standard)/page.tsx
+++ b/app/(root)/(standard)/page.tsx
@@ -60,6 +60,7 @@ export default async function Home() {
             "PORTFOLIO",
             "PLUGIN",
             "PRODUCT_REVIEW",
+            "PREDICTION",
             "ROOM_CANVAS",
           ]}
           currentUserId={user.userId}

--- a/app/api/market/[id]/trade/route.ts
+++ b/app/api/market/[id]/trade/route.ts
@@ -1,0 +1,12 @@
+import { NextRequest, NextResponse } from "next/server";
+import { tradeMarket } from "@/lib/actions/prediction.actions";
+
+export async function POST(req: NextRequest, { params }: { params: { id: string } }) {
+  const body = await req.json();
+  const result = await tradeMarket({
+    marketId: params.id,
+    side: body.side,
+    credits: body.credits,
+  });
+  return NextResponse.json(result);
+}

--- a/app/api/market/route.ts
+++ b/app/api/market/route.ts
@@ -1,0 +1,12 @@
+import { NextRequest, NextResponse } from "next/server";
+import { createMarket } from "@/lib/actions/prediction.actions";
+
+export async function POST(req: NextRequest) {
+  const body = await req.json();
+  const result = await createMarket({
+    question: body.question,
+    closesAt: body.closesAt,
+    liquidity: body.liquidity ?? 100,
+  });
+  return NextResponse.json(result);
+}

--- a/app/api/realtime-posts/route.ts
+++ b/app/api/realtime-posts/route.ts
@@ -24,6 +24,7 @@ export async function GET(req: NextRequest) {
         "PORTFOLIO",
         "PLUGIN",
         "PRODUCT_REVIEW",
+        "PREDICTION",
       ];
 
   const data = await fetchRealtimePosts({

--- a/components/cards/PostCard.tsx
+++ b/components/cards/PostCard.tsx
@@ -16,6 +16,7 @@ import GalleryCarousel from "./GalleryCarousel";
 import SoundCloudPlayer from "../players/SoundCloudPlayer";
 import Spline from "@splinetool/react-spline";
 import dynamic from "next/dynamic";
+import PredictionMarketCard from "./PredictionMarketCard";
 import { PortfolioPayload } from "@/lib/actions/realtimepost.actions";
 //import EmbeddedCanvas from "./EmbeddedCanvas";
 import type { Like, RealtimeLike } from "@prisma/client";
@@ -317,6 +318,9 @@ const PostCard = ({
                   )
                 );
               })()}
+            {type === "PREDICTION" && (
+              <PredictionMarketCard post={{ predictionMarket: JSON.parse(content || "{}") }} />
+            )}
             {type === "PLUGIN" && pluginType === "PDF_VIEWER" && pluginData && (
               <div className="mt-2 mb-2 flex img-feed-frame w-[100%] ml-[23%]  justify-center items-center">
                 <object

--- a/components/cards/PredictionMarketCard.tsx
+++ b/components/cards/PredictionMarketCard.tsx
@@ -1,0 +1,33 @@
+"use client";
+import { useState } from "react";
+import { priceYes } from "@/lib/prediction/lmsr";
+
+interface Props {
+  post: any;
+}
+
+export default function PredictionMarketCard({ post }: Props) {
+  const [price, setPrice] = useState(post.predictionMarket ? priceYes(post.predictionMarket.yesPool, post.predictionMarket.noPool, post.predictionMarket.b) : 0.5);
+
+  return (
+    <div className="border rounded-lg p-4 space-y-3">
+      <h3 className="font-semibold">{post.predictionMarket?.question}</h3>
+      <div className="h-3 rounded bg-gray-200 relative overflow-hidden">
+        <div
+          className="bg-green-500 absolute inset-y-0 left-0"
+          style={{ width: `${price * 100}%` }}
+        />
+      </div>
+      <div className="text-xs text-gray-600">{Math.round(price * 100)} % YES</div>
+      <button
+        className="btn-primary w-full"
+        disabled={post.predictionMarket?.state !== "OPEN"}
+      >
+        {post.predictionMarket?.state === "OPEN" ? "Trade" : "Closed"}
+      </button>
+      {post.predictionMarket?.state === "RESOLVED" && (
+        <div className="text-sm font-medium">Outcome: {post.predictionMarket.outcome}</div>
+      )}
+    </div>
+  );
+}

--- a/components/forms/CreateFeedPost.tsx
+++ b/components/forms/CreateFeedPost.tsx
@@ -27,6 +27,7 @@ import ProductReviewNodeModal from "../modals/ProductReviewNodeModal";
 import MusicNodeModal from "../modals/MusicNodeModal";
 import SplineViewerNodeModal from "../modals/SplineViewerNodeModal";
 import RoomCanvasModal from "../modals/RoomCanvasModal";
+import PredictionMarketModal from "../modals/PredictionMarketModal";
 import { exportRoomCanvas } from "@/lib/actions/realtimeroom.actions";
 import {
   uploadFileToSupabase,
@@ -68,6 +69,7 @@ const nodeOptions: { label: string; nodeType: string }[] = [
   { label: "PDF", nodeType: "PDF_VIEWER" },
   { label: "SPLINE", nodeType: "SPLINE_VIEWER" },
   { label: "PRODUCT_REVIEW", nodeType: "PRODUCT_REVIEW" },
+  { label: "PREDICTION", nodeType: "PREDICTION" },
   { label: "ROOM_CANVAS", nodeType: "ROOM_CANVAS" },
 ];
 
@@ -448,6 +450,24 @@ const CreateFeedPost = ({ roomId = "global" }: Props) => {
                 type: "PRODUCT_REVIEW",
                 realtimeRoomId: roomId,
                 ...(urls.length > 0 && { imageUrl: urls[0] }),
+              });
+              reset();
+              router.refresh();
+            }}
+          />
+        );
+
+      case "PREDICTION":
+        return (
+          <PredictionMarketModal
+            onSubmit={async (vals) => {
+              await fetch("/api/market", {
+                method: "POST",
+                body: JSON.stringify({
+                  question: vals.question,
+                  closesAt: vals.closesAt,
+                  liquidity: vals.liquidity,
+                }),
               });
               reset();
               router.refresh();

--- a/components/forms/CreatePredictionPost.tsx
+++ b/components/forms/CreatePredictionPost.tsx
@@ -1,0 +1,65 @@
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useForm } from "react-hook-form";
+import { z } from "zod";
+import { Button } from "../ui/button";
+import { Input } from "../ui/input";
+import { Form, FormField, FormItem, FormControl, FormMessage } from "../ui/form";
+import { PredictionPostValidation } from "@/lib/validations/thread";
+
+interface Props {
+  onSubmit: (values: z.infer<typeof PredictionPostValidation>) => void;
+}
+
+export default function CreatePredictionPost({ onSubmit }: Props) {
+  const form = useForm({
+    resolver: zodResolver(PredictionPostValidation),
+    defaultValues: {
+      question: "",
+      closesAt: "",
+      liquidity: 100,
+    },
+  });
+  return (
+    <Form {...form}>
+      <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
+        <FormField
+          control={form.control}
+          name="question"
+          render={({ field }) => (
+            <FormItem>
+              <FormControl>
+                <Input placeholder="Market question" {...field} />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+        <FormField
+          control={form.control}
+          name="closesAt"
+          render={({ field }) => (
+            <FormItem>
+              <FormControl>
+                <Input type="datetime-local" {...field} />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+        <FormField
+          control={form.control}
+          name="liquidity"
+          render={({ field }) => (
+            <FormItem>
+              <FormControl>
+                <Input type="number" min={50} {...field} />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+        <Button type="submit">Create</Button>
+      </form>
+    </Form>
+  );
+}

--- a/components/modals/PredictionMarketModal.tsx
+++ b/components/modals/PredictionMarketModal.tsx
@@ -1,0 +1,19 @@
+import CreatePredictionPost from "../forms/CreatePredictionPost";
+import { DialogContent, DialogHeader } from "@/components/ui/dialog";
+import { z } from "zod";
+import { PredictionPostValidation } from "@/lib/validations/thread";
+
+interface Props {
+  onSubmit: (values: z.infer<typeof PredictionPostValidation>) => void;
+}
+
+export default function PredictionMarketModal({ onSubmit }: Props) {
+  return (
+    <DialogContent className="p-4">
+      <DialogHeader className="dialog-header text-lg mb-4">
+        Create Prediction Market
+      </DialogHeader>
+      <CreatePredictionPost onSubmit={onSubmit} />
+    </DialogContent>
+  );
+}

--- a/lib/actions/prediction.actions.ts
+++ b/lib/actions/prediction.actions.ts
@@ -1,0 +1,61 @@
+"use server";
+import { prisma } from "../prismaclient";
+import { costToBuy } from "@/lib/prediction/lmsr";
+import { getUserFromCookies } from "@/lib/serverutils";
+import { Prisma } from "@prisma/client";
+
+export async function createMarket({ question, closesAt, liquidity }:{ question:string; closesAt:string; liquidity:number; }) {
+  const user = await getUserFromCookies();
+  if (!user) throw new Error("Not authenticated");
+
+  const post = await prisma.realtimePost.create({
+    data: {
+      author_id: user.userId!,
+      x_coordinate: new Prisma.Decimal(0),
+      y_coordinate: new Prisma.Decimal(0),
+      type: "PREDICTION",
+      realtime_room_id: "global",
+      locked: false,
+    },
+  });
+
+  const market = await prisma.predictionMarket.create({
+    data: {
+      postId: post.id,
+      question,
+      closesAt: new Date(closesAt),
+      b: liquidity,
+      creatorId: user.userId!,
+    },
+  });
+
+  await prisma.realtimePost.update({
+    where: { id: post.id },
+    data: { predictionMarket: { connect: { id: market.id } }, content: JSON.stringify(market) },
+  });
+
+  return { postId: post.id };
+}
+
+export async function tradeMarket({ marketId, side, credits }:{ marketId:string; side:"YES"|"NO"; credits:number; }) {
+  const user = await getUserFromCookies();
+  if (!user) throw new Error("Not authenticated");
+  const market = await prisma.predictionMarket.findUniqueOrThrow({ where:{ id: marketId } });
+  if (market.state !== "OPEN") throw new Error("Market closed");
+  let lo=0, hi=1000;
+  for(let i=0;i<30;i++){
+    const mid=(lo+hi)/2;
+    const cost=costToBuy(side, mid, market.yesPool, market.noPool, market.b);
+    cost>credits?hi=mid:lo=mid;
+  }
+  const shares=lo;
+  const cost=Math.ceil(costToBuy(side, shares, market.yesPool, market.noPool, market.b));
+  await prisma.$transaction(async tx => {
+    await tx.trade.create({ data:{ marketId, userId:user.userId!, side, shares, cost, price: cost/shares } });
+    await tx.predictionMarket.update({
+      where:{ id: marketId },
+      data: side === "YES" ? { yesPool: { increment: shares } } : { noPool:{ increment: shares } }
+    });
+  });
+  return { shares, cost };
+}

--- a/lib/models/migrations/20251001000000_add_prediction_market.sql
+++ b/lib/models/migrations/20251001000000_add_prediction_market.sql
@@ -1,0 +1,33 @@
+ALTER TYPE "realtime_post_type" ADD VALUE IF NOT EXISTS 'PREDICTION';
+
+CREATE TABLE IF NOT EXISTS "prediction_markets" (
+  "id" TEXT PRIMARY KEY DEFAULT uuid_generate_v4(),
+  "postId" BIGINT UNIQUE NOT NULL,
+  "question" VARCHAR(140) NOT NULL,
+  "closesAt" TIMESTAMPTZ NOT NULL,
+  "resolvesAt" TIMESTAMPTZ,
+  "state" TEXT NOT NULL DEFAULT 'OPEN',
+  "outcome" TEXT,
+  "b" DOUBLE PRECISION NOT NULL,
+  "yesPool" DOUBLE PRECISION NOT NULL DEFAULT 0,
+  "noPool" DOUBLE PRECISION NOT NULL DEFAULT 0,
+  "creatorId" BIGINT NOT NULL,
+  "oracleId" BIGINT,
+  CONSTRAINT "prediction_markets_postId_fkey" FOREIGN KEY ("postId") REFERENCES "realtime_posts"("id") ON DELETE CASCADE,
+  CONSTRAINT "prediction_markets_creatorId_fkey" FOREIGN KEY ("creatorId") REFERENCES "users"("id") ON DELETE CASCADE,
+  CONSTRAINT "prediction_markets_oracleId_fkey" FOREIGN KEY ("oracleId") REFERENCES "users"("id") ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS "prediction_trades" (
+  "id" TEXT PRIMARY KEY DEFAULT uuid_generate_v4(),
+  "marketId" TEXT NOT NULL REFERENCES "prediction_markets"("id") ON DELETE CASCADE,
+  "userId" BIGINT NOT NULL REFERENCES "users"("id") ON DELETE CASCADE,
+  "side" TEXT NOT NULL,
+  "shares" DOUBLE PRECISION NOT NULL,
+  "price" DOUBLE PRECISION NOT NULL,
+  "cost" INT NOT NULL,
+  "createdAt" TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+ALTER TABLE "realtime_posts" ADD COLUMN IF NOT EXISTS "predictionMarketId" TEXT;
+ALTER TABLE "realtime_posts" ADD CONSTRAINT "realtime_posts_predictionMarketId_fkey" FOREIGN KEY ("predictionMarketId") REFERENCES "prediction_markets"("id");

--- a/lib/models/schema.prisma
+++ b/lib/models/schema.prisma
@@ -164,6 +164,7 @@ model RealtimePost {
   pluginType         String?
   room_post_content  Json?
   productReview      ProductReview?
+  predictionMarket   PredictionMarket?
   outgoing_edges     RealtimeEdge[]     @relation("RealtimeEdgeToSourceRealtimePost")
   incoming_edges     RealtimeEdge[]     @relation("RealtimeEdgeToTargetRealtimePost")
   likes              RealtimeLike[]
@@ -593,6 +594,57 @@ model UserSimilarityKnn {
   @@map("user_similarity_knn")
 }
 
+model PredictionMarket {
+  id         String   @id @default(cuid())
+  postId     BigInt   @unique
+  question   String   @db.VarChar(140)
+  closesAt   DateTime
+  resolvesAt DateTime?
+  state      PredictionState @default(OPEN)
+  outcome    MarketOutcome?
+  b          Float
+  yesPool    Float     @default(0)
+  noPool     Float     @default(0)
+  creatorId  BigInt
+  oracleId   BigInt?
+
+  trades     Trade[]
+  post       RealtimePost @relation(fields: [postId], references: [id])
+  creator    User        @relation(fields: [creatorId], references: [id])
+  oracle     User?       @relation(fields: [oracleId], references: [id])
+
+  @@map("prediction_markets")
+}
+
+model Trade {
+  id        String   @id @default(cuid())
+  marketId  String
+  userId    BigInt
+  side      MarketOutcome
+  shares    Float
+  price     Float
+  cost      Int
+  createdAt DateTime @default(now()) @db.Timestamptz(6)
+
+  market PredictionMarket @relation(fields: [marketId], references: [id])
+  user   User             @relation(fields: [userId], references: [id])
+
+  @@index([marketId])
+  @@index([userId])
+  @@map("prediction_trades")
+}
+
+enum PredictionState {
+  OPEN
+  CLOSED
+  RESOLVED
+}
+
+enum MarketOutcome {
+  YES
+  NO
+}
+
 enum like_type {
   LIKE
   DISLIKE
@@ -615,6 +667,7 @@ enum realtime_post_type {
   CODE
   PORTFOLIO
   LLM_INSTRUCTION
+  PREDICTION
   PLUGIN
   PRODUCT_REVIEW
   ENTROPY

--- a/lib/prediction/lmsr.ts
+++ b/lib/prediction/lmsr.ts
@@ -1,0 +1,19 @@
+export function priceYes(qYes: number, qNo: number, b: number) {
+  const expYes = Math.exp(qYes / b);
+  const expNo = Math.exp(qNo / b);
+  return expYes / (expYes + expNo);
+}
+
+export function costToBuy(
+  side: "YES" | "NO",
+  delta: number,
+  qYes: number,
+  qNo: number,
+  b: number,
+) {
+  const C = (qY: number, qN: number) =>
+    b * Math.log(Math.exp(qY / b) + Math.exp(qN / b));
+  const costBefore = C(qYes, qNo);
+  const costAfter = side === "YES" ? C(qYes + delta, qNo) : C(qYes, qNo + delta);
+  return costAfter - costBefore;
+}

--- a/lib/reactflow/types.ts
+++ b/lib/reactflow/types.ts
@@ -13,6 +13,7 @@ import CollageCreationModal from "@/components/modals/CollageCreationModal";
 import GalleryNodeModal from "@/components/modals/GalleryNodeModal";
 import PortfolioNodeModal from "@/components/modals/PortfolioNodeModal";
 import ProductReviewNodeModal from "@/components/modals/ProductReviewNodeModal";
+import PredictionMarketModal from "@/components/modals/PredictionMarketModal";
 import ShareRoomModal from "@/components/modals/ShareRoomModal";
 import MusicNodeModal from "@/components/modals/MusicNodeModal";
 import { PluginDescriptor } from "../pluginLoader";
@@ -252,6 +253,7 @@ export const NodeTypeMap = {
   LLM_INSTRUCTION: {} as LLMInstructionNode,
   PRODUCT_REVIEW: {} as ProductReviewNodeData,
   ROOM_CANVAS: {} as RoomCanvasNodeData,
+  PREDICTION: {} as TextNode,
   PLUGIN: {} as PluginDescriptor,
 };
 
@@ -270,6 +272,7 @@ export const NodeTypeToModalMap = {
   GALLERY: GalleryNodeModal,
   PORTFOLIO: PortfolioNodeModal,
   PRODUCT_REVIEW: ProductReviewNodeModal,
+  PREDICTION: PredictionMarketModal,
   PORTAL: ShareRoomModal,
   LIVECHAT: ShareRoomModal,
   ENTROPY: ShareRoomModal,
@@ -296,6 +299,7 @@ export type AppNode =
   | PortfolioNodeData
   | LLMInstructionNode
   | ProductReviewNodeData
+  | TextNode /* Prediction uses TextNode shape */
   | RoomCanvasNodeData
   | PluginDescriptor;
 
@@ -324,6 +328,7 @@ export const DEFAULT_NODE_VALUES: Record<AppNodeType, string> = {
   ["PORTFOLIO"]: "",
   ["LLM_INSTRUCTION"]: "",
   ["PRODUCT_REVIEW"]: "",
+  ["PREDICTION"]: "",
   ["ROOM_CANVAS"]: "",
   ["PLUGIN"]: "",
 };

--- a/lib/validations/thread.ts
+++ b/lib/validations/thread.ts
@@ -182,6 +182,12 @@ export const MusicPostValidation = z.object({
   title: z.string().min(1),
 });
 
+export const PredictionPostValidation = z.object({
+  question: z.string().min(1).max(140),
+  closesAt: z.string(),
+  liquidity: z.number().min(50),
+});
+
 export const RoomCanvasPostValidation = z.object({
   roomId: z.string().min(1),
   description: z.string().optional(),


### PR DESCRIPTION
## Summary
- implement LMSR functions and prediction market actions
- create prediction market Prisma models and migration
- add prediction market card and creation form
- extend feed creation flow and React Flow node types
- expose API routes for creating and trading markets

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68828a7f92a483298f5c07731d47ed49