### PR TITLE
Add flash auction, party presence, heatmap

### DIFF
--- a/app/api/auction/[id]/events/route.ts
+++ b/app/api/auction/[id]/events/route.ts
@@ -1,0 +1,49 @@
+import { prisma } from "@/lib/prismaclient";
+export const runtime = "edge";
+
+export async function GET(
+  _req: Request,
+  { params }: { params: { id: string } },
+) {
+  const auctionId = BigInt(params.id);
+
+  const stream = new ReadableStream({
+    async start(controller) {
+      let lastBid = 0n;
+      const tick = setInterval(async () => {
+        const a = await prisma.auction.findUnique({
+          where: { id: auctionId },
+          include: { bids: { where: { id: { gt: lastBid } }, include: { bidder: true }, orderBy: { id: "asc" } } },
+        });
+        if (!a) return;
+        if (a.state === "CLOSED" || Date.now() > a.ends_at.getTime()) {
+          controller.enqueue(`data: ${JSON.stringify({ state: "CLOSED" })}\n\n`);
+          clearInterval(tick);
+          controller.close();
+          return;
+        }
+
+        const remaining = a.ends_at.getTime() - Date.now();
+        controller.enqueue(`data: ${JSON.stringify({ remainingMs: remaining })}\n\n`);
+
+        if (a.bids.length) {
+          lastBid = a.bids[a.bids.length - 1].id;
+          controller.enqueue(`data: ${JSON.stringify({ bids: a.bids.map(b => ({
+            id: b.id.toString(),
+            user: b.bidder.name,
+            amount: b.amount_cents,
+          })) })}\n\n`);
+        }
+      }, 2000);
+    },
+  });
+
+  return new Response(stream, {
+    headers: {
+      "Content-Type": "text/event-stream",
+      "Cache-Control": "no-store",
+      "Connection": "keep-alive",
+      "X-Accel-Buffering": "no",
+    },
+  });
+}

--- a/app/api/auction/[id]/route.ts
+++ b/app/api/auction/[id]/route.ts
@@ -1,0 +1,16 @@
+import { prisma } from "@/lib/prismaclient";
+import { jsonSafe } from "@/lib/bigintjson";
+
+export async function GET(
+  _req: Request,
+  { params }: { params: { id: string } },
+) {
+  const id = Number(params.id);
+  const a = await prisma.auction.findUnique({
+    where: { id: BigInt(id) },
+    include: {
+      bids: { orderBy: { amount_cents: "desc" }, take: 10, include: { bidder: { select: { name: true } } } },
+    },
+  });
+  return Response.json(jsonSafe(a), { headers: { "Cache-Control": "no-store" } });
+}

--- a/app/api/auction/bid/route.ts
+++ b/app/api/auction/bid/route.ts
@@ -1,0 +1,11 @@
+import { getUserFromCookies } from "@/lib/serverutils";
+import { placeBid } from "@/lib/actions/auction.server";
+
+export async function POST(req: Request) {
+  const user = await getUserFromCookies();
+  if (!user) return new Response("auth", { status: 401 });
+
+  const { auctionId, amountCents } = await req.json();
+  await placeBid(auctionId, user.userId, amountCents);
+  return new Response("ok");
+}

--- a/app/api/auction/create/route.ts
+++ b/app/api/auction/create/route.ts
@@ -1,0 +1,11 @@
+import { getUserFromCookies } from "@/lib/serverutils";
+import { createAuction } from "@/lib/actions/auction.server";
+
+export async function POST(req: Request) {
+  const user = await getUserFromCookies();
+  if (!user) return new Response("auth", { status: 401 });
+
+  const { stallId, itemId, reserveCents, minutes } = await req.json();
+  const a = await createAuction(stallId, itemId, reserveCents, minutes);
+  return Response.json({ id: a.id });
+}

--- a/app/api/party/[id]/events/route.ts
+++ b/app/api/party/[id]/events/route.ts
@@ -1,0 +1,26 @@
+import { prisma } from "@/lib/prismaclient";
+export const runtime = "edge";
+
+export async function GET(_req: Request, { params }: { params: { id: string } }) {
+  const partyId = params.id;
+  const stream = new ReadableStream({
+    async start(controller) {
+      const tick = setInterval(async () => {
+        const rows = await prisma.partyPresence.findMany({
+          where: { party_id: partyId },
+        });
+        controller.enqueue(
+          `data: ${JSON.stringify({ cursors: rows.map(r => ({ userId: r.user_id.toString(), x: r.x, y: r.y })) })}\n\n`
+        );
+      }, 1000);
+    },
+  });
+
+  return new Response(stream, {
+    headers: {
+      "Content-Type": "text/event-stream",
+      "Cache-Control": "no-store",
+      Connection: "keep-alive",
+    },
+  });
+}

--- a/app/api/party/join/route.ts
+++ b/app/api/party/join/route.ts
@@ -1,0 +1,19 @@
+import { prisma } from "@/lib/prismaclient";
+import { getUserFromCookies } from "@/lib/serverutils";
+
+export async function POST(req: Request) {
+  const user = await getUserFromCookies();
+  if (!user) return new Response("auth", { status: 401 });
+  const { partyId, x, y } = await req.json();
+  await prisma.partyPresence.upsert({
+    where: { id: `${partyId}-${user.userId}` }, // composite id trick
+    update: { x, y },
+    create: {
+      id: `${partyId}-${user.userId}`,
+      party_id: partyId,
+      user_id: user.userId,
+      x, y,
+    },
+  });
+  return new Response("ok");
+}

--- a/app/api/party/leave/route.ts
+++ b/app/api/party/leave/route.ts
@@ -1,0 +1,10 @@
+import { prisma } from "@/lib/prismaclient";
+import { getUserFromCookies } from "@/lib/serverutils";
+
+export async function POST(req: Request) {
+  const user = await getUserFromCookies();
+  if (!user) return new Response("auth", { status: 401 });
+  const { partyId } = await req.json();
+  await prisma.partyPresence.delete({ where: { id: `${partyId}-${user.userId}` } }).catch(() => {});
+  return new Response("ok");
+}

--- a/app/api/stall/[id]/heat/route.ts
+++ b/app/api/stall/[id]/heat/route.ts
@@ -1,0 +1,9 @@
+import { prisma } from "@/lib/prismaclient";
+export async function GET(_req:Request,{params}:{params:{id:string}}){
+  const rows=await prisma.stallHeat.findMany({
+    where:{ stall_id: BigInt(params.id) }
+  });
+  const arr=Array(9).fill(0);
+  rows.forEach(r=>arr[r.cell]=r.views);
+  return Response.json(arr,{headers:{"Cache-Control":"no-store"}});
+}

--- a/app/api/track/route.ts
+++ b/app/api/track/route.ts
@@ -1,0 +1,11 @@
+import { prisma } from "@/lib/prismaclient";
+
+export async function POST(req: Request) {
+  const { stallId, cell } = await req.json();
+  await prisma.stallHeat.upsert({
+    where: { stall_id_cell: { stall_id: BigInt(stallId), cell } },
+    update: { views: { increment: 1 } },
+    create: { stall_id: BigInt(stallId), cell, views: 1 },
+  });
+  return new Response("ok");
+}

--- a/app/swapmeet/api/items/route.ts
+++ b/app/swapmeet/api/items/route.ts
@@ -9,7 +9,14 @@ export async function GET(req: Request) {
     ? []
     : await prisma.item.findMany({
         where: { stall_id: BigInt(stall) },
-        select: { id: true, name: true, price_cents: true },
+        select: {
+          id: true,
+          name: true,
+          price_cents: true,
+          auction: {
+            select: { id: true, reserve_cents: true, ends_at: true },
+          },
+        },
       });
   return NextResponse.json(jsonSafe(items), {
     headers: { "Cache-Control": "no-store" },

--- a/app/swapmeet/components/AuctionBar.tsx
+++ b/app/swapmeet/components/AuctionBar.tsx
@@ -1,0 +1,68 @@
+"use client";
+import { useEffect, useState } from "react";
+import { motion } from "framer-motion";
+
+export default function AuctionBar({ auctionId, reserve, endsAt }: {
+  auctionId: number; reserve: number; endsAt: string;
+}) {
+  const [remaining, setRemaining] = useState(
+    new Date(endsAt).getTime() - Date.now(),
+  );
+  const [bids, setBids] = useState<{ user: string; amount: number }[]>([]);
+
+  useEffect(() => {
+    const es = new EventSource(`/api/auction/${auctionId}/events`);
+    es.onmessage = (e) => {
+      const data = JSON.parse(e.data);
+      if (data.remainingMs !== undefined) setRemaining(data.remainingMs);
+      if (data.bids) setBids((prev) => [...prev, ...data.bids]);
+    };
+    return () => es.close();
+  }, [auctionId]);
+
+  const total = new Date(endsAt).getTime() - (Date.now() - remaining);
+  const pct = Math.max(0, remaining / total);
+
+  return (
+    <div className="space-y-2">
+      <motion.div
+        className="h-2 rounded bg-green-500 origin-left"
+        style={{ scaleX: pct }}
+        transition={{ ease: "linear", duration: 0.2 }}
+      />
+      <p className="text-sm">
+        {Math.ceil(remaining / 1000)} s left – highest bid $
+        {(Math.max(reserve, ...bids.map((b) => b.amount)) / 100).toFixed(2)}
+      </p>
+
+      <ul className="text-xs max-h-24 overflow-y-auto">
+        {bids.map((b) => (
+          <li key={b.amount + b.user}>
+            {b.user}: ${(b.amount / 100).toFixed(2)}
+          </li>
+        ))}
+      </ul>
+      <form
+        onSubmit={async (e) => {
+          e.preventDefault();
+          const amt = Number((e.target as any).bid.value) * 100;
+          await fetch("/api/auction/bid", {
+            method: "POST",
+            body: JSON.stringify({ auctionId, amountCents: amt }),
+          });
+          (e.target as any).bid.value = "";
+        }}
+        className="flex gap-2"
+      >
+        <input
+          name="bid"
+          type="number"
+          step="0.01"
+          placeholder="Your bid"
+          className="border px-2 py-1 flex-1"
+        />
+        <button className="btn-primary px-3">Bid</button>
+      </form>
+    </div>
+  );
+}

--- a/app/swapmeet/components/ItemsPane.tsx
+++ b/app/swapmeet/components/ItemsPane.tsx
@@ -2,6 +2,7 @@
 
 import useSWR from "swr";
 import { Skeleton } from "@/components/ui/skeleton";
+import AuctionBar from "./AuctionBar";
 
 const fetcher = (u: string) => fetch(u).then(r => r.json());
 
@@ -19,8 +20,18 @@ export function ItemsPane({ stallId }: { stallId: number }) {
       ))}
       {data.map((item: any) => (
         <div key={item.id ?? item.name} className="flex justify-between">
-          <span>{item.name}</span>
-          <span>${(item.price_cents / 100).toFixed(2)}</span>
+          {item.auction ? (
+            <AuctionBar
+              auctionId={item.auction.id}
+              reserve={item.auction.reserve_cents}
+              endsAt={item.auction.ends_at}
+            />
+          ) : (
+            <>
+              <span>{item.name}</span>
+              <span>${(item.price_cents / 100).toFixed(2)}</span>
+            </>
+          )}
         </div>
       ))}
     </div>

--- a/app/swapmeet/components/TrackGrid.tsx
+++ b/app/swapmeet/components/TrackGrid.tsx
@@ -1,0 +1,40 @@
+"use client";
+import { useCallback, useRef } from "react";
+
+export default function TrackGrid({ stallId, items }: { stallId: number; items: any[] }) {
+  const lastJoin = useRef(0);
+  const sendJoin = useCallback((x:number,y:number)=>{
+    const now=Date.now();
+    if(now-lastJoin.current<400) return;
+    lastJoin.current=now;
+    fetch("/api/party/join",{method:"POST",body:JSON.stringify({partyId:`stall-${stallId}`,x,y})});
+  },[stallId]);
+  const enter = useCallback((idx: number) => {
+    setTimeout(() => fetch("/api/track", {
+      method: "POST",
+      body: JSON.stringify({ stallId, cell: idx }),
+    }), 500);
+  }, [stallId]);
+
+  return (
+    <ul
+      className="grid grid-cols-3 gap-2"
+      onPointerMove={(e)=>{
+        const rect=(e.currentTarget as HTMLElement).getBoundingClientRect();
+        const x=((e.clientX-rect.left)/rect.width)*100;
+        const y=((e.clientY-rect.top)/rect.height)*100;
+        sendJoin(Math.round(x),Math.round(y));
+      }}
+    >
+      {Array.from({ length: 9 }).map((_, i) => (
+        <li
+          key={i}
+          onMouseEnter={() => enter(i)}
+          className="border aspect-square flex items-center justify-center"
+        >
+          {items[i] ? items[i].name : null}
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/app/swapmeet/stall/[id]/page.tsx
+++ b/app/swapmeet/stall/[id]/page.tsx
@@ -1,4 +1,20 @@
-export default function Page() {
-    return <div>SwapMeet coming soon</div>;
-  }
-  
+import HeatWidget from "@/components/HeatWidget";
+import PartyOverlay from "@/components/PartyOverlay";
+import TrackGrid from "@/app/swapmeet/components/TrackGrid";
+import { getStall } from "@/lib/actions/stall.server";
+
+export default async function Page({ params }: { params: { id: string } }) {
+  const stallId = Number(params.id);
+  const stall = await getStall(stallId);
+  if (!stall) return <div>Not found</div>;
+  const items = stall.items as any[];
+  return (
+    <div className="relative p-4">
+      <TrackGrid stallId={stallId} items={items} />
+      <PartyOverlay partyId={`stall-${stallId}`} />
+      <div className="mt-4">
+        <HeatWidget stallId={stallId} />
+      </div>
+    </div>
+  );
+}

--- a/components/HeatWidget.tsx
+++ b/components/HeatWidget.tsx
@@ -1,0 +1,11 @@
+import { Bar } from "react-chartjs-2";
+import useSWR from "swr";
+export default function HeatWidget({ stallId }:{ stallId:number }){
+  const { data=[] } = useSWR(`/api/stall/${stallId}/heat`, (u)=>fetch(u).then(r=>r.json()), { refreshInterval: 10_000 });
+  return (
+    <Bar data={{
+      labels:["↖","↑","↗","←","•","→","↙","↓","↘"],
+      datasets:[{ data, backgroundColor:"rgba(34,99,255,.6)" }],
+    }} options={{ plugins:{legend:{display:false}}, scales:{y:{display:false}} }} />
+  );
+}

--- a/components/PartyOverlay.tsx
+++ b/components/PartyOverlay.tsx
@@ -1,0 +1,20 @@
+import { usePartyPresence } from "@/lib/hooks/usePartyPresence";
+
+export default function PartyOverlay({ partyId }: { partyId: string }) {
+  const curs = usePartyPresence(partyId);
+  return (
+    <>
+      {curs.map((c) => (
+        <div
+          key={c.userId}
+          className="absolute w-4 h-4 rounded-full pointer-events-none"
+          style={{
+            left: `${c.x}%`,
+            top: `${c.y}%`,
+            backgroundColor: `hsl(${BigInt(c.userId) % 360n}deg 70% 50%)`,
+          }}
+        />
+      ))}
+    </>
+  );
+}

--- a/lib/actions/auction.server.ts
+++ b/lib/actions/auction.server.ts
@@ -1,0 +1,43 @@
+import { prisma } from "@/lib/prismaclient";
+
+export async function createAuction(
+  stallId: number,
+  itemId: number,
+  reserve: number,
+  minutes = 30,
+) {
+  const ends = new Date(Date.now() + minutes * 60_000);
+  return prisma.auction.create({
+    data: {
+      stall_id: BigInt(stallId),
+      item_id: BigInt(itemId),
+      reserve_cents: reserve,
+      ends_at: ends,
+    },
+  });
+}
+
+export async function placeBid(
+  auctionId: number,
+  userId: number,
+  amount: number,
+) {
+  const a = await prisma.auction.findUnique({
+    where: { id: BigInt(auctionId) },
+    include: { bids: true },
+  });
+  if (!a || a.state !== "LIVE" || Date.now() > a.ends_at.getTime())
+    throw new Error("closed");
+  const highest = Math.max(
+    a.reserve_cents,
+    ...a.bids.map((b) => b.amount_cents),
+  );
+  if (amount <= highest) throw new Error("too low");
+  return prisma.bid.create({
+    data: {
+      auction_id: BigInt(auctionId),
+      bidder_id: BigInt(userId),
+      amount_cents: amount,
+    },
+  });
+}

--- a/lib/hooks/usePartyPresence.ts
+++ b/lib/hooks/usePartyPresence.ts
@@ -1,0 +1,14 @@
+"use client";
+import { useEffect, useState } from "react";
+
+export function usePartyPresence(partyId: string) {
+  const [cursors, setCursors] = useState<
+    { userId: string; x: number; y: number }[]
+  >([]);
+  useEffect(() => {
+    const es = new EventSource(`/api/party/${partyId}/events`);
+    es.onmessage = (e) => setCursors(JSON.parse(e.data).cursors);
+    return () => es.close();
+  }, [partyId]);
+  return cursors;
+}

--- a/lib/models/schema.prisma
+++ b/lib/models/schema.prisma
@@ -862,6 +862,8 @@ model Auction {
   stall_id      BigInt
   reserve_cents Int
   ends_at       DateTime
+  state         auction_state @default(LIVE)
+  winner_id     BigInt?
   created_at    DateTime @default(now()) @db.Timestamptz(6)
   item          Item     @relation(fields: [item_id], references: [id])
   stall         Stall    @relation(fields: [stall_id], references: [id])
@@ -882,6 +884,11 @@ model Bid {
 
   @@index([auction_id])
   @@map("bids")
+}
+
+enum auction_state {
+  LIVE
+  CLOSED
 }
 
 model Order {
@@ -972,4 +979,26 @@ model Escrow {
   cart       Cart         @relation("CartEscrow", fields: [cart_id], references: [id])
 
   @@map("escrow")
+}
+
+model PartyPresence {
+  id         String   @id @default(cuid())
+  party_id   String
+  user_id    BigInt
+  x          Int
+  y          Int
+  updated_at DateTime @default(now()) @updatedAt @db.Timestamptz(6)
+
+  @@index([party_id])
+  @@map("party_presence")
+}
+
+model StallHeat {
+  id       BigInt   @id @default(autoincrement())
+  stall_id BigInt
+  cell     Int
+  views    Int
+
+  @@unique([stall_id, cell], name: "stall_id_cell")
+  @@map("stall_heat")
 }


### PR DESCRIPTION
## Summary
- extend Prisma schema with auction_state, PartyPresence, StallHeat
- add API routes for auctions, party presence and stall heat tracking
- stream auction and presence data via SSE
- add React components AuctionBar, HeatWidget, PartyOverlay
- update swapmeet pages to use new components and tracking

## Testing
- `npm run lint`
- `npx prisma validate`


------
https://chatgpt.com/codex/tasks/task_e_68885e2373588329b91b55621833aabb