### PR TITLE
Improve swapmeet stall UX

### DIFF
--- a/app/api/v2/discovery/candidates/route.ts
+++ b/app/api/v2/discovery/candidates/route.ts
@@ -1,12 +1,11 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getUserFromCookies } from "@/lib/serverutils";
 import redis from "@/lib/redis";
-import rateLimit from "next-rate-limit";
+import { checkNext, check } from "@/lib/limiter";
 import { getTwoTowerCandidates } from "@/lib/twoTower";
 import { tasteFallbackCandidates } from "@/util/taste";
 import { unionWithoutDuplicates } from "@/lib/union";
 
-const limiter = rateLimit({ limit: 30, interval: 60 * 1000 });
 
 export async function GET(req: NextRequest) {
   const user = await getUserFromCookies();
@@ -15,7 +14,7 @@ export async function GET(req: NextRequest) {
   }
   const kParam = parseInt(req.nextUrl.searchParams.get("k") || "50", 10);
   const k = Math.min(Math.max(kParam, 1), 100);
-  await limiter.checkNext(req, 30);
+  await checkNext(req, 30);
   const ttl = parseInt(process.env.CANDIDATE_CACHE_TTL || "30", 10);
   const results = await getOrSet(`candCache:${user.userId}:${k}`, ttl, () =>
     knn(String(user.userId), k + 1),
@@ -26,7 +25,7 @@ export async function GET(req: NextRequest) {
     .map((r) => ({ userId: r.userId, score: r.score }));
   return NextResponse.json(filtered);
 
-  await limiter.check(req, `cand-${user.userId}`);
+  await check(req, `cand-${user.userId}`);
   const cacheKey = `candidates:v2:${user.userId}`;
   const cached = await redis.get(cacheKey);
   if (cached) return NextResponse.json(JSON.parse(cached));

--- a/app/globals.css
+++ b/app/globals.css
@@ -1329,3 +1329,5 @@ html:before{
 @media (min-width:768px) and (max-width:1279px){
   .section-grid{grid-template-columns:repeat(2,1fr)!important}
 }
+.kbdTip{display:block}
+@media (max-width:600px){.kbdTip{display:none}}

--- a/app/swapmeet/api/stall/route.ts
+++ b/app/swapmeet/api/stall/route.ts
@@ -13,13 +13,19 @@ export async function POST(req: Request) {
     );
   }
 
-  const stall = await prisma.stall.create({
-    data: {
-      name,
-      section_id: BigInt(sectionId),
-      owner_id: 1n,
-    },
-  });
-  return NextResponse.json(jsonSafe({ id: stall.id }));
+  const [stall] = await prisma.$transaction([
+    prisma.stall.create({
+      data: {
+        name,
+        section_id: BigInt(sectionId),
+        owner_id: 1n,
+      },
+    }),
+    prisma.section.update({
+      where: { id: BigInt(sectionId) },
+      data: { visitors: { increment: 1 } },
+    }),
+  ]);
+  return NextResponse.json(jsonSafe({ id: stall.id, name: stall.name }));
 }
 

--- a/app/swapmeet/components/EdgeNav.tsx
+++ b/app/swapmeet/components/EdgeNav.tsx
@@ -1,0 +1,14 @@
+"use client";
+import { useRouter } from "next/navigation";
+
+export function EdgeNav({ x, y }: { x: number; y: number }) {
+  const { push } = useRouter();
+  return (
+    <>
+      <div onMouseEnter={() => push(`/swapmeet/market/${x}/${y + 1}`)} className="fixed top-0 left-0 h-4 w-full" />
+      <div onMouseEnter={() => push(`/swapmeet/market/${x}/${y - 1}`)} className="fixed bottom-0 left-0 h-4 w-full" />
+      <div onMouseEnter={() => push(`/swapmeet/market/${x - 1}/${y}`)} className="fixed top-0 left-0 w-4 h-full" />
+      <div onMouseEnter={() => push(`/swapmeet/market/${x + 1}/${y}`)} className="fixed top-0 right-0 w-4 h-full" />
+    </>
+  );
+}

--- a/app/swapmeet/components/useArrowNav.ts
+++ b/app/swapmeet/components/useArrowNav.ts
@@ -16,9 +16,13 @@ const map = {
 export function useArrowNav(x: number, y: number) {
   const r = useRouter();
   useEffect(() => {
+    let last = 0;
     const h = (e: KeyboardEvent) => {
       const v = map[e.key as keyof typeof map];
       if (v) {
+        const now = Date.now();
+        if (now - last < 300) return;
+        last = now;
         e.preventDefault();
         r.push(`/swapmeet/market/${x + v[0]}/${y + v[1]}`);
       }

--- a/app/swapmeet/dashboard/stalls/page.tsx
+++ b/app/swapmeet/dashboard/stalls/page.tsx
@@ -15,6 +15,7 @@ const fetcher = (url: string) => fetch(url).then((r) => r.json());
 export default function StallsPage() {
   const { data, mutate } = useSWR("/swapmeet/api/section?x=0&y=0", fetcher);
   const stalls = data?.stalls ?? [];
+  const isLoading = !data;
 
   const [open, setOpen] = useState(false);
   const [loading, setLoading] = useState(false);
@@ -57,7 +58,13 @@ export default function StallsPage() {
         });
       }
     }
-    await mutate();
+    mutate(
+      (prev) =>
+        prev
+          ? { ...prev, stalls: [...prev.stalls, { id: stallId, name: rest.name }] }
+          : prev,
+      false,
+    );
     setLoading(false);
   }
 
@@ -84,16 +91,24 @@ export default function StallsPage() {
           ))}
         </thead>
         <tbody>
-          {table.getRowModel().rows.map((row) => (
-            <tr key={row.id}>
-              {row.getVisibleCells().map((cell) => (
-                <td key={cell.id} className="border px-2 py-1">
-                  {flexRender(cell.column.columnDef.cell, cell.getContext())}
-                </td>
+          {isLoading
+            ? [1, 2, 3].map((n) => (
+                <tr key={n}>
+                  <td colSpan={3} className="px-2 py-1">
+                    <div className="animate-pulse h-6 bg-gray-200 rounded" />
+                  </td>
+                </tr>
+              ))
+            : table.getRowModel().rows.map((row) => (
+                <tr key={row.id}>
+                  {row.getVisibleCells().map((cell) => (
+                    <td key={cell.id} className="border px-2 py-1">
+                      {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                    </td>
+                  ))}
+                  <StallPresenceTracker stallId={row.original.id} />
+                </tr>
               ))}
-              <StallPresenceTracker stallId={row.original.id} />
-            </tr>
-          ))}
         </tbody>
       </table>
       <Link href="/swapmeet" className="block mt-4">Back to market</Link>

--- a/app/swapmeet/market/[x]/[y]/page.tsx
+++ b/app/swapmeet/market/[x]/[y]/page.tsx
@@ -5,6 +5,7 @@ import { TeleportButton } from "@/app/swapmeet/components/TeleportButton";
 import { StallCard } from "@/app/swapmeet/components/StallCard";
 import { getSection } from "swapmeet-api";
 import { NavHook } from "@/app/swapmeet/components/NavHook";
+import { EdgeNav } from "@/app/swapmeet/components/EdgeNav";
 
 export default async function SectionPage({ params }: { params: { x?: string; y?: string } }) {
   const x = parseInt(params.x ?? "0", 10);
@@ -18,6 +19,7 @@ export default async function SectionPage({ params }: { params: { x?: string; y?
   return (
     <main className="relative h-dvh bg-[var(--ubz-bg)]">
       <NavHook x={x} y={y} />
+      <EdgeNav x={x} y={y} />
       <NavArrow dir="N" x={x} y={y} />
       <NavArrow dir="E" x={x} y={y} />
       <NavArrow dir="S" x={x} y={y} />
@@ -28,6 +30,9 @@ export default async function SectionPage({ params }: { params: { x?: string; y?
         {stalls.map((s) => (
           <StallCard key={s.id} stall={s} />
         ))}
+      </div>
+      <div className="kbdTip fixed bottom-2 left-1/2 -translate-x-1/2 text-xs text-[var(--ubz-street)] select-none">
+        ← ↑ ↓ → &nbsp; / &nbsp; WASD
       </div>
     </main>
   );

--- a/components/forms/StallForm.tsx
+++ b/components/forms/StallForm.tsx
@@ -53,6 +53,7 @@ export default function StallForm({
       image: undefined,
     },
   });
+  const [step, setStep] = useState(0);
 
   const handleSubmit = async (values: StallFormValues) => {
     await onSubmit(values);
@@ -62,71 +63,95 @@ export default function StallForm({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="max-w-sm">
+      <DialogContent role="dialog" aria-labelledby="new-stall" className="max-w-sm">
         <DialogHeader>
           <DialogTitle>
             {defaultValues ? "Edit Stall" : "New Stall"}
           </DialogTitle>
         </DialogHeader>
         <Form {...form}>
-          <form
-            onSubmit={form.handleSubmit(handleSubmit)}
-            className="space-y-4"
-          >
-            <FormField
-              control={form.control}
-              name="name"
-              render={({ field }) => (
-                <FormItem>
-                  <FormLabel>Name</FormLabel>
-                  <FormControl>
-                    <Input type="text" {...field} className="text-black" />
-                  </FormControl>
-                  <FormMessage />
-                </FormItem>
-              )}
-            />
+          <form onSubmit={form.handleSubmit(handleSubmit)} className="space-y-4">
+            {step === 0 && (
+              <>
+                <FormField
+                  control={form.control}
+                  name="name"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Name</FormLabel>
+                      <FormControl>
+                        <Input type="text" {...field} className="text-black" />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
 
-            <FormField
-              control={form.control}
-              name="sectionId"
-              render={({ field }) => (
-                <FormItem>
-                  <FormLabel>Section</FormLabel>
-                  <FormControl>
-                    <select
-                      {...field}
-                      className="text-black border px-2 py-1"
-                      value={field.value ?? sections?.[0]?.id ?? ""}
-                    >
-                      {sections?.map((s: any) => (
-                        <option key={s.id} value={s.id}>
-                          ({s.x}, {s.y})
-                        </option>
-                      ))}
-                    </select>
-                  </FormControl>
-                  <FormMessage />
-                </FormItem>
-              )}
-            />
+                <FormField
+                  control={form.control}
+                  name="sectionId"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Section</FormLabel>
+                      <FormControl>
+                        <select
+                          {...field}
+                          className="text-black border px-2 py-1"
+                          value={field.value ?? sections?.[0]?.id ?? ""}
+                        >
+                          {sections?.map((s: any) => (
+                            <option key={s.id} value={s.id}>
+                              ({s.x}, {s.y})
+                            </option>
+                          ))}
+                        </select>
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+                <Button type="button" onClick={() => setStep(1)}>
+                  Next
+                </Button>
+              </>
+            )}
 
-            <FormField
-              control={form.control}
-              name="image"
-              render={({ field }) => (
-                <FormItem>
-                  <FormLabel>Thumbnail</FormLabel>
-                  <FormControl>
-                    <ImageDropzone onFile={field.onChange} />
-                  </FormControl>
-                  <FormMessage />
-                </FormItem>
-              )}
-            />
-            <Button type="submit" className="mt-2" disabled={loading}>
-              {loading ? "Saving..." : "Save"}
-            </Button>
+            {step === 1 && (
+              <>
+                <FormField
+                  control={form.control}
+                  name="image"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Thumbnail</FormLabel>
+                      <FormControl>
+                        <ImageDropzone onFile={field.onChange} />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+                <div className="flex justify-between">
+                  <Button type="button" onClick={() => setStep(0)}>
+                    Back
+                  </Button>
+                  <Button type="button" onClick={() => setStep(2)}>
+                    Next
+                  </Button>
+                </div>
+              </>
+            )}
+
+            {step === 2 && (
+              <>
+                <Button type="button" onClick={() => setStep(1)}>
+                  Back
+                </Button>
+                <Button type="submit" className="ml-2" disabled={loading}>
+                  {loading ? "Saving..." : "Save"}
+                </Button>
+              </>
+            )}
           </form>
         </Form>
       </DialogContent>

--- a/database/migrations/20260921_add_stall_updated.sql
+++ b/database/migrations/20260921_add_stall_updated.sql
@@ -1,0 +1,2 @@
+ALTER TABLE stall ADD COLUMN IF NOT EXISTS updated_at TIMESTAMPTZ DEFAULT NOW();
+CREATE INDEX IF NOT EXISTS idx_stall_owner_vis ON stall(owner_id, updated_at DESC);

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -32,6 +32,10 @@ jest.mock("@xyflow/react", () => {
 
 jest.mock("nanoid", () => ({ nanoid: () => "id" }));
 jest.mock("@/lib/prismaclient", () => ({ prisma: { $connect: jest.fn() } }));
+jest.mock("@/lib/limiter", () => ({
+  checkNext: jest.fn(() => true),
+  check: jest.fn(() => true),
+}));
 
 (require as any).context = () => {
   const fn = () => ({});

--- a/lib/limiter.ts
+++ b/lib/limiter.ts
@@ -1,0 +1,8 @@
+import rateLimit from "next-rate-limit";
+
+const limiter = rateLimit({ limit: 30, interval: 60 * 1000 });
+
+export const checkNext = (req: Request, limit: number) => limiter.checkNext(req, limit);
+export const check = (req: Request, key: string) => limiter.check(req, key);
+
+export default { checkNext, check };

--- a/lib/models/schema.prisma
+++ b/lib/models/schema.prisma
@@ -771,6 +771,7 @@ model Stall {
   owner_id   BigInt
   name       String
   created_at DateTime  @default(now()) @db.Timestamptz(6)
+  updated_at DateTime? @default(now()) @updatedAt @db.Timestamptz(6)
   section    Section?  @relation(fields: [section_id], references: [id])
   owner      User      @relation(fields: [owner_id], references: [id])
   items      Item[]
@@ -779,6 +780,7 @@ model Stall {
   images     StallImage[]
 
   @@index([section_id])
+  @@index([owner_id, updated_at])
   @@unique([section_id, owner_id])
   @@map("stalls")
 }


### PR DESCRIPTION
## Summary
- batch stall creation in a Prisma transaction
- add rate limiter helper and mock in Jest setup
- step-based stall form with dialog accessibility
- add skeleton loading rows and optimistic update for stalls
- debounce arrow navigation and add edge hover panels
- add updated_at column and index for stalls

## Testing
- `npm run lint`
- `npm run test` *(fails: friend-suggestions.test.ts, explain_api.test.ts, feature_store.test.ts, discovery-candidates.integration.test.ts, explain_integration.test.ts, spotify.test.ts, favorites_builder.test.ts, embed_worker.integration.test.ts, pivotGenerator.test.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68866427032c8329b404d764747a920f