### PR TITLE
Update SwapMeet docs and dashboard

### DIFF
--- a/SwapMeet_Docs/SwapMeet_Implementation_Plan.md
+++ b/SwapMeet_Docs/SwapMeet_Implementation_Plan.md
@@ -4,7 +4,7 @@ This document distills the key actions required to build the **SwapMeet** module
 
 ## 1. Repository Integration
 
-- **Monorepo packages**: follow the pattern in existing `apps/` and `services/` folders. Create `apps/swapmeet-web` for the Next.js frontend and `services/swapmeet-api` for API routes and business logic.
+- **Monorepo packages**: follow the pattern in existing `apps/` and `services/` folders. The SwapMeet Next.js frontend now lives under `app/swapmeet`, with server logic in `services/swapmeet-api`.
 - **Database schema**: extend the Prisma models in `database` with tables listed in the SRS (`section`, `stall`, `item`, `offer`, `auction`, `order`). Use migration scripts in `scripts/`.
 - **Realtime**: use Supabase Realtime channels as done in other features (see `lib/supaClient.ts`). Yjs documents per stall store chat and offer state.
 - **Video streaming**: integrate LiveKit via `@livekit/components-react` similar to existing livestream nodes.

--- a/SwapMeet_Docs/SwapMeet_Phase2_Task_List.md
+++ b/SwapMeet_Docs/SwapMeet_Phase2_Task_List.md
@@ -2,11 +2,11 @@
 *(covers remaining Block 1 work + Block 2 “Stall CRUD & Thumbnails”)*
 
 ## 1. Macro Grid Navigation (finish Block 1)
-- [ ] Arrow buttons + WASD keys (`components/GridNavControls.tsx`)
-- [ ] Minimap canvas with heat‑map overlay (`components/Minimap.tsx`)
-- [ ] Heat‑map API route `/api/heatmap`
-- [ ] Teleport to busy section helper
-- [ ] SWR neighbour prefetch for instant navigation
+- [x] Arrow buttons + WASD keys (`components/GridNavControls.tsx`)
+- [x] Minimap canvas with heat‑map overlay (`components/Minimap.tsx`)
+- [x] Heat‑map API route `/api/heatmap`
+- [x] Teleport to busy section helper
+- [x] SWR neighbour prefetch for instant navigation
 
 ## 2. Stall CRUD & Thumbnails (Block 2)
 - [ ] Seller dashboard route `/dashboard/stalls`
@@ -18,12 +18,11 @@
 - [ ] Presence badge via Supabase Realtime
 
 ## 3. Migrations
-- [ ] `ALTER TABLE section ADD COLUMN visitors INT DEFAULT 0;`
-- [ ] `CREATE TABLE stall_image (…)` *if multiple images per stall*
-- [ ] `CREATE UNIQUE INDEX idx_stall_section ON "Stall"(seller_id, section_id);`
+- [x] `ALTER TABLE section ADD COLUMN visitors INT DEFAULT 0;`
+- [x] `CREATE TABLE stall_image (…)` *if multiple images per stall*
+- [x] `CREATE UNIQUE INDEX idx_stall_section ON "Stall"(seller_id, section_id);`
 
-## 4. Testing
-- [ ] Vitest unit tests for `getHeatmap`
+- [x] Vitest unit tests for `getHeatmap`
 - [ ] Playwright e2e: create stall → image upload → appears on section page
 - [ ] k6: 1 k simultaneous heat‑map pings
 

--- a/app/swapmeet/dashboard/stalls/page.tsx
+++ b/app/swapmeet/dashboard/stalls/page.tsx
@@ -1,0 +1,34 @@
+"use client";
+
+import useSWR from "swr";
+import Link from "next/link";
+
+const fetcher = (url: string) => fetch(url).then((r) => r.json());
+
+export default function StallsPage() {
+  const { data } = useSWR("/api/section?x=0&y=0", fetcher);
+  const stalls = data?.stalls ?? [];
+
+  return (
+    <div className="p-4">
+      <h1 className="text-lg font-bold mb-4">My Stalls</h1>
+      <table className="min-w-full border">
+        <thead>
+          <tr>
+            <th className="border px-2 py-1 text-left">ID</th>
+            <th className="border px-2 py-1 text-left">Name</th>
+          </tr>
+        </thead>
+        <tbody>
+          {stalls.map((s: any) => (
+            <tr key={s.id}>
+              <td className="border px-2 py-1">{s.id}</td>
+              <td className="border px-2 py-1">{s.name}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+      <Link href="/swapmeet">Back to market</Link>
+    </div>
+  );
+}

--- a/database/migrations/20260901_swapmeet_images.sql
+++ b/database/migrations/20260901_swapmeet_images.sql
@@ -1,0 +1,10 @@
+-- Additional SwapMeet tables
+CREATE TABLE IF NOT EXISTS stall_image (
+  id SERIAL PRIMARY KEY,
+  stall_id INT REFERENCES stall(id),
+  url TEXT NOT NULL,
+  blurhash TEXT,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_stall_section ON stall(owner_id, section_id);

--- a/services/swapmeet-api/README.md
+++ b/services/swapmeet-api/README.md
@@ -2,6 +2,6 @@
 
 Backend service for SwapMeet features.
 
-`getSection(x, y)` now queries Prisma for stalls within the requested section. The function is used by `swapmeet-web` and is exposed via the `/api/section` endpoint.
+`getSection(x, y)` now queries Prisma for stalls within the requested section. The function is used by `app/swapmeet` and is exposed via the `/api/section` endpoint.
 
 Future iterations will surface additional tRPC routes as detailed in the SRS.


### PR DESCRIPTION
## Summary
- update SwapMeet Implementation Plan to reflect new `app/swapmeet` location
- mark completed tasks in SwapMeet Phase2 list
- document API usage path in swapmeet-api README
- add stalls dashboard placeholder page
- add migration for stall images and unique index

## Testing
- `npm run lint`
- `npx vitest run services/swapmeet-api/src/__tests__/heatmap.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_6883d944ed8883299962b2936d8150a9