### PR TITLE
Add StallSheet overlay with keyboard navigation

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -1323,3 +1323,9 @@ html:before{
 .nav.south { @apply left-1/2 bottom-2 -translate-x-1/2; }
 .nav.west { @apply left-2 top-1/2 -translate-y-1/2; }
 .nav.teleport { @apply right-2 bottom-2; }
+@media (max-width:767px){
+  .section-grid{grid-template-columns:1fr!important}
+}
+@media (min-width:768px) and (max-width:1279px){
+  .section-grid{grid-template-columns:repeat(2,1fr)!important}
+}

--- a/app/swapmeet/api/stall/[id]/route.ts
+++ b/app/swapmeet/api/stall/[id]/route.ts
@@ -1,0 +1,20 @@
+import { NextResponse } from "next/server";
+import { getStall } from "swapmeet-api";
+import { jsonSafe } from "@/lib/bigintjson";
+
+export async function GET(
+  _req: Request,
+  { params }: { params: { id: string } },
+) {
+  const id = Number(params.id);
+  if (Number.isNaN(id)) {
+    return NextResponse.json({ message: "Invalid id" }, { status: 400 });
+  }
+  const stall = await getStall(id);
+  if (!stall) {
+    return NextResponse.json({ message: "Not found" }, { status: 404 });
+  }
+  return NextResponse.json(jsonSafe(stall), {
+    headers: { "Cache-Control": "s-maxage=2, stale-while-revalidate=5" },
+  });
+}

--- a/app/swapmeet/components/OfferLadder.tsx
+++ b/app/swapmeet/components/OfferLadder.tsx
@@ -1,0 +1,25 @@
+"use client";
+import useSWR from "swr";
+
+const fetcher = (u: string) => fetch(u).then((r) => r.json());
+
+export function OfferLadder({ stallId }: { stallId: number }) {
+  const { data } = useSWR(
+    `/swapmeet/api/offers?stall=${stallId}`,
+    fetcher,
+    { refreshInterval: 2000 },
+  );
+  return (
+    <div className="sticky bottom-0 bg-white/80 backdrop-blur p-2">
+      {data?.map((o: any) => (
+        <div
+          key={o.id}
+          className={`grid grid-cols-[1fr_60px] ${o.mine ? "text-green-600" : "text-red-600"}`}
+        >
+          <span>${o.price}</span>
+          <span>{o.user}</span>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/app/swapmeet/components/StallCard.tsx
+++ b/app/swapmeet/components/StallCard.tsx
@@ -1,17 +1,18 @@
 "use client";
-import Link from "next/link";
+import { StallSheet } from "./StallSheet";
 
 export function StallCard({ stall }: { stall: any }) {
   return (
-    <Link href={`/swapmeet/stall/${stall.id}`} className="ubz-card ubz-card-h group rounded-lg overflow-hidden">
+    <div className="ubz-card ubz-card-h group rounded-lg overflow-hidden relative">
       <div className="relative aspect-square">
         <img src={stall.img} alt={stall.name} className="object-cover w-full h-full group-hover:scale-105 transition-transform" />
-        {stall.live && <span className="ubz-ring ubz-pulse absolute top-1 right-1 w-3 h-3"></span>}
+        {stall.live && <span className="ubz-ring ubz-pulse absolute top-1 right-1 w-3 h-3" />}
       </div>
       <div className="p-2">
         <p className="font-headline text-sm">{stall.name}</p>
         <span className="text-xs bg-white/60 px-1 rounded">{stall.visitors}👥</span>
       </div>
-    </Link>
+      <StallSheet stallId={stall.id} />
+    </div>
   );
 }

--- a/app/swapmeet/components/StallSheet.tsx
+++ b/app/swapmeet/components/StallSheet.tsx
@@ -1,0 +1,46 @@
+"use client";
+import useSWR from "swr";
+import { useState } from "react";
+import { Sheet, SheetContent } from "@/components/ui/sheet";
+import { OfferLadder } from "./OfferLadder";
+
+const fetcher = (url: string) => fetch(url).then((r) => r.json());
+
+export function StallSheet({ stallId }: { stallId: number }) {
+  const [open, setOpen] = useState(false);
+  const { data: stall } = useSWR(
+    open ? `/swapmeet/api/stall/${stallId}` : null,
+    fetcher,
+  );
+
+  return (
+    <>
+      <button onClick={() => setOpen(true)} className="absolute inset-0" />
+      <Sheet open={open} onOpenChange={setOpen}>
+        <SheetContent
+          side="bottom"
+          className="!h-[90vh] rounded-t-lg overflow-y-auto"
+        >
+          <header className="flex items-center gap-2 pb-2 border-b">
+            {stall?.avatar && (
+              <img src={stall.avatar} className="w-8 h-8 rounded-full" />
+            )}
+            <h2 className="font-headline text-lg">{stall?.name}</h2>
+          </header>
+          <div className="relative mt-2">
+            {stall?.liveSrc && (
+              <video
+                src={stall.liveSrc}
+                className="w-full aspect-video bg-black"
+                autoPlay
+                muted
+                playsInline
+              />
+            )}
+          </div>
+          <OfferLadder stallId={stallId} />
+        </SheetContent>
+      </Sheet>
+    </>
+  );
+}

--- a/app/swapmeet/components/useArrowNav.ts
+++ b/app/swapmeet/components/useArrowNav.ts
@@ -1,0 +1,29 @@
+"use client";
+import { useEffect } from "react";
+import { useRouter } from "next/navigation";
+
+const map = {
+  ArrowUp: [0, 1],
+  ArrowDown: [0, -1],
+  ArrowLeft: [-1, 0],
+  ArrowRight: [1, 0],
+  w: [0, 1],
+  s: [0, -1],
+  a: [-1, 0],
+  d: [1, 0],
+} as const;
+
+export function useArrowNav(x: number, y: number) {
+  const r = useRouter();
+  useEffect(() => {
+    const h = (e: KeyboardEvent) => {
+      const v = map[e.key as keyof typeof map];
+      if (v) {
+        e.preventDefault();
+        r.push(`/swapmeet/market/${x + v[0]}/${y + v[1]}`);
+      }
+    };
+    window.addEventListener("keydown", h);
+    return () => window.removeEventListener("keydown", h);
+  }, [x, y, r]);
+}

--- a/app/swapmeet/market/[x]/[y]/page.tsx
+++ b/app/swapmeet/market/[x]/[y]/page.tsx
@@ -4,6 +4,12 @@ import { Minimap } from "@/app/swapmeet/components/Minimap";
 import { TeleportButton } from "@/app/swapmeet/components/TeleportButton";
 import { StallCard } from "@/app/swapmeet/components/StallCard";
 import { getSection } from "swapmeet-api";
+import { useArrowNav } from "@/app/swapmeet/components/useArrowNav";
+
+function NavHook({ x, y }: { x: number; y: number }) {
+  useArrowNav(x, y);
+  return null;
+}
 
 export default async function SectionPage({ params }: { params: { x?: string; y?: string } }) {
   const x = parseInt(params.x ?? "0", 10);
@@ -16,13 +22,14 @@ export default async function SectionPage({ params }: { params: { x?: string; y?
 
   return (
     <main className="relative h-dvh bg-[var(--ubz-bg)]">
+      <NavHook x={x} y={y} />
       <NavArrow dir="N" x={x} y={y} />
       <NavArrow dir="E" x={x} y={y} />
       <NavArrow dir="S" x={x} y={y} />
       <NavArrow dir="W" x={x} y={y} />
       <TeleportButton />
       <Minimap cx={x} cy={y} />
-      <div className="absolute inset-0 grid grid-cols-3 gap-[3%] p-[clamp(16px,4vw,40px)]">
+      <div className="absolute inset-0 section-grid gap-[3%] p-[clamp(16px,4vw,40px)]">
         {stalls.map((s) => (
           <StallCard key={s.id} stall={s} />
         ))}

--- a/services/swapmeet-api/src/heatmap.ts
+++ b/services/swapmeet-api/src/heatmap.ts
@@ -16,12 +16,10 @@ export async function getHeatmap(
 }
 
 export async function getRandomBusySection() {
-  const sections = await prisma.section.findMany({
-    where: { visitors: { gt: 0 } },
-    orderBy: { visitors: "desc" },
-    take: 10,
-  });
-  if (sections.length === 0) return null;
-  const pick = sections[Math.floor(Math.random() * sections.length)];
+  const res = await prisma.$queryRawUnsafe<{ x: number; y: number }[]>(
+    "SELECT x,y FROM section ORDER BY visitors DESC LIMIT 20 OFFSET floor(random()*20)"
+  );
+  if (!res.length) return null;
+  const pick = res[Math.floor(Math.random() * res.length)];
   return { x: pick.x, y: pick.y };
 }

--- a/services/swapmeet-api/src/index.ts
+++ b/services/swapmeet-api/src/index.ts
@@ -1,5 +1,6 @@
 export { getSection, type StallSummary } from "./section";
 export { getHeatmap, getRandomBusySection } from "./heatmap";
+export { getStall, type StallDetail } from "./stall";
 
 export function hello() {
   return "swapmeet-api";

--- a/services/swapmeet-api/src/stall.ts
+++ b/services/swapmeet-api/src/stall.ts
@@ -1,0 +1,37 @@
+export interface StallDetail {
+  id: number;
+  name: string;
+  visitors: number;
+  avatar?: string | null;
+  liveSrc?: string | null;
+  items: { id: number; name: string; price_cents: number }[];
+}
+
+import { prisma } from "@/lib/prismaclient";
+
+export async function getStall(id: number): Promise<StallDetail | null> {
+  const stall = await prisma.stall.findUnique({
+    where: { id: BigInt(id) },
+    select: {
+      id: true,
+      name: true,
+      visitors: true,
+      avatar: true,
+      live_src: true,
+      items: { select: { id: true, name: true, price_cents: true } },
+    },
+  });
+  if (!stall) return null;
+  return {
+    id: Number(stall.id),
+    name: stall.name,
+    visitors: stall.visitors ?? 0,
+    avatar: stall.avatar,
+    liveSrc: stall.live_src,
+    items: stall.items.map((i) => ({
+      id: Number(i.id),
+      name: i.name,
+      price_cents: i.price_cents,
+    })),
+  };
+}


### PR DESCRIPTION
## Summary
- implement StallSheet overlay with OfferLadder
- add keyboard navigation hook and use it in section page
- expose stall details API and new heatmap busy query
- update StallCard to open sheet
- add responsive `.section-grid` styles

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68859dcb7cd08329808c452d75145f8e