### PR TITLE
Fix lock wallet migration

### DIFF
--- a/supabase/migrations/20260101000000_lock_wallet.sql
+++ b/supabase/migrations/20260101000000_lock_wallet.sql
@@ -8,14 +8,14 @@ $$ LANGUAGE plpgsql;
 
 CREATE TABLE IF NOT EXISTS resolution_log (
   id TEXT PRIMARY KEY DEFAULT gen_random_uuid(),
-  market_id TEXT NOT NULL REFERENCES prediction_markets(id),
-  user_id BIGINT NOT NULL REFERENCES users(id),
+  "marketId" TEXT NOT NULL REFERENCES prediction_markets(id),
+  "userId" BIGINT NOT NULL REFERENCES users(id),
   amount INT NOT NULL,
-  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+  "createdAt" TIMESTAMPTZ NOT NULL DEFAULT NOW()
 );
 
-CREATE INDEX IF NOT EXISTS idx_resolution_market ON resolution_log(market_id);
-CREATE INDEX IF NOT EXISTS idx_resolution_user ON resolution_log(user_id);
+CREATE INDEX IF NOT EXISTS idx_resolution_market ON resolution_log("marketId");
+CREATE INDEX IF NOT EXISTS idx_resolution_user ON resolution_log("userId");
 
 CREATE TABLE IF NOT EXISTS wallet (
   user_id BIGINT PRIMARY KEY REFERENCES users(id),


### PR DESCRIPTION
## Summary
- adjust column names in `20260101000000_lock_wallet.sql` to match existing schema

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6883e53a9a448329891e5097ca7ceb5d