### PR TITLE
Update stall sheet features

### DIFF
--- a/app/swapmeet/api/stall/[id]/route.ts
+++ b/app/swapmeet/api/stall/[id]/route.ts
@@ -1,12 +1,13 @@
 import { getStall } from "@/lib/actions/stall.server";
 import { NextResponse } from "next/server";
+import { jsonSafe } from "@/lib/bigintjson";
 
 export async function GET(
   _req: Request,
   { params }: { params: { id: string } },
 ) {
   const stall = await getStall(Number(params.id));
-  return NextResponse.json(stall, {
+  return NextResponse.json(jsonSafe(stall), {
     headers: { "Cache-Control": "no-store" },
   });
 }

--- a/app/swapmeet/components/StallCard.tsx
+++ b/app/swapmeet/components/StallCard.tsx
@@ -57,7 +57,7 @@ export function StallCard({ stall }) {
         className="relative w-full h-full min-w-0 min-h-0 group bg-white rounded-xl likebutton 
         overflow-hidden hover-tilt hover:scale-105">
       
-      <img src={stall.img ?? "/placeholder-stall.svg"}
+      <img src={("img" in stall ? (stall as any).img : undefined) ?? "/placeholder-stall.svg"}
            alt={stall.name}
 
            className="absolute inset-0 object-contain w-full h-full object-cover rounded-xl transition-transform 

--- a/app/swapmeet/components/StallSheet.tsx
+++ b/app/swapmeet/components/StallSheet.tsx
@@ -18,26 +18,32 @@ interface Props {
 export function StallSheet({ stallId, open, onOpenChange }: Props) {
   // SWR only when visible
   const { data: stall } = useSWR(
-
     open ? `/swapmeet/api/stall/${stallId}` : null,
     fetcher
   );
+  const liveSrc = stall && "liveSrc" in stall ? (stall as any).liveSrc : undefined;
 
   return (
     <Sheet open={open} onOpenChange={onOpenChange}>
      
       <SheetContent
         side="bottom"
-        className="h-[90dvh] grid grid-rows-[auto_1fr_auto] gap-3 p-0 overflow-hidden rounded-t-lg"
+        className="h-[90dvh] grid grid-rows-[auto_auto_1fr_auto] gap-3 p-0 overflow-hidden rounded-t-lg"
+        motion={{
+          initial: { y: "100%" },
+          animate: { y: 0, transition: { type: "spring", stiffness: 260, damping: 24 } },
+          exit: { y: "100%", transition: { duration: 0.25 } },
+        }}
       >
         <div className="mx-auto my-2 h-1.5 w-12 rounded-full bg-gray-300" />
         <Link
-  href={`/swapmeet/stall/${stallId}`}
-  className="mt-4 inline-block text-sm text-[var(--ubz-brand)] underline"
->
-  View full stall →
-</Link>
-        <VideoPane src={stall?.liveSrc} open={open} />
+          href={`/swapmeet/stall/${stallId}`}
+          onClick={() => onOpenChange(false)}
+          className="-mt-1 inline-block text-sm text-[var(--ubz-brand)] underline"
+        >
+          View full stall →
+        </Link>
+        <VideoPane src={liveSrc} open={open} />
         <ItemsPane stallId={stallId} />
         <ChatPane stallId={stallId} />
       </SheetContent>

--- a/lib/actions/stall.server.ts
+++ b/lib/actions/stall.server.ts
@@ -4,8 +4,8 @@ export async function getStall(id: number) {
   return prisma.stall.findUnique({
     where: { id: BigInt(id) },
     include: {
-      items: true,
-      owner: { select: { name: true, avatar: true } },
+      items: { select: { id: true, name: true, price_cents: true } },
+      owner: { select: { name: true, image: true } },
     },
   });
 }


### PR DESCRIPTION
## Summary
- handle BigInt values in `/api/stall/[id]`
- select owner image in `getStall`
- improve StallSheet layout and closing behaviour
- guard optional fields in StallSheet and StallCard

## Testing
- `npm run lint`
- `npx prisma generate && npx prisma validate`
- `curl -I http://localhost:3000/api/stall/1` *(fails: Couldn't connect to server)*

------
https://chatgpt.com/codex/tasks/task_e_6888481bb5dc8329b13cb980299e7134