### PR TITLE
Implement cart API with badge

### DIFF
--- a/app/api/cart/add/route.ts
+++ b/app/api/cart/add/route.ts
@@ -1,0 +1,10 @@
+import { getUserFromCookies } from "@/lib/serverutils";
+import { addToCart } from "@/lib/actions/cart.server";
+
+export async function POST(req: Request) {
+  const user = await getUserFromCookies();
+  if (!user) return new Response("Auth", { status: 401 });
+  const { itemId, qty = 1 } = await req.json();
+  await addToCart(user.userId, BigInt(itemId), qty);
+  return new Response("ok");
+}

--- a/app/api/cart/count/route.ts
+++ b/app/api/cart/count/route.ts
@@ -1,0 +1,8 @@
+import { getUserFromCookies } from "@/lib/serverutils";
+import { getCartCount } from "@/lib/actions/cart.server";
+
+export async function GET() {
+  const user = await getUserFromCookies();
+  const n = user ? await getCartCount(user.userId) : 0;
+  return Response.json({ n }, { headers: { "Cache-Control": "no-store" } });
+}

--- a/components/CartButton.tsx
+++ b/components/CartButton.tsx
@@ -1,0 +1,21 @@
+"use client";
+
+import useSWR from "swr";
+import Link from "next/link";
+
+const fetcher = (u: string) => fetch(u).then((r) => r.json());
+
+export default function CartButton() {
+  const { data } = useSWR("/api/cart/count", fetcher, { refreshInterval: 15000 });
+  const n = data?.n ?? 0;
+  return (
+    <Link href="/cart" className="relative">
+      🛒
+      {n > 0 && (
+        <span className="absolute -right-2 -top-2 bg-red-500 text-white text-xs w-5 h-5 rounded-full flex items-center justify-center">
+          {n}
+        </span>
+      )}
+    </Link>
+  );
+}

--- a/components/shared/Topbar.tsx
+++ b/components/shared/Topbar.tsx
@@ -7,6 +7,7 @@ import { signOut, getAuth } from "firebase/auth";
 import { useRouter } from "next/navigation";
 import { app } from "@/lib/firebase/firebase";
 import { useAuth } from "@/lib/AuthContext";
+import CartButton from "@/components/CartButton";
 import { Chakra_Petch } from "next/font/google";
 import localFont from 'next/font/local'
 const parabole = localFont({ src: './Parabole-DisplayRegular.woff2' })
@@ -47,12 +48,13 @@ function Topbar() {
       )}
       <div className="fixed top-[1rem]  justify-start ">
       <Link href="/" className="flex items-center gap-4">
-        <Image src="/assets/logo-black.svg" alt="logo" width={36} height={36} /> 
+        <Image src="/assets/logo-black.svg" alt="logo" width={36} height={36} />
         <div className={`${parabole.className}`}>
         <span  className=" text-[2.5rem] font-bold text-black tracking-[.0rem] max-xs:hidden">MESH</span>
         </div>
 
       </Link>
+      <CartButton />
       </div>
 
     </nav>

--- a/lib/actions/cart.server.ts
+++ b/lib/actions/cart.server.ts
@@ -1,0 +1,30 @@
+"use server";
+
+import { prisma } from "@/lib/prismaclient";
+
+export async function addToCart(userId: bigint, itemId: bigint, qty = 1) {
+  await prisma.cartItem.upsert({
+    where: {
+      user_id_item_id: {
+        user_id: userId,
+        item_id: itemId,
+      },
+    },
+    update: {
+      qty: { increment: qty },
+    },
+    create: {
+      user_id: userId,
+      item_id: itemId,
+      qty,
+    },
+  });
+}
+
+export async function getCartCount(userId: bigint) {
+  const c = await prisma.cartItem.aggregate({
+    where: { user_id: userId },
+    _sum: { qty: true },
+  });
+  return c._sum.qty ?? 0;
+}

--- a/lib/models/schema.prisma
+++ b/lib/models/schema.prisma
@@ -61,6 +61,7 @@ model User {
   offers                   Offer[]
   bids                     Bid[]
   orders                   Order[]
+  cartItems               CartItem[]
 
   @@map("users")
 }
@@ -831,6 +832,7 @@ model Item {
   offers      Offer[]
   auction     Auction?
   orderLines  OrderLine[]
+  cartItems   CartItem[]
 
   @@index([stall_id])
   @@map("items")
@@ -905,4 +907,17 @@ model OrderLine {
 
   @@index([order_id])
   @@map("order_lines")
+}
+
+model CartItem {
+  id         BigInt   @id @default(autoincrement())
+  user_id    BigInt
+  item_id    BigInt
+  qty        Int      @default(1)
+  created_at DateTime @default(now()) @db.Timestamptz(6)
+  user       User     @relation(fields: [user_id], references: [id])
+  item       Item     @relation(fields: [item_id], references: [id])
+
+  @@unique([user_id, item_id])
+  @@map("cart_items")
 }


### PR DESCRIPTION
## Summary
- define `CartItem` model in Prisma schema
- add cart actions for server usage
- create API routes `/api/cart/add` and `/api/cart/count`
- show cart count via new `CartButton` in `Topbar`

## Testing
- `npm run lint`
- `npx prisma migrate dev -n cart_items --skip-seed` *(fails: can't reach database)*
- `npx prisma generate`

------
https://chatgpt.com/codex/tasks/task_e_68884c9fe330832996a80b7ef58e6f12