### PR TITLE
Fix useArrowNav hook

### DIFF
--- a/app/swapmeet/components/NavHook.tsx
+++ b/app/swapmeet/components/NavHook.tsx
@@ -1,0 +1,7 @@
+"use client";
+import { useArrowNav } from "@/app/swapmeet/components/useArrowNav";
+
+export function NavHook({ x, y }: { x: number; y: number }) {
+  useArrowNav(x, y);
+  return null;
+}

--- a/app/swapmeet/market/[x]/[y]/page.tsx
+++ b/app/swapmeet/market/[x]/[y]/page.tsx
@@ -4,12 +4,7 @@ import { Minimap } from "@/app/swapmeet/components/Minimap";
 import { TeleportButton } from "@/app/swapmeet/components/TeleportButton";
 import { StallCard } from "@/app/swapmeet/components/StallCard";
 import { getSection } from "swapmeet-api";
-import { useArrowNav } from "@/app/swapmeet/components/useArrowNav";
-
-function NavHook({ x, y }: { x: number; y: number }) {
-  useArrowNav(x, y);
-  return null;
-}
+import { NavHook } from "@/app/swapmeet/components/NavHook";
 
 export default async function SectionPage({ params }: { params: { x?: string; y?: string } }) {
   const x = parseInt(params.x ?? "0", 10);


### PR DESCRIPTION
## Summary
- add `NavHook` client component
- use `NavHook` in swapmeet page

## Testing
- `yarn lint`
- `yarn test` *(fails: 'limiter.checkNext is not a function', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6885df0a01c883298496053717fd10c7