### PR TITLE
Implement SwapMeet section query

### DIFF
--- a/apps/swapmeet-web/README.md
+++ b/apps/swapmeet-web/README.md
@@ -2,5 +2,6 @@
 
 This package contains the Next.js frontend for the Mesh Bazaar module.
 
-Initial scaffolding exposes a dynamic route at `/market/[x]/[y]` showing the selected section coordinates.
+The `/market/[x]/[y]` route now loads stall data using the `swapmeet-api` package and lists stall names for the requested section. An API endpoint at `/api/section?x=&y=` also exposes this query for client requests.
+
 See `SwapMeet_Implementation_Plan.md` for the milestone breakdown.

--- a/apps/swapmeet-web/app/api/section/route.ts
+++ b/apps/swapmeet-web/app/api/section/route.ts
@@ -1,0 +1,15 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getSection } from "swapmeet-api";
+
+export async function GET(req: NextRequest) {
+  const { searchParams } = new URL(req.url);
+  const x = parseInt(searchParams.get("x") ?? "0", 10);
+  const y = parseInt(searchParams.get("y") ?? "0", 10);
+
+  if (Number.isNaN(x) || Number.isNaN(y)) {
+    return NextResponse.json({ message: "Invalid coordinates" }, { status: 400 });
+  }
+
+  const data = await getSection(x, y);
+  return NextResponse.json(data);
+}

--- a/apps/swapmeet-web/app/market/[x]/[y]/page.tsx
+++ b/apps/swapmeet-web/app/market/[x]/[y]/page.tsx
@@ -1,6 +1,7 @@
 import { notFound } from "next/navigation";
+import { getSection } from "swapmeet-api";
 
-export default function SectionPage({ params }: { params: { x?: string; y?: string } }) {
+export default async function SectionPage({ params }: { params: { x?: string; y?: string } }) {
   const x = parseInt(params.x ?? "0", 10);
   const y = parseInt(params.y ?? "0", 10);
 
@@ -8,5 +9,16 @@ export default function SectionPage({ params }: { params: { x?: string; y?: stri
     notFound();
   }
 
-  return <div>{`Section (${x}, ${y})`}</div>;
+  const { stalls } = await getSection(x, y);
+
+  return (
+    <div>
+      <h1>{`Section (${x}, ${y})`}</h1>
+      <ul>
+        {stalls.map((s) => (
+          <li key={s.id}>{s.name}</li>
+        ))}
+      </ul>
+    </div>
+  );
 }

--- a/services/swapmeet-api/README.md
+++ b/services/swapmeet-api/README.md
@@ -2,5 +2,6 @@
 
 Backend service for SwapMeet features.
 
-A placeholder `getSection` helper returns stall data for a given `(x, y)` coordinate.
-Future iterations will expose this via tRPC as detailed in the SRS.
+`getSection(x, y)` now queries Prisma for stalls within the requested section. The function is used by `swapmeet-web` and is exposed via the `/api/section` endpoint.
+
+Future iterations will surface additional tRPC routes as detailed in the SRS.

--- a/services/swapmeet-api/src/section.ts
+++ b/services/swapmeet-api/src/section.ts
@@ -4,7 +4,20 @@ export interface StallSummary {
   live: boolean;
 }
 
+import { prisma } from "@/lib/prismaclient";
+
 export async function getSection(x: number, y: number): Promise<{ stalls: StallSummary[] }> {
-  // TODO: replace with database query
-  return { stalls: [] };
+  const section = await prisma.section.findFirst({
+    where: { x, y },
+    include: { stalls: { select: { id: true, name: true } } },
+  });
+
+  return {
+    stalls:
+      section?.stalls.map((s) => ({
+        id: Number(s.id),
+        name: s.name,
+        live: false,
+      })) ?? [],
+  };
 }


### PR DESCRIPTION
## Summary
- add Prisma-backed `getSection` helper in `swapmeet-api`
- expose `/api/section` route in `swapmeet-web`
- display stalls on section page via service call
- update SwapMeet READMEs

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6883bb0c97ac8329bf51aeb0bcc31cfc