### PR TITLE
Fix feed post actions

### DIFF
--- a/components/buttons/DeleteCardButton.tsx
+++ b/components/buttons/DeleteCardButton.tsx
@@ -2,15 +2,17 @@
 
 import Image from "next/image";
 import { deletePost } from "@/lib/actions/thread.actions";
+import { deleteFeedPost } from "@/lib/actions/feed.actions";
 import { deleteRealtimePost } from "@/lib/actions/realtimepost.actions";
 import { useRouter, usePathname } from "next/navigation";
 
 interface Props {
   postId?: bigint;
   realtimePostId?: string;
+  feedPostId?: bigint;
 }
 
-const DeleteCardButton = ({ postId, realtimePostId }: Props) => {
+const DeleteCardButton = ({ postId, realtimePostId, feedPostId }: Props) => {
   const router = useRouter();
   const pathname = usePathname();
 
@@ -18,6 +20,8 @@ const DeleteCardButton = ({ postId, realtimePostId }: Props) => {
     if (!confirm("Are you sure you want to delete this post?")) return;
     if (realtimePostId) {
       await deleteRealtimePost({ id: realtimePostId, path: pathname });
+    } else if (feedPostId) {
+      await deleteFeedPost({ id: feedPostId, path: pathname });
     } else if (postId) {
       await deletePost({ id: postId, path: pathname });
     }

--- a/components/buttons/LikeButton.tsx
+++ b/components/buttons/LikeButton.tsx
@@ -8,6 +8,7 @@ import {
   unlikeRealtimePost,
   dislikeRealtimePost,
 } from "@/lib/actions/like.actions";
+import { likeFeedPost, unlikeFeedPost } from "@/lib/actions/feed.actions";
 import { useAuth } from "@/lib/AuthContext";
 import { Like, RealtimeLike } from "@prisma/client";
 import Image from "next/image";
@@ -17,11 +18,12 @@ import { Button } from "@/components/ui/button";
 interface Props {
   postId?: bigint;
   realtimePostId?: string;
+  feedPostId?: bigint;
   likeCount: number;
   initialLikeState?: Like | RealtimeLike | null;
 }
 
-const LikeButton = ({ postId, realtimePostId, likeCount, initialLikeState }: Props) => {
+const LikeButton = ({ postId, realtimePostId, feedPostId, likeCount, initialLikeState }: Props) => {
   const user = useAuth();
   const router = useRouter();
   const isUserSignedIn = !!user.user;
@@ -47,6 +49,9 @@ const LikeButton = ({ postId, realtimePostId, likeCount, initialLikeState }: Pro
       if (realtimePostId) {
         unlikeRealtimePost({ userId: userObjectId, realtimePostId });
       }
+      if (feedPostId) {
+        unlikeFeedPost({ id: feedPostId });
+      }
       setCurrentLikeType("NONE");
       setDisplayLikeCount(displayLikeCount - 1);
     } else {
@@ -55,6 +60,9 @@ const LikeButton = ({ postId, realtimePostId, likeCount, initialLikeState }: Pro
       }
       if (realtimePostId) {
         likeRealtimePost({ userId: userObjectId, realtimePostId });
+      }
+      if (feedPostId) {
+        likeFeedPost({ id: feedPostId });
       }
       if (currentLikeType === "NONE") {
         setDisplayLikeCount(displayLikeCount + 1);
@@ -81,6 +89,9 @@ const LikeButton = ({ postId, realtimePostId, likeCount, initialLikeState }: Pro
       if (realtimePostId) {
         unlikeRealtimePost({ userId: userObjectId, realtimePostId });
       }
+      if (feedPostId) {
+        unlikeFeedPost({ id: feedPostId });
+      }
       setCurrentLikeType("NONE");
       setDisplayLikeCount(displayLikeCount + 1);
     } else {
@@ -94,6 +105,9 @@ const LikeButton = ({ postId, realtimePostId, likeCount, initialLikeState }: Pro
         setDisplayLikeCount(displayLikeCount - 1);
       } else if (currentLikeType === "LIKE") {
         setDisplayLikeCount(displayLikeCount - 2);
+      }
+      if (feedPostId) {
+        unlikeFeedPost({ id: feedPostId });
       }
       setCurrentLikeType("DISLIKE");
     }

--- a/components/buttons/ReplicateButton.tsx
+++ b/components/buttons/ReplicateButton.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { replicatePost } from "@/lib/actions/thread.actions";
+import { replicateFeedPost } from "@/lib/actions/feed.actions";
 import { replicateRealtimePost } from "@/lib/actions/realtimepost.actions";
 import { useAuth } from "@/lib/AuthContext";
 import Image from "next/image";
@@ -20,9 +21,10 @@ import { Button } from "@/components/ui/button";
 interface Props {
   postId?: bigint;
   realtimePostId?: string;
+  feedPostId?: bigint;
 }
 
-const ReplicateButton = ({ postId, realtimePostId }: Props) => {
+const ReplicateButton = ({ postId, realtimePostId, feedPostId }: Props) => {
   const user = useAuth();
   const router = useRouter();
   const pathname = usePathname();
@@ -44,6 +46,13 @@ const ReplicateButton = ({ postId, realtimePostId }: Props) => {
     if (realtimePostId) {
       await replicateRealtimePost({
         originalPostId: realtimePostId.toString(),
+        userId: userObjectId.toString(),
+        path: pathname,
+        text,
+      });
+    } else if (feedPostId) {
+      await replicateFeedPost({
+        originalPostId: feedPostId.toString(),
         userId: userObjectId.toString(),
         path: pathname,
         text,

--- a/components/cards/PostCard.tsx
+++ b/components/cards/PostCard.tsx
@@ -58,6 +58,7 @@ interface Props {
   };
   createdAt: string;
   isRealtimePost?: boolean;
+  isFeedPost?: boolean;
   likeCount?: number;
   commentCount?: number;
   expirationDate?: string | null;
@@ -80,6 +81,7 @@ const PostCard = ({
   type,
   createdAt,
   isRealtimePost = false,
+  isFeedPost = false,
   likeCount = 0,
   commentCount = 0,
   expirationDate = null,
@@ -359,6 +361,8 @@ const PostCard = ({
                 <LikeButton
                   {...(isRealtimePost
                     ? { realtimePostId: id.toString() }
+                    : isFeedPost
+                    ? { feedPostId: id }
                     : { postId: id })}
                   likeCount={likeCount}
                   initialLikeState={currentUserLike}
@@ -367,6 +371,8 @@ const PostCard = ({
                   <ExpandButton
                     {...(isRealtimePost
                       ? { realtimePostId: id.toString() }
+                      : isFeedPost
+                      ? { postId: id }
                       : { postId: id })}
                     commentCount={commentCount}
                   />
@@ -374,18 +380,24 @@ const PostCard = ({
                 <ReplicateButton
                   {...(isRealtimePost
                     ? { realtimePostId: id.toString() }
+                    : isFeedPost
+                    ? { feedPostId: id }
                     : { postId: id })}
                 />
                 <ShareButton postId={id} />
-                <TimerButton
-                  postId={id}
-                  isOwned={currentUserId === author.id}
-                  expirationDate={expirationDate ?? undefined}
-                />
+                {!isFeedPost && (
+                  <TimerButton
+                    postId={id}
+                    isOwned={currentUserId === author.id}
+                    expirationDate={expirationDate ?? undefined}
+                  />
+                )}
                 {currentUserId === author.id && (
                   <DeleteCardButton
                     {...(isRealtimePost
                       ? { realtimePostId: id.toString() }
+                      : isFeedPost
+                      ? { feedPostId: id }
                       : { postId: id })}
                   />
                 )}

--- a/components/shared/RealtimeFeed.tsx
+++ b/components/shared/RealtimeFeed.tsx
@@ -39,6 +39,8 @@ export default function RealtimeFeed({
     };
   }, [roomId, postTypes]);
 
+  const isFeed = roomId === "global" && (!postTypes || postTypes.length === 0);
+
   const { posts, loaderRef, loading } = useInfiniteRealtimePosts(
     fetchPage,
     initialPosts,
@@ -53,6 +55,7 @@ export default function RealtimeFeed({
           currentUserId={currentUserId}
           id={realtimePost.id}
           isRealtimePost={Boolean(roomId && postTypes && postTypes.length > 0)}
+          isFeedPost={isFeed}
           likeCount={realtimePost.like_count}
           commentCount={realtimePost.commentCount ?? 0}
           content={realtimePost.content ? realtimePost.content : undefined}

--- a/lib/actions/feed.actions.ts
+++ b/lib/actions/feed.actions.ts
@@ -1,6 +1,7 @@
 import { prisma } from "../prismaclient";
 import { useSession } from "../useSession";
 import { getUserFromCookies } from "@/lib/serverutils";  // server‑only util
+import { revalidatePath } from "next/cache";
 import { jsonSafe } from "../bigintjson";
 export interface CreateFeedPostArgs {
   type: "TEXT" | "IMAGE" | "VIDEO" | "GALLERY" | "PREDICTION" | "PRODUCT_REVIEW";
@@ -39,4 +40,55 @@ export async function fetchFeedPosts() {
     include: { predictionMarket: true, author: true },
   });
   return posts.map((p) => ({ ...p }));
+}
+
+export async function deleteFeedPost({ id, path }: { id: bigint; path?: string }) {
+  const user = await getUserFromCookies();
+  if (!user) return;
+  const post = await prisma.feedPost.findUnique({ where: { id } });
+  if (!post || post.author_id !== user.userId) return;
+  await prisma.feedPost.delete({ where: { id } });
+  if (path) revalidatePath(path);
+}
+
+export async function replicateFeedPost({
+  originalPostId,
+  userId,
+  path,
+  text,
+}: {
+  originalPostId: string | number | bigint;
+  userId: string | number | bigint;
+  path: string;
+  text?: string;
+}) {
+  const oid = BigInt(originalPostId);
+  const uid = BigInt(userId);
+  const original = await prisma.feedPost.findUnique({ where: { id: oid } });
+  if (!original) throw new Error("Feed post not found");
+  const payload = JSON.stringify({ id: oid.toString(), text });
+  const newPost = await prisma.feedPost.create({
+    data: {
+      content: `REPLICATE:${payload}`,
+      author_id: uid,
+      type: "TEXT",
+      isPublic: true,
+    },
+  });
+  if (path) revalidatePath(path);
+  return newPost;
+}
+
+export async function likeFeedPost({ id }: { id: bigint }) {
+  await prisma.feedPost.update({
+    where: { id },
+    data: { like_count: { increment: 1 } },
+  });
+}
+
+export async function unlikeFeedPost({ id }: { id: bigint }) {
+  await prisma.feedPost.update({
+    where: { id },
+    data: { like_count: { decrement: 1 } },
+  });
 }


### PR DESCRIPTION
## Summary
- support feed post deletion, liking, and replication
- wire PostCard actions to feed post operations
- add feed post helpers in feed.actions
- expose feed post flag in RealtimeFeed

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68880bf040548329b6a08b7e48af2164