### PR TITLE
Expand SwapMeet scaffolding

### DIFF
--- a/apps/swapmeet-web/README.md
+++ b/apps/swapmeet-web/README.md
@@ -1,4 +1,6 @@
 # SwapMeet Web
 
 This package contains the Next.js frontend for the Mesh Bazaar module.
-Currently it only includes placeholder files. See `SwapMeet_Implementation_Plan.md` for the milestone breakdown.
+
+Initial scaffolding exposes a dynamic route at `/market/[x]/[y]` showing the selected section coordinates.
+See `SwapMeet_Implementation_Plan.md` for the milestone breakdown.

--- a/apps/swapmeet-web/app/market/[x]/[y]/page.tsx
+++ b/apps/swapmeet-web/app/market/[x]/[y]/page.tsx
@@ -1,0 +1,12 @@
+import { notFound } from "next/navigation";
+
+export default function SectionPage({ params }: { params: { x?: string; y?: string } }) {
+  const x = parseInt(params.x ?? "0", 10);
+  const y = parseInt(params.y ?? "0", 10);
+
+  if (Number.isNaN(x) || Number.isNaN(y)) {
+    notFound();
+  }
+
+  return <div>{`Section (${x}, ${y})`}</div>;
+}

--- a/database/migrations/20250802_swapmeet_offers_orders.sql
+++ b/database/migrations/20250802_swapmeet_offers_orders.sql
@@ -1,0 +1,44 @@
+-- Additional tables for SwapMeet
+CREATE TABLE IF NOT EXISTS offer (
+  id SERIAL PRIMARY KEY,
+  item_id INT REFERENCES item(id),
+  buyer_id BIGINT REFERENCES users(id),
+  price_cents INT NOT NULL,
+  status TEXT NOT NULL DEFAULT 'PENDING',
+  message TEXT,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS auction (
+  id SERIAL PRIMARY KEY,
+  item_id INT REFERENCES item(id),
+  stall_id INT REFERENCES stall(id),
+  reserve_cents INT NOT NULL,
+  ends_at TIMESTAMPTZ NOT NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS bid (
+  id SERIAL PRIMARY KEY,
+  auction_id INT REFERENCES auction(id),
+  bidder_id BIGINT REFERENCES users(id),
+  amount_cents INT NOT NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS "order" (
+  id SERIAL PRIMARY KEY,
+  stall_id INT REFERENCES stall(id),
+  buyer_id BIGINT REFERENCES users(id),
+  status TEXT NOT NULL DEFAULT 'PENDING',
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS order_line (
+  id SERIAL PRIMARY KEY,
+  order_id INT REFERENCES "order"(id),
+  item_id INT REFERENCES item(id),
+  quantity INT NOT NULL,
+  price_cents INT NOT NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);

--- a/lib/models/schema.prisma
+++ b/lib/models/schema.prisma
@@ -748,3 +748,118 @@ enum notification_type {
   FOLLOW
   MESSAGE
 }
+
+model Section {
+  id         BigInt   @id @default(autoincrement())
+  x          Int
+  y          Int
+  created_at DateTime @default(now()) @db.Timestamptz(6)
+  stalls     Stall[]
+
+  @@unique([x, y])
+  @@map("sections")
+}
+
+model Stall {
+  id         BigInt   @id @default(autoincrement())
+  section_id BigInt?
+  owner_id   BigInt
+  name       String
+  created_at DateTime @default(now()) @db.Timestamptz(6)
+  section    Section? @relation(fields: [section_id], references: [id])
+  owner      User     @relation(fields: [owner_id], references: [id])
+  items      Item[]
+  offers     Offer[]
+  auctions   Auction[]
+  orders     Order[]
+
+  @@index([section_id])
+  @@map("stalls")
+}
+
+model Item {
+  id         BigInt   @id @default(autoincrement())
+  stall_id   BigInt
+  name       String
+  price_cents Int
+  created_at DateTime @default(now()) @db.Timestamptz(6)
+  stall      Stall    @relation(fields: [stall_id], references: [id])
+  offers     Offer[]
+  auction    Auction?
+  orderLines OrderLine[]
+
+  @@index([stall_id])
+  @@map("items")
+}
+
+model Offer {
+  id         BigInt   @id @default(autoincrement())
+  item_id    BigInt
+  buyer_id   BigInt
+  price_cents Int
+  status     String   @default("PENDING")
+  message    String?
+  created_at DateTime @default(now()) @db.Timestamptz(6)
+  item       Item     @relation(fields: [item_id], references: [id])
+  buyer      User     @relation(fields: [buyer_id], references: [id])
+
+  @@index([item_id])
+  @@map("offers")
+}
+
+model Auction {
+  id         BigInt   @id @default(autoincrement())
+  item_id    BigInt
+  stall_id   BigInt
+  reserve_cents Int
+  ends_at    DateTime
+  created_at DateTime @default(now()) @db.Timestamptz(6)
+  item       Item     @relation(fields: [item_id], references: [id])
+  stall      Stall    @relation(fields: [stall_id], references: [id])
+  bids       Bid[]
+
+  @@index([stall_id])
+  @@map("auctions")
+}
+
+model Bid {
+  id         BigInt   @id @default(autoincrement())
+  auction_id BigInt
+  bidder_id  BigInt
+  amount_cents Int
+  created_at DateTime @default(now()) @db.Timestamptz(6)
+  auction    Auction  @relation(fields: [auction_id], references: [id])
+  bidder     User     @relation(fields: [bidder_id], references: [id])
+
+  @@index([auction_id])
+  @@map("bids")
+}
+
+model Order {
+  id         BigInt   @id @default(autoincrement())
+  stall_id   BigInt
+  buyer_id   BigInt
+  status     String   @default("PENDING")
+  created_at DateTime @default(now()) @db.Timestamptz(6)
+  stall      Stall    @relation(fields: [stall_id], references: [id])
+  buyer      User     @relation(fields: [buyer_id], references: [id])
+  lines      OrderLine[]
+
+  @@index([stall_id])
+  @@map("orders")
+}
+
+model OrderLine {
+  id         BigInt   @id @default(autoincrement())
+  order_id   BigInt
+  item_id    BigInt
+  quantity   Int
+  price_cents Int
+  created_at DateTime @default(now()) @db.Timestamptz(6)
+  order      Order    @relation(fields: [order_id], references: [id])
+  item       Item     @relation(fields: [item_id], references: [id])
+
+  @@index([order_id])
+  @@map("order_lines")
+}
+

--- a/services/swapmeet-api/README.md
+++ b/services/swapmeet-api/README.md
@@ -2,4 +2,5 @@
 
 Backend service for SwapMeet features.
 
-This package will host tRPC routers and business logic as described in the SwapMeet SRS.
+A placeholder `getSection` helper returns stall data for a given `(x, y)` coordinate.
+Future iterations will expose this via tRPC as detailed in the SRS.

--- a/services/swapmeet-api/src/index.ts
+++ b/services/swapmeet-api/src/index.ts
@@ -1,3 +1,5 @@
+export { getSection, type StallSummary } from "./section";
+
 export function hello() {
   return "swapmeet-api";
 }

--- a/services/swapmeet-api/src/section.ts
+++ b/services/swapmeet-api/src/section.ts
@@ -1,0 +1,10 @@
+export interface StallSummary {
+  id: number;
+  name: string;
+  live: boolean;
+}
+
+export async function getSection(x: number, y: number): Promise<{ stalls: StallSummary[] }> {
+  // TODO: replace with database query
+  return { stalls: [] };
+}


### PR DESCRIPTION
## Summary
- add dynamic market route in `swapmeet-web`
- create placeholder API helper `getSection`
- extend Prisma schema with SwapMeet models
- add SQL migration for offers, auctions, and orders
- update module READMEs

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6882fb394fbc8329a123eb0200545262