### PR TITLE
Decouple feed posts from canvas nodes

### DIFF
--- a/app/(root)/(standard)/page.tsx
+++ b/app/(root)/(standard)/page.tsx
@@ -1,6 +1,6 @@
 import Modal from "@/components/modals/Modal";
 import RealtimeFeed from "@/components/shared/RealtimeFeed";
-import { fetchRealtimePosts } from "@/lib/actions/realtimepost.actions";
+import { fetchFeedPosts } from "@/lib/actions/feed.actions";
 import { getUserFromCookies } from "@/lib/serverutils";
 import { redirect } from "next/navigation";
 
@@ -13,56 +13,21 @@ export const metadata = {
 export const dynamic = "force-dynamic";
 
 export default async function Home() {
-  const result = await fetchRealtimePosts({
-    realtimeRoomId: "global",
-    postTypes: [
-      "TEXT",
-      "VIDEO",
-      "IMAGE",
-      "IMAGE_COMPUTE",
-      "GALLERY",
-      "DRAW",
-      "LIVECHAT",
-      "MUSIC",
-      "ENTROPY",
-      "PORTFOLIO",
-
-      "PLUGIN",
-      "PRODUCT_REVIEW",
-      "ROOM_CANVAS",
-
-
-    ],
-  });
+  const posts = await fetchFeedPosts();
   const user = await getUserFromCookies();
   if (!user) redirect("/login");
 
   return (
     <div>
       <Modal />
-      {result.posts.length === 0 ? (
+      {posts.length === 0 ? (
         <p className="no-result">Nothing found</p>
       ) : (
         <RealtimeFeed
-          initialPosts={result.posts}
-          initialIsNext={result.isNext}
+          initialPosts={posts}
+          initialIsNext={false}
           roomId="global"
-          postTypes={[
-            "TEXT",
-            "VIDEO",
-            "IMAGE",
-            "IMAGE_COMPUTE",
-            "GALLERY",
-            "DRAW",
-            "LIVECHAT",
-            "MUSIC",
-            "ENTROPY",
-            "PORTFOLIO",
-            "PLUGIN",
-            "PRODUCT_REVIEW",
-            "PREDICTION",
-            "ROOM_CANVAS",
-          ]}
+          postTypes={[]}
           currentUserId={user.userId}
         />
       )}

--- a/app/api/feed/route.ts
+++ b/app/api/feed/route.ts
@@ -1,0 +1,12 @@
+import { NextResponse } from "next/server";
+import { prisma } from "@/lib/prismaclient";
+import { serializeBigInt } from "@/lib/utils";
+
+export async function GET() {
+  const posts = await prisma.feedPost.findMany({
+    where: { isPublic: true },
+    orderBy: { created_at: "desc" },
+    include: { predictionMarket: true },
+  });
+  return NextResponse.json(serializeBigInt(posts));
+}

--- a/lib/actions/feed.actions.ts
+++ b/lib/actions/feed.actions.ts
@@ -1,0 +1,39 @@
+import { prisma } from "../prismaclient";
+import { getUserFromCookies } from "@/lib/serverutils";
+
+export interface CreateFeedPostArgs {
+  type: "TEXT" | "IMAGE" | "VIDEO" | "GALLERY" | "PREDICTION" | "PRODUCT_REVIEW";
+  content?: string;
+  imageUrl?: string;
+  videoUrl?: string;
+  isPublic?: boolean;
+}
+
+export async function createFeedPost(args: CreateFeedPostArgs): Promise<{ postId: bigint }> {
+  const user = await getUserFromCookies();
+  if (!user) throw new Error("Not authenticated");
+
+  const { type, isPublic = true, ...rest } = args;
+
+  const post = await prisma.feedPost.create({
+    data: {
+      author_id: user.userId!,
+      type,
+      isPublic,
+      ...(rest.content && { content: rest.content }),
+      ...(rest.imageUrl && { image_url: rest.imageUrl }),
+      ...(rest.videoUrl && { video_url: rest.videoUrl }),
+    },
+  });
+
+  return { postId: post.id };
+}
+
+export async function fetchFeedPosts() {
+  const posts = await prisma.feedPost.findMany({
+    where: { isPublic: true },
+    orderBy: { created_at: "desc" },
+    include: { predictionMarket: true, author: true },
+  });
+  return posts.map((p) => ({ ...p }));
+}

--- a/lib/models/schema.prisma
+++ b/lib/models/schema.prisma
@@ -44,14 +44,15 @@ model User {
   realtimeedges            RealtimeEdge[]
   realtimeLikes            RealtimeLike[]
   realtimeposts            RealtimePost[]
+  feedPosts                FeedPost[]
   realtimeRoomInviteTokens RealtimeRoomInviteToken[]
   recommendationClicks     RecommendationClick[]
   attributeEdits           UserAttributeEdit[]
   userAttributes           UserAttributes?
   userEmbedding            UserEmbedding?
-  createdPredictionMarkets PredictionMarket[] @relation("CreatedPredictionMarkets")
-  oraclePredictionMarkets  PredictionMarket[] @relation("OraclePredictionMarkets")
-  trades                   Trade[]             @relation("UserTrades")
+  createdPredictionMarkets PredictionMarket[]        @relation("CreatedPredictionMarkets")
+  oraclePredictionMarkets  PredictionMarket[]        @relation("OraclePredictionMarkets")
+  trades                   Trade[]                   @relation("UserTrades")
   realtimerooms            UserRealtimeRoom[]
   workflows                Workflow[]
 
@@ -115,6 +116,34 @@ model Like {
   @@map("likes")
 }
 
+model FeedPost {
+  id         BigInt         @id @default(autoincrement())
+  created_at DateTime       @default(now()) @db.Timestamptz(6)
+  updated_at DateTime?      @default(now()) @updatedAt @db.Timestamptz(6)
+  author_id  BigInt
+  type       feed_post_type
+  content    String?
+  image_url  String?
+  video_url  String?
+  isPublic   Boolean        @default(true)
+  like_count Int            @default(0)
+
+  author           User              @relation(fields: [author_id], references: [id])
+  predictionMarket PredictionMarket? @relation("FeedPostPrediction")
+
+  @@index([author_id])
+  @@map("feed_posts")
+}
+
+enum feed_post_type {
+  TEXT
+  IMAGE
+  VIDEO
+  GALLERY
+  PREDICTION
+  PRODUCT_REVIEW
+}
+
 model RealtimeLike {
   id               BigInt       @id @default(autoincrement())
   created_at       DateTime     @default(now()) @db.Timestamptz(6)
@@ -167,7 +196,7 @@ model RealtimePost {
   pluginType         String?
   room_post_content  Json?
   productReview      ProductReview?
-  predictionMarket   PredictionMarket?
+  predictionMarket   PredictionMarket?  @relation(fields: [predictionMarketId], references: [id])
   outgoing_edges     RealtimeEdge[]     @relation("RealtimeEdgeToSourceRealtimePost")
   incoming_edges     RealtimeEdge[]     @relation("RealtimeEdgeToTargetRealtimePost")
   likes              RealtimeLike[]
@@ -175,6 +204,7 @@ model RealtimePost {
   realtimePost       RealtimePost?      @relation("RealtimePostChildren", fields: [parent_id], references: [id], onDelete: Restrict)
   children           RealtimePost[]     @relation("RealtimePostChildren")
   realtimeroom       RealtimeRoom       @relation(fields: [realtime_room_id], references: [id])
+  predictionMarketId String?
 
   @@map("realtime_posts")
 }
@@ -554,7 +584,7 @@ model PortfolioPage {
   slug       String   @unique
   html       String
   css        String
-  tsx        String?       // NEW nullable column
+  tsx        String? // NEW nullable column
   created_at DateTime @default(now()) @db.Timestamptz(6)
 
   @@map("portfolio_pages")
@@ -598,36 +628,37 @@ model UserSimilarityKnn {
 }
 
 model PredictionMarket {
-  id         String   @id @default(cuid())
-  postId     BigInt   @unique
-  question   String   @db.VarChar(140)
+  id         String          @id @default(cuid())
+  postId     BigInt          @unique
+  question   String          @db.VarChar(140)
   closesAt   DateTime
   resolvesAt DateTime?
   state      PredictionState @default(OPEN)
   outcome    MarketOutcome?
   b          Float
-  yesPool    Float     @default(0)
-  noPool     Float     @default(0)
+  yesPool    Float           @default(0)
+  noPool     Float           @default(0)
   creatorId  BigInt
   oracleId   BigInt?
 
-  trades     Trade[]
-  post       RealtimePost @relation(fields: [postId], references: [id])
-  creator    User        @relation("CreatedPredictionMarkets", fields: [creatorId], references: [id])
-  oracle     User?       @relation("OraclePredictionMarkets", fields: [oracleId], references: [id])
+  trades       Trade[]
+  post         FeedPost       @relation("FeedPostPrediction", fields: [postId], references: [id])
+  creator      User           @relation("CreatedPredictionMarkets", fields: [creatorId], references: [id])
+  oracle       User?          @relation("OraclePredictionMarkets", fields: [oracleId], references: [id])
+  RealtimePost RealtimePost[]
 
   @@map("prediction_markets")
 }
 
 model Trade {
-  id        String   @id @default(cuid())
+  id        String        @id @default(cuid())
   marketId  String
   userId    BigInt
   side      MarketOutcome
   shares    Float
   price     Float
   cost      Int
-  createdAt DateTime @default(now()) @db.Timestamptz(6)
+  createdAt DateTime      @default(now()) @db.Timestamptz(6)
 
   market PredictionMarket @relation(fields: [marketId], references: [id])
   user   User             @relation("UserTrades", fields: [userId], references: [id])


### PR DESCRIPTION
## Summary
- add `FeedPost` model and `feed_post_type` enum
- adjust `PredictionMarket.post` to reference new model
- implement creation/fetch utilities for feed posts
- expose `/api/feed` endpoint
- update home feed to use new API
- update `RealtimeFeed` component for dual use

## Testing
- `npm run lint`
- `npx prisma migrate dev -n "decouple_feed_posts"` *(fails: Can't reach database server)*

------
https://chatgpt.com/codex/tasks/task_e_6882b61607c88329a23082d1ca61fa9b