### PR TITLE
Implement arrow key nav and heatmap test

### DIFF
--- a/components/GridNavControls.tsx
+++ b/components/GridNavControls.tsx
@@ -1,14 +1,22 @@
 "use client";
 
 import { useRouter } from "next/navigation";
-import { useCallback } from "react";
+import { useCallback, useRef } from "react";
 import { useKeyPress } from "@/hooks/useKeyPress";
 import { ArrowUp, ArrowRight, ArrowDown, ArrowLeft, SendHorizonal } from "lucide-react";
 
 export function GridNavControls({ x, y }: { x: number; y: number }) {
   const router = useRouter();
+  const lastRef = useRef(0);
   const go = useCallback(
     (dx: number, dy: number) => {
+      const now = Date.now();
+      if (now - lastRef.current < 150) return;
+      lastRef.current = now;
+      const el = document.activeElement;
+      if (el && (el.tagName === "INPUT" || el.tagName === "TEXTAREA")) {
+        return;
+      }
       router.push(`/market/${x + dx}/${y + dy}`);
     },
     [x, y, router],
@@ -18,6 +26,10 @@ export function GridNavControls({ x, y }: { x: number; y: number }) {
   useKeyPress("a", () => go(-1, 0));
   useKeyPress("s", () => go(0, 1));
   useKeyPress("d", () => go(1, 0));
+  useKeyPress("ArrowUp", () => go(0, -1));
+  useKeyPress("ArrowLeft", () => go(-1, 0));
+  useKeyPress("ArrowDown", () => go(0, 1));
+  useKeyPress("ArrowRight", () => go(1, 0));
 
   async function teleport() {
     try {

--- a/services/swapmeet-api/src/__tests__/heatmap.test.ts
+++ b/services/swapmeet-api/src/__tests__/heatmap.test.ts
@@ -1,0 +1,32 @@
+import { vi, describe, it, expect, beforeEach } from "vitest";
+import { getHeatmap } from "../heatmap";
+import { prisma } from "@/lib/prismaclient";
+
+vi.mock("@/lib/prismaclient", () => ({
+  prisma: {
+    section: {
+      findMany: vi.fn(),
+    },
+  },
+}));
+
+const mockFindMany = (prisma.section.findMany as unknown as vi.Mock);
+
+beforeEach(() => {
+  mockFindMany.mockReset();
+});
+
+describe("getHeatmap", () => {
+  it("queries sections within bounds", async () => {
+    mockFindMany.mockResolvedValue([{ x: 1, y: 2, visitors: 3 }]);
+    const result = await getHeatmap(0, 2, 0, 3);
+    expect(mockFindMany).toHaveBeenCalledWith({
+      where: {
+        x: { gte: 0, lte: 2 },
+        y: { gte: 0, lte: 3 },
+      },
+      select: { x: true, y: true, visitors: true },
+    });
+    expect(result).toEqual([{ x: 1, y: 2, visitors: 3 }]);
+  });
+});


### PR DESCRIPTION
## Summary
- enable keyboard arrows in GridNavControls
- throttle grid moves and ignore when typing
- add unit test for getHeatmap using Vitest

## Testing
- `yarn lint`
- `yarn vitest run services/swapmeet-api/src/__tests__/heatmap.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_6883ccfe40908329b491ed4cd5dddad5