### PR TITLE
Implement cart escrow

### DIFF
--- a/app/api/cart/add/route.ts
+++ b/app/api/cart/add/route.ts
@@ -1,10 +1,16 @@
 import { getUserFromCookies } from "@/lib/serverutils";
-import { addToCart } from "@/lib/actions/cart.server";
+import { addOfferToCart } from "@/lib/actions/offerCart.server";
 
 export async function POST(req: Request) {
   const user = await getUserFromCookies();
   if (!user) return new Response("Auth", { status: 401 });
-  const { itemId, qty = 1 } = await req.json();
-  await addToCart(user.userId, BigInt(itemId), qty);
+  const { offerId, deadline } = await req.json();
+  if (!offerId || !deadline)
+    return new Response("Missing fields", { status: 400 });
+  await addOfferToCart(
+    user.userId,
+    BigInt(offerId),
+    new Date(deadline)
+  );
   return new Response("ok");
 }

--- a/app/api/cart/checkout/route.ts
+++ b/app/api/cart/checkout/route.ts
@@ -1,0 +1,11 @@
+import { getUserFromCookies } from "@/lib/serverutils";
+import { createEscrow } from "@/lib/actions/offerCart.server";
+
+export async function POST(req: Request) {
+  const user = await getUserFromCookies();
+  if (!user) return new Response("Auth", { status: 401 });
+  const { cartId, txRef } = await req.json();
+  if (!cartId || !txRef) return new Response("Missing", { status: 400 });
+  const escrow = await createEscrow(BigInt(cartId), txRef);
+  return Response.json(escrow);
+}

--- a/app/api/cart/expire/route.ts
+++ b/app/api/cart/expire/route.ts
@@ -1,0 +1,11 @@
+import { prisma } from "@/lib/prismaclient";
+
+export async function POST() {
+  const expired = await prisma.cart.deleteMany({
+    where: {
+      deadline: { lt: new Date() },
+      escrow: { none: {} },
+    },
+  });
+  return Response.json(expired);
+}

--- a/app/api/cart/release/route.ts
+++ b/app/api/cart/release/route.ts
@@ -1,0 +1,11 @@
+import { getUserFromCookies } from "@/lib/serverutils";
+import { releaseEscrow } from "@/lib/actions/offerCart.server";
+
+export async function POST(req: Request) {
+  const user = await getUserFromCookies();
+  if (!user) return new Response("Auth", { status: 401 });
+  const { cartId } = await req.json();
+  if (!cartId) return new Response("Missing", { status: 400 });
+  const esc = await releaseEscrow(BigInt(cartId));
+  return Response.json(esc);
+}

--- a/app/api/cart/view/route.ts
+++ b/app/api/cart/view/route.ts
@@ -1,0 +1,10 @@
+import { getUserFromCookies } from "@/lib/serverutils";
+import { viewCart } from "@/lib/actions/offerCart.server";
+import { jsonSafe } from "@/lib/bigintjson";
+
+export async function GET() {
+  const user = await getUserFromCookies();
+  if (!user) return new Response("Auth", { status: 401 });
+  const rows = await viewCart(user.userId);
+  return Response.json(jsonSafe(rows), { headers: { "Cache-Control": "no-store" } });
+}

--- a/lib/actions/offerCart.server.ts
+++ b/lib/actions/offerCart.server.ts
@@ -1,0 +1,38 @@
+"use server";
+
+import { prisma } from "@/lib/prismaclient";
+
+export async function addOfferToCart(userId: bigint, offerId: bigint, deadline: Date) {
+  await prisma.cart.upsert({
+    where: { offer_id: offerId },
+    update: { deadline },
+    create: { user_id: userId, offer_id: offerId, deadline },
+  });
+}
+
+export async function viewCart(userId: bigint) {
+  return prisma.cart.findMany({
+    where: { user_id: userId },
+    orderBy: { added_at: "desc" },
+    select: {
+      id: true,
+      deadline: true,
+      offer: {
+        select: { id: true, price_cents: true, item: { select: { id: true, name: true } } },
+      },
+    },
+  });
+}
+
+export async function createEscrow(cartId: bigint, txRef: string) {
+  return prisma.escrow.create({
+    data: { cart_id: cartId, state: "HELD", tx_ref: txRef },
+  });
+}
+
+export async function releaseEscrow(cartId: bigint) {
+  return prisma.escrow.update({
+    where: { cart_id: cartId },
+    data: { state: "RELEASED" },
+  });
+}

--- a/lib/models/migrations/20251101000000_add_cart_escrow.sql
+++ b/lib/models/migrations/20251101000000_add_cart_escrow.sql
@@ -1,0 +1,20 @@
+CREATE TYPE "escrow_state" AS ENUM ('PENDING', 'HELD', 'RELEASED', 'REFUNDED');
+
+CREATE TABLE "cart" (
+  "id" BIGSERIAL PRIMARY KEY,
+  "user_id" BIGINT NOT NULL REFERENCES "users"("id"),
+  "offer_id" BIGINT NOT NULL UNIQUE REFERENCES "offers"("id"),
+  "added_at" TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  "deadline" TIMESTAMPTZ NOT NULL
+);
+
+CREATE INDEX "idx_cart_user" ON "cart"("user_id");
+
+CREATE TABLE "escrow" (
+  "id" BIGSERIAL PRIMARY KEY,
+  "cart_id" BIGINT NOT NULL UNIQUE REFERENCES "cart"("id"),
+  "state" "escrow_state" NOT NULL DEFAULT 'PENDING',
+  "tx_ref" TEXT,
+  "created_at" TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  "updated_at" TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);

--- a/lib/models/schema.prisma
+++ b/lib/models/schema.prisma
@@ -62,6 +62,7 @@ model User {
   bids                     Bid[]
   orders                   Order[]
   cartItems               CartItem[]
+  carts                    Cart[]
 
   @@map("users")
 }
@@ -920,4 +921,36 @@ model CartItem {
 
   @@unique([user_id, item_id])
   @@map("cart_items")
+}
+
+enum escrow_state {
+  PENDING
+  HELD
+  RELEASED
+  REFUNDED
+}
+
+model Cart {
+  id        BigInt   @id @default(autoincrement())
+  user_id   BigInt
+  offer_id  BigInt   @unique
+  added_at  DateTime @default(now()) @db.Timestamptz(6)
+  deadline  DateTime @db.Timestamptz(6)
+  offer     Offer    @relation(fields: [offer_id], references: [id])
+  user      User     @relation(fields: [user_id], references: [id])
+
+  @@index([user_id])
+  @@map("cart")
+}
+
+model Escrow {
+  id         BigInt       @id @default(autoincrement())
+  cart_id    BigInt       @unique
+  state      escrow_state @default(PENDING)
+  tx_ref     String?
+  created_at DateTime     @default(now()) @db.Timestamptz(6)
+  updated_at DateTime     @updatedAt @db.Timestamptz(6)
+  cart       Cart         @relation(fields: [cart_id], references: [id])
+
+  @@map("escrow")
 }


### PR DESCRIPTION
## Summary
- add new `Cart` and `Escrow` models with `escrow_state` enum
- support offer-based cart actions and endpoints
- migration for new tables

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_688854305f248329b5deefcd76bc0990