### PR TITLE
Implement prediction market trade modal and resolve API

### DIFF
--- a/app/api/market/[id]/resolve/route.ts
+++ b/app/api/market/[id]/resolve/route.ts
@@ -1,0 +1,11 @@
+import { NextRequest, NextResponse } from "next/server";
+import { resolveMarket } from "@/lib/actions/prediction.actions";
+
+export async function POST(
+  req: NextRequest,
+  { params }: { params: { id: string } }
+) {
+  const body = await req.json();
+  const result = await resolveMarket({ marketId: params.id, outcome: body.outcome });
+  return NextResponse.json(result);
+}

--- a/app/api/market/[id]/route.ts
+++ b/app/api/market/[id]/route.ts
@@ -1,0 +1,15 @@
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@/lib/prismaclient";
+import { serializeBigInt } from "@/lib/utils";
+
+export async function GET(
+  req: NextRequest,
+  { params }: { params: { id: string } }
+) {
+  const market = await prisma.predictionMarket.findUnique({
+    where: { id: params.id },
+    include: { trades: true },
+  });
+  if (!market) return NextResponse.json({ message: "Not found" }, { status: 404 });
+  return NextResponse.json(serializeBigInt(market));
+}

--- a/components/cards/PredictionMarketCard.tsx
+++ b/components/cards/PredictionMarketCard.tsx
@@ -1,13 +1,23 @@
 "use client";
 import { useState } from "react";
 import { priceYes } from "@/lib/prediction/lmsr";
+import TradePredictionModal from "../modals/TradePredictionModal";
 
 interface Props {
   post: any;
 }
 
 export default function PredictionMarketCard({ post }: Props) {
-  const [price, setPrice] = useState(post.predictionMarket ? priceYes(post.predictionMarket.yesPool, post.predictionMarket.noPool, post.predictionMarket.b) : 0.5);
+  const [price, setPrice] = useState(
+    post.predictionMarket
+      ? priceYes(
+          post.predictionMarket.yesPool,
+          post.predictionMarket.noPool,
+          post.predictionMarket.b
+        )
+      : 0.5
+  );
+  const [showTrade, setShowTrade] = useState(false);
 
   return (
     <div className="border rounded-lg p-4 space-y-3">
@@ -22,9 +32,17 @@ export default function PredictionMarketCard({ post }: Props) {
       <button
         className="btn-primary w-full"
         disabled={post.predictionMarket?.state !== "OPEN"}
+        onClick={() => setShowTrade(true)}
       >
         {post.predictionMarket?.state === "OPEN" ? "Trade" : "Closed"}
       </button>
+      {showTrade && post.predictionMarket && (
+        <TradePredictionModal
+          market={post.predictionMarket}
+          onClose={() => setShowTrade(false)}
+          onTraded={(p) => setPrice(p)}
+        />
+      )}
       {post.predictionMarket?.state === "RESOLVED" && (
         <div className="text-sm font-medium">Outcome: {post.predictionMarket.outcome}</div>
       )}

--- a/components/modals/TradePredictionModal.tsx
+++ b/components/modals/TradePredictionModal.tsx
@@ -1,0 +1,91 @@
+import { useState, useMemo } from "react";
+import { costToBuy, priceYes } from "@/lib/prediction/lmsr";
+import { Button } from "../ui/button";
+import { Input } from "../ui/input";
+
+interface Market {
+  id: string;
+  yesPool: number;
+  noPool: number;
+  b: number;
+}
+
+interface Props {
+  market: Market;
+  onClose: () => void;
+  onTraded?: (newPrice: number) => void;
+}
+
+export default function TradePredictionModal({ market, onClose, onTraded }: Props) {
+  const [side, setSide] = useState<"YES" | "NO">("YES");
+  const [credits, setCredits] = useState(0);
+  const currentPrice = useMemo(
+    () => priceYes(market.yesPool, market.noPool, market.b),
+    [market]
+  );
+
+  const shares = useMemo(() => {
+    let lo = 0,
+      hi = 1000;
+    for (let i = 0; i < 30; i++) {
+      const mid = (lo + hi) / 2;
+      const cost = costToBuy(side, mid, market.yesPool, market.noPool, market.b);
+      cost > credits ? (hi = mid) : (lo = mid);
+    }
+    return lo;
+  }, [credits, side, market]);
+
+  const cost = Math.ceil(
+    costToBuy(side, shares, market.yesPool, market.noPool, market.b)
+  );
+
+  const priceAfter = useMemo(() => {
+    const yes = market.yesPool + (side === "YES" ? shares : 0);
+    const no = market.noPool + (side === "NO" ? shares : 0);
+    return priceYes(yes, no, market.b);
+  }, [shares, side, market]);
+
+  async function handleTrade() {
+    await fetch(`/api/market/${market.id}/trade`, {
+      method: "POST",
+      body: JSON.stringify({ side, credits: cost }),
+    });
+    onTraded?.(priceAfter);
+    onClose();
+  }
+
+  return (
+    <div className="p-4 space-y-4 bg-white rounded-lg shadow-md">
+      <div className="flex justify-between">
+        <Button
+          variant={side === "YES" ? "default" : "outline"}
+          onClick={() => setSide("YES")}
+        >
+          YES
+        </Button>
+        <Button
+          variant={side === "NO" ? "default" : "outline"}
+          onClick={() => setSide("NO")}
+        >
+          NO
+        </Button>
+      </div>
+      <Input
+        type="range"
+        min={0}
+        max={100}
+        value={credits}
+        onChange={(e) => setCredits(Number(e.target.value))}
+      />
+      <div className="text-sm text-gray-700">
+        Spend: {cost} credits for {shares.toFixed(2)} shares
+      </div>
+      <div className="text-sm text-gray-700">
+        New probability: {(priceAfter * 100).toFixed(2)}% YES
+      </div>
+      <Button className="w-full" onClick={handleTrade}>
+        Confirm Trade
+      </Button>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add TradePredictionModal component for trading markets
- integrate modal in PredictionMarketCard
- add resolveMarket action and API routes
- expose GET /api/market/[id]

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6882c2d52cac8329be3c8ff58ef056f8