### PR TITLE
Initialize SwapMeet module scaffolding

### DIFF
--- a/apps/swapmeet-web/README.md
+++ b/apps/swapmeet-web/README.md
@@ -1,0 +1,4 @@
+# SwapMeet Web
+
+This package contains the Next.js frontend for the Mesh Bazaar module.
+Currently it only includes placeholder files. See `SwapMeet_Implementation_Plan.md` for the milestone breakdown.

--- a/apps/swapmeet-web/app/page.tsx
+++ b/apps/swapmeet-web/app/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <div>SwapMeet coming soon</div>;
+}

--- a/apps/swapmeet-web/package.json
+++ b/apps/swapmeet-web/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "swapmeet-web",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start"
+  },
+  "dependencies": {
+    "next": "^14.2.30",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  }
+}

--- a/apps/swapmeet-web/tsconfig.json
+++ b/apps/swapmeet-web/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["../../*"]
+    }
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}

--- a/database/migrations/20250801_swapmeet_initial.sql
+++ b/database/migrations/20250801_swapmeet_initial.sql
@@ -1,0 +1,23 @@
+-- SwapMeet initial tables
+CREATE TABLE IF NOT EXISTS section (
+  id SERIAL PRIMARY KEY,
+  x INT NOT NULL,
+  y INT NOT NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS stall (
+  id SERIAL PRIMARY KEY,
+  section_id INT REFERENCES section(id),
+  owner_id BIGINT NOT NULL REFERENCES users(id),
+  name TEXT NOT NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS item (
+  id SERIAL PRIMARY KEY,
+  stall_id INT REFERENCES stall(id),
+  name TEXT NOT NULL,
+  price_cents INT NOT NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);

--- a/services/swapmeet-api/README.md
+++ b/services/swapmeet-api/README.md
@@ -1,0 +1,5 @@
+# SwapMeet API
+
+Backend service for SwapMeet features.
+
+This package will host tRPC routers and business logic as described in the SwapMeet SRS.

--- a/services/swapmeet-api/package.json
+++ b/services/swapmeet-api/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "swapmeet-api",
+  "private": true,
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "dependencies": {
+    "@prisma/client": "^6.10.1"
+  }
+}

--- a/services/swapmeet-api/src/index.ts
+++ b/services/swapmeet-api/src/index.ts
@@ -1,0 +1,3 @@
+export function hello() {
+  return "swapmeet-api";
+}


### PR DESCRIPTION
## Summary
- scaffold `apps/swapmeet-web` and `services/swapmeet-api`
- add initial migration for swapmeet tables

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6882f663d2ac83299f71b7f2e1a961b1