### PR TITLE
Add StallSheet panes

### DIFF
--- a/app/swapmeet/api/items/route.ts
+++ b/app/swapmeet/api/items/route.ts
@@ -1,0 +1,13 @@
+import { NextResponse } from "next/server";
+
+export async function GET(req: Request) {
+  const url = new URL(req.url);
+  const stall = Number(url.searchParams.get("stall"));
+  return NextResponse.json(
+    stall
+      ? [{ id: 1, name: "Mock item", price_cents: 1000 }]
+      : [],
+    { headers: { "Cache-Control": "no-store" } },
+  );
+}
+

--- a/app/swapmeet/components/ChatPane.tsx
+++ b/app/swapmeet/components/ChatPane.tsx
@@ -1,0 +1,10 @@
+"use client";
+
+export function ChatPane({ stallId }: { stallId: number }) {
+  return (
+    <div className="p-4 text-center text-sm text-gray-500">
+      Chat coming soon
+    </div>
+  );
+}
+

--- a/app/swapmeet/components/ItemsPane.tsx
+++ b/app/swapmeet/components/ItemsPane.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+import useSWR from "swr";
+import { Skeleton } from "@/components/ui/skeleton";
+
+const fetcher = (u: string) => fetch(u).then(r => r.json());
+
+export function ItemsPane({ stallId }: { stallId: number }) {
+  const { data = [{ name: "Mock item", price_cents: 10 }], isLoading } = useSWR(
+    stallId ? `/swapmeet/api/items?stall=${stallId}` : null,
+    fetcher,
+    { fallbackData: [] }
+  );
+
+  return (
+    <div className="overflow-y-auto px-4 space-y-2">
+      {isLoading && Array.from({ length: 3 }).map((_, i) => (
+        <Skeleton key={i} className="h-6 w-full" />
+      ))}
+      {data.map((item: any) => (
+        <div key={item.id ?? item.name} className="flex justify-between">
+          <span>{item.name}</span>
+          <span>${(item.price_cents / 100).toFixed(2)}</span>
+        </div>
+      ))}
+    </div>
+  );
+}
+

--- a/app/swapmeet/components/StallSheet.tsx
+++ b/app/swapmeet/components/StallSheet.tsx
@@ -2,7 +2,9 @@
 "use client";
 import useSWR from "swr";
 import { Sheet, SheetContent } from "@/components/ui/sheet";
-import { OfferLadder } from "./OfferLadder";
+import { VideoPane } from "./VideoPane";
+import { ItemsPane } from "./ItemsPane";
+import { ChatPane } from "./ChatPane";
 
 const fetcher = (url: string) => fetch(url).then(r => r.json());
 
@@ -22,27 +24,14 @@ export function StallSheet({ stallId, open, onOpenChange }: Props) {
 
   return (
     <Sheet open={open} onOpenChange={onOpenChange}>
-      <SheetContent side="bottom" className="h-full overflow-y-auto rounded-t-lg">
-        <header className="flex items-center gap-2 border-b pb-2">
-          {stall?.avatar && (
-            <img src={stall.avatar} className="h-8 w-8 rounded-full" />
-          )}
-          <h2 className="font-headline text-lg">{stall?.name}</h2>
-        </header>
-
-        {/* video pane */}
-        {stall?.liveSrc && (
-          <video
-            src={stall.liveSrc}
-            className="mt-2 w-full aspect-video bg-black"
-            autoPlay
-            muted
-            playsInline
-          />
-        )}
-
-        {/* items / offer ladder  */}
-        <OfferLadder stallId={stallId} />
+      <SheetContent
+        side="bottom"
+        className="h-[90dvh] grid grid-rows-[auto_1fr_auto] gap-3 p-0 overflow-hidden rounded-t-lg"
+      >
+        <div className="mx-auto my-2 h-1.5 w-12 rounded-full bg-gray-300" />
+        <VideoPane src={stall?.liveSrc} open={open} />
+        <ItemsPane stallId={stallId} />
+        <ChatPane stallId={stallId} />
       </SheetContent>
     </Sheet>
   );

--- a/app/swapmeet/components/VideoPane.tsx
+++ b/app/swapmeet/components/VideoPane.tsx
@@ -1,0 +1,28 @@
+"use client";
+import { useRef, useEffect } from "react";
+
+interface Props {
+  src?: string;
+  open: boolean;
+}
+
+export function VideoPane({ src, open }: Props) {
+  const vidRef = useRef<HTMLVideoElement>(null);
+  useEffect(() => {
+    if (!open) vidRef.current?.pause();
+  }, [open]);
+
+  if (!src) return null;
+
+  return (
+    <video
+      ref={vidRef}
+      src={src}
+      className="w-full aspect-video bg-black"
+      autoPlay
+      muted
+      playsInline
+    />
+  );
+}
+


### PR DESCRIPTION
## Summary
- create `ItemsPane`, `VideoPane`, and `ChatPane`
- add mock items API
- rework `StallSheet` into a three-row grid with new panes

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6887ddaed52083299c58e62652c7a3b9