### PR TITLE
Polish stall creation flow

### DIFF
--- a/app/swapmeet/api/section/route.ts
+++ b/app/swapmeet/api/section/route.ts
@@ -15,10 +15,25 @@
 // }
 // // 
 import { jsonSafe } from "@/lib/bigintjson";
-import { NextResponse } from "next/server";
+import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/lib/prismaclient";
+import { getSection } from "swapmeet-api";
 
-export async function GET() {
+export async function GET(req: NextRequest) {
+  const { searchParams } = new URL(req.url);
+  const xParam = searchParams.get("x");
+  const yParam = searchParams.get("y");
+
+  if (xParam !== null && yParam !== null) {
+    const x = Number(xParam);
+    const y = Number(yParam);
+    if (Number.isNaN(x) || Number.isNaN(y)) {
+      return NextResponse.json({ message: "Invalid coordinates" }, { status: 400 });
+    }
+    const section = await getSection(x, y);
+    return NextResponse.json(jsonSafe(section));
+  }
+
   const sections = await prisma.section.findMany({
     select: { id: true, x: true, y: true },
     orderBy: [{ y: "asc" }, { x: "asc" }],

--- a/components/forms/StallForm.tsx
+++ b/components/forms/StallForm.tsx
@@ -35,6 +35,7 @@ interface Props {
   onOpenChange: (v: boolean) => void;
   onSubmit: (values: StallFormValues) => Promise<void> | void;
   defaultValues?: Partial<StallFormValues>;
+  loading?: boolean;
 }
 
 export default function StallForm({
@@ -42,6 +43,7 @@ export default function StallForm({
   onOpenChange,
   onSubmit,
   defaultValues,
+  loading,
 }: Props) {
   const form = useForm<StallFormValues>({
     resolver: zodResolver(StallFormSchema),
@@ -122,8 +124,8 @@ export default function StallForm({
                 </FormItem>
               )}
             />
-            <Button type="submit" className="mt-2">
-              Save
+            <Button type="submit" className="mt-2" disabled={loading}>
+              {loading ? "Saving..." : "Save"}
             </Button>
           </form>
         </Form>


### PR DESCRIPTION
## Summary
- update `/swapmeet/api/section` to return stalls when x/y params are supplied
- streamline stall creation with concurrent image upload and blurhash generation
- style dashboard per SwapMeet UI guide
- add loading states to stall form

## Testing
- `yarn lint`

------
https://chatgpt.com/codex/tasks/task_e_6885e2ed082483298d87d04b4a21002a