### PR TITLE
Fix Prisma schema relations

### DIFF
--- a/lib/models/schema.prisma
+++ b/lib/models/schema.prisma
@@ -57,6 +57,10 @@ model User {
   resolutionLogs           ResolutionLog[]
   realtimerooms            UserRealtimeRoom[]
   workflows                Workflow[]
+  stalls                   Stall[]
+  offers                   Offer[]
+  bids                     Bid[]
+  orders                   Order[]
 
   @@map("users")
 }
@@ -769,7 +773,6 @@ model Stall {
   section    Section? @relation(fields: [section_id], references: [id])
   owner      User     @relation(fields: [owner_id], references: [id])
   items      Item[]
-  offers     Offer[]
   auctions   Auction[]
   orders     Order[]
 
@@ -809,7 +812,7 @@ model Offer {
 
 model Auction {
   id         BigInt   @id @default(autoincrement())
-  item_id    BigInt
+  item_id    BigInt   @unique
   stall_id   BigInt
   reserve_cents Int
   ends_at    DateTime


### PR DESCRIPTION
## Summary
- add missing reverse relations on User for SwapMeet models
- remove unused Stall.offers field
- ensure each Item has at most one Auction

## Testing
- `yarn install --immutable` *(fails: lockfile would have been modified)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68830a482de88329b0747a7616be83bd