### PR TITLE
Implement SwapMeet presence badge

### DIFF
--- a/SwapMeet_Docs/SwapMeet_Phase2_Task_List.md
+++ b/SwapMeet_Docs/SwapMeet_Phase2_Task_List.md
@@ -15,7 +15,7 @@
 - [x] Prisma uniqueness constraint on `sectionId + sellerId`
 - [ ] Supabase Storage bucket `stall-images`
 - [ ] ImageDropzone + blurhash generation
-- [ ] Presence badge via Supabase Realtime
+- [x] Presence badge via Supabase Realtime
 
 ## 3. Migrations
 - [x] `ALTER TABLE section ADD COLUMN visitors INT DEFAULT 0;`

--- a/app/swapmeet/api/stall/route.ts
+++ b/app/swapmeet/api/stall/route.ts
@@ -2,21 +2,21 @@ import { NextResponse } from "next/server";
 import { prisma } from "@/lib/prismaclient";
 import { jsonSafe } from "@/lib/bigintjson";
 export async function POST(req: Request) {
-  const { name, sectionId } = await req.json();
-
   const body = await req.json();
-    // validate FK
-    const exists = await prisma.section.count({ where: { id: sectionId } });
-    if (!exists) {
-      return NextResponse.json(
-        { message: "Section not found" },
-        { status: 400 }
-      );
-    }
+  const { name, sectionId } = body;
+
+  const exists = await prisma.section.count({ where: { id: sectionId } });
+  if (!exists) {
+    return NextResponse.json(
+      { message: "Section not found" },
+      { status: 400 }
+    );
+  }
+
   const stall = await prisma.stall.create({
     data: {
-      name: body.name,
-      section_id: BigInt(body.sectionId),
+      name,
+      section_id: BigInt(sectionId),
       owner_id: 1n,
     },
   });

--- a/app/swapmeet/dashboard/stalls/page.tsx
+++ b/app/swapmeet/dashboard/stalls/page.tsx
@@ -5,6 +5,7 @@ import Link from "next/link";
 import { ColumnDef, flexRender, getCoreRowModel, useReactTable } from "@tanstack/react-table";
 import { useMemo, useState } from "react";
 import StallForm from "@/components/forms/StallForm";
+import { StallPresenceTracker } from "@/components/PresenceBadge";
 import { Button } from "@/components/ui/button";
 
 const fetcher = (url: string) => fetch(url).then((r) => r.json());
@@ -62,6 +63,7 @@ export default function StallsPage() {
                   {flexRender(cell.column.columnDef.cell, cell.getContext())}
                 </td>
               ))}
+              <StallPresenceTracker stallId={row.original.id} />
             </tr>
           ))}
         </tbody>

--- a/app/swapmeet/market/[x]/[y]/SectionClient.tsx
+++ b/app/swapmeet/market/[x]/[y]/SectionClient.tsx
@@ -5,6 +5,7 @@ import { useEffect } from "react";
 import { GridNavControls } from "@/components/GridNavControls";
 import { Minimap } from "@/components/Minimap";
 import { upsertSectionPing } from "@/lib/analytics/upsertSectionPing";
+import { PresenceBadge } from "@/components/PresenceBadge";
 
 const fetcher = (url: string) => fetch(url).then((r) => r.json());
 
@@ -41,7 +42,10 @@ export default function SectionClient({ x, y }: { x: number; y: number }) {
       <Minimap x={x} y={y} />
       <ul>
         {stalls.map((s: any) => (
-          <li key={s.id}>{s.name}</li>
+          <li key={s.id} className="flex items-center gap-1">
+            {s.name}
+            <PresenceBadge stallId={s.id} />
+          </li>
         ))}
       </ul>
     </div>

--- a/components/PresenceBadge.tsx
+++ b/components/PresenceBadge.tsx
@@ -1,0 +1,17 @@
+"use client";
+import { useStallPresence } from "@/hooks/useStallPresence";
+
+export function PresenceBadge({ stallId }: { stallId: number }) {
+  const online = useStallPresence(stallId);
+  return (
+    <span
+      className={`ml-1 inline-block w-2 h-2 rounded-full ${online ? "bg-green-500" : "bg-gray-400"}`}
+      title={online ? "Online" : "Offline"}
+    />
+  );
+}
+
+export function StallPresenceTracker({ stallId }: { stallId: number }) {
+  useStallPresence(stallId, true);
+  return null;
+}

--- a/hooks/useStallPresence.ts
+++ b/hooks/useStallPresence.ts
@@ -1,0 +1,40 @@
+import { useEffect, useState } from "react";
+import { supabase } from "@/lib/supabaseclient";
+import { v4 as uuidv4 } from "uuid";
+
+function getPresenceKey() {
+  if (typeof window === "undefined") return uuidv4();
+  const existing = localStorage.getItem("presence-key");
+  if (existing) return existing;
+  const key = uuidv4();
+  localStorage.setItem("presence-key", key);
+  return key;
+}
+
+export function useStallPresence(stallId: number, track = false) {
+  const [online, setOnline] = useState(false);
+
+  useEffect(() => {
+    const key = getPresenceKey();
+    const channel = supabase.channel(`stall-${stallId}`, {
+      config: { presence: { key } },
+    });
+
+    channel.on("presence", { event: "sync" }, () => {
+      const state = channel.presenceState<Record<string, unknown>>();
+      setOnline(Object.keys(state).length > 0);
+    });
+
+    channel.subscribe((status) => {
+      if (status === "SUBSCRIBED" && track) {
+        channel.track({});
+      }
+    });
+
+    return () => {
+      supabase.removeChannel(channel);
+    };
+  }, [stallId, track]);
+
+  return online;
+}


### PR DESCRIPTION
## Summary
- track stall presence using Supabase realtime
- show presence indicator in market section list
- track presence from seller dashboard
- fix stall API body parsing bug
- mark presence badge task complete in docs

## Testing
- `yarn install`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6885643c3350832983fae02f11b18436