### PR TITLE
feat/stall-chat-pane

### DIFF
--- a/app/swapmeet/api/chat/route.ts
+++ b/app/swapmeet/api/chat/route.ts
@@ -1,0 +1,21 @@
+import { getUserFromCookies } from "@/lib/serverutils";
+import { prisma } from "@/lib/prismaclient";
+
+export async function POST(req: Request) {
+  const user = await getUserFromCookies();
+  if (!user) return new Response("Auth required", { status: 401 });
+
+  const { stallId, text } = await req.json();
+  if (!stallId || !text?.trim())
+    return new Response("Bad request", { status: 400 });
+
+  await prisma.stallMessage.create({
+    data: {
+      stall_id: BigInt(stallId),
+      user_id: user.userId,
+      text: text.trim(),
+    },
+  });
+
+  return new Response("ok");
+}

--- a/app/swapmeet/api/stall/[id]/events/route.ts
+++ b/app/swapmeet/api/stall/[id]/events/route.ts
@@ -1,0 +1,47 @@
+import { prisma } from "@/lib/prismaclient";
+
+const viewers = new Map<number, number>();
+
+export async function GET(_req: Request, { params }: { params: { id: string } }) {
+  const stallId = Number(params.id);
+  if (!stallId) return new Response("Invalid stall", { status: 400 });
+
+  viewers.set(stallId, (viewers.get(stallId) || 0) + 1);
+
+  let tick: NodeJS.Timeout;
+  const stream = new ReadableStream({
+    start(controller) {
+      let lastMsgId = 0n;
+      tick = setInterval(async () => {
+        const count = viewers.get(stallId) || 0;
+        controller.enqueue(`data: ${JSON.stringify({ viewers: count })}\n\n`);
+
+        const msgs = await prisma.stallMessage.findMany({
+          where: { stall_id: BigInt(stallId), id: { gt: lastMsgId } },
+          include: { user: { select: { name: true } } },
+          orderBy: { id: "asc" },
+        });
+        if (msgs.length) {
+          lastMsgId = msgs[msgs.length - 1].id;
+          controller.enqueue(
+            `data: ${JSON.stringify({ chat: msgs.map(m => ({ id: m.id.toString(), user: m.user.name, text: m.text, at: m.created_at })) })}\n\n`
+          );
+        }
+      }, 3000);
+    },
+    cancel() {
+      clearInterval(tick);
+      const count = (viewers.get(stallId) || 1) - 1;
+      if (count <= 0) viewers.delete(stallId);
+      else viewers.set(stallId, count);
+    },
+  });
+
+  return new Response(stream, {
+    headers: {
+      "Content-Type": "text/event-stream",
+      "Cache-Control": "no-cache",
+      Connection: "keep-alive",
+    },
+  });
+}

--- a/app/swapmeet/components/ChatPane.tsx
+++ b/app/swapmeet/components/ChatPane.tsx
@@ -1,10 +1,86 @@
 "use client";
 
+import { useEffect, useRef, useState } from "react";
+import { useAuth } from "@/lib/AuthContext";
+
+interface Msg {
+  id: string;
+  user: string;
+  text: string;
+  at: string;
+}
+
 export function ChatPane({ stallId }: { stallId: number }) {
+  const { user } = useAuth();
+  const [msgs, setMsgs] = useState<Msg[]>([]);
+  const [input, setInput] = useState("");
+  const bottomRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const es = new EventSource(`/swapmeet/api/stall/${stallId}/events`);
+    es.onmessage = e => {
+      const data = JSON.parse(e.data);
+      if (data.chat) {
+        setMsgs(prev => [...prev, ...data.chat]);
+      }
+    };
+    return () => es.close();
+  }, [stallId]);
+
+  useEffect(() => {
+    bottomRef.current?.scrollIntoView({ behavior: "smooth" });
+  }, [msgs]);
+
+  async function send() {
+    const txt = input.trim();
+    if (!txt) return;
+    setInput("");
+    await fetch("/swapmeet/api/chat", {
+      method: "POST",
+      body: JSON.stringify({ stallId, text: txt }),
+    });
+  }
+
   return (
-    <div className="p-4 text-center text-sm text-gray-500">
-      Chat coming soon
+    <div className="flex flex-col h-full">
+      <div className="flex-1 overflow-y-auto space-y-1 px-4 py-2">
+        {msgs.map(m => (
+          <p
+            key={m.id}
+            className={
+              m.user === user?.displayName
+                ? "text-right text-[var(--ubz-brand)]"
+                : "text-gray-800"
+            }
+          >
+            <span className="font-medium">{m.user}: </span>
+            {m.text}
+          </p>
+        ))}
+        <div ref={bottomRef} />
+      </div>
+
+      <form
+        onSubmit={e => {
+          e.preventDefault();
+          send();
+        }}
+        className="flex gap-2 border-t p-2"
+      >
+        <input
+          className="flex-1 border rounded px-2 py-1 text-sm"
+          value={input}
+          onChange={e => setInput(e.target.value)}
+          placeholder="Say something…"
+        />
+        <button
+          type="submit"
+          disabled={!input.trim()}
+          className="btn-primary px-3 disabled:opacity-40"
+        >
+          Send
+        </button>
+      </form>
     </div>
   );
 }
-

--- a/lib/models/schema.prisma
+++ b/lib/models/schema.prisma
@@ -61,6 +61,7 @@ model User {
   offers                   Offer[]
   bids                     Bid[]
   orders                   Order[]
+  StallMessage             StallMessage[]
 
   @@map("users")
 }
@@ -123,31 +124,31 @@ model Like {
 }
 
 model FeedPost {
-  id         BigInt         @id @default(autoincrement())
-  created_at DateTime       @default(now()) @db.Timestamptz(6)
-  updated_at DateTime?      @default(now()) @updatedAt @db.Timestamptz(6)
-  author_id  BigInt
-  type       feed_post_type
-  content    String?
-  image_url  String?
-  video_url  String?
-  isPublic   Boolean        @default(true)
-  like_count Int            @default(0)
+  id               BigInt            @id @default(autoincrement())
+  created_at       DateTime          @default(now()) @db.Timestamptz(6)
+  updated_at       DateTime?         @default(now()) @updatedAt @db.Timestamptz(6)
+  author_id        BigInt
+  type             feed_post_type
+  content          String?
+  image_url        String?
+  video_url        String?
+  isPublic         Boolean           @default(true)
+  like_count       Int               @default(0)
   author           User              @relation(fields: [author_id], references: [id])
   predictionMarket PredictionMarket? @relation("FeedPostPrediction")
-  productReview      ProductReview?
-  parent_id          BigInt?
-  pluginData         Json?
-  pluginType         String?
-  feedPost           FeedPost?      @relation("FeedPostChildren", fields: [parent_id], references: [id], onDelete: Restrict)
-  children           FeedPost[]     @relation("FeedPostChildren") 
+  productReview    ProductReview?
+  parent_id        BigInt?
+  pluginData       Json?
+  pluginType       String?
+  feedPost         FeedPost?         @relation("FeedPostChildren", fields: [parent_id], references: [id], onDelete: Restrict)
+  children         FeedPost[]        @relation("FeedPostChildren")
 
   @@index([author_id])
   @@map("feed_posts")
 }
 
 enum feed_post_type {
-TEXT
+  TEXT
   VIDEO
   IMAGE
   LIVESTREAM
@@ -476,8 +477,7 @@ model ProductReview {
   claims           ProductReviewClaim[]
   author           User                 @relation(fields: [author_id], references: [id], onDelete: Cascade)
   realtime_post    RealtimePost?        @relation(fields: [realtime_post_id], references: [id])
-  feed_post      FeedPost?             @relation(fields: [feed_post_id], references: [id])
-
+  feed_post        FeedPost?            @relation(fields: [feed_post_id], references: [id])
 
   @@map("product_reviews")
 }
@@ -786,26 +786,27 @@ model Section {
   stalls     Stall[]
 
   @@unique([x, y])
-  @@map("section")      // 👈 tell Prisma the real table name
+  @@map("section") // 👈 tell Prisma the real table name
 }
 
 model Stall {
-  id         BigInt    @id @default(autoincrement())
-  section_id BigInt?
-  owner_id   BigInt
-  name       String
-  created_at DateTime  @default(now()) @db.Timestamptz(6)
-  updated_at DateTime? @default(now()) @updatedAt @db.Timestamptz(6)
-  section    Section?  @relation(fields: [section_id], references: [id])
-  owner      User      @relation(fields: [owner_id], references: [id])
-  items      Item[]
-  auctions   Auction[]
-  orders     Order[]
-  images     StallImage[]
+  id           BigInt         @id @default(autoincrement())
+  section_id   BigInt?
+  owner_id     BigInt
+  name         String
+  created_at   DateTime       @default(now()) @db.Timestamptz(6)
+  updated_at   DateTime?      @default(now()) @updatedAt @db.Timestamptz(6)
+  section      Section?       @relation(fields: [section_id], references: [id])
+  owner        User           @relation(fields: [owner_id], references: [id])
+  items        Item[]
+  auctions     Auction[]
+  orders       Order[]
+  images       StallImage[]
+  StallMessage StallMessage[]
 
+  @@unique([section_id, owner_id])
   @@index([section_id])
   @@index([owner_id, updated_at])
-  @@unique([section_id, owner_id])
   @@map("stalls")
 }
 
@@ -905,4 +906,17 @@ model OrderLine {
 
   @@index([order_id])
   @@map("order_lines")
+}
+
+model StallMessage {
+  id         BigInt   @id @default(autoincrement())
+  stall_id   BigInt
+  user_id    BigInt
+  text       String
+  created_at DateTime @default(now()) @db.Timestamptz(6)
+  stall      Stall    @relation(fields: [stall_id], references: [id])
+  user       User     @relation(fields: [user_id], references: [id])
+
+  @@index([stall_id])
+  @@map("stall_messages")
 }


### PR DESCRIPTION
## Summary
- implement ChatPane component for real-time chatting
- add POST `/swapmeet/api/chat` API to create messages
- create SSE `/swapmeet/api/stall/[id]/events` route serving viewers and chat updates
- extend Prisma schema with `StallMessage` model

## Testing
- `yarn lint`

------
https://chatgpt.com/codex/tasks/task_e_68884fd554d48329bc8ea8237c4381b9