### PR TITLE
Add CreateAuctionDialog

### DIFF
--- a/app/api/auction/create/route.ts
+++ b/app/api/auction/create/route.ts
@@ -1,11 +1,29 @@
 import { getUserFromCookies } from "@/lib/serverutils";
 import { createAuction } from "@/lib/actions/auction.server";
+import { prisma } from "@/lib/prismaclient";
 
 export async function POST(req: Request) {
   const user = await getUserFromCookies();
   if (!user) return new Response("auth", { status: 401 });
 
   const { stallId, itemId, reserveCents, minutes } = await req.json();
+  const item = await prisma.item.findUnique({
+    where: { id: BigInt(itemId) },
+    select: {
+      stall_id: true,
+      auction: { select: { id: true } },
+      stall: { select: { owner_id: true } },
+    },
+  });
+  if (
+    !item ||
+    Number(item.stall_id) !== Number(stallId) ||
+    item.auction ||
+    Number(item.stall.owner_id) !== Number(user.userId)
+  ) {
+    return new Response("forbidden", { status: 403 });
+  }
+
   const a = await createAuction(stallId, itemId, reserveCents, minutes);
   return Response.json({ id: a.id });
 }

--- a/app/swapmeet/components/CreateAuctionDialog.tsx
+++ b/app/swapmeet/components/CreateAuctionDialog.tsx
@@ -1,0 +1,53 @@
+"use client";
+
+import { Dialog, DialogContent, DialogTrigger } from "@/components/ui/dialog";
+import { useState } from "react";
+import { mutate } from "swr";
+
+export default function CreateAuctionDialog({ stallId, itemId }: { stallId: number; itemId: number; }) {
+  const [open, setOpen] = useState(false);
+
+  const submit = async (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    const form = new FormData(e.currentTarget);
+    await fetch("/api/auction/create", {
+      method: "POST",
+      body: JSON.stringify({
+        stallId,
+        itemId,
+        reserveCents: +form.get("reserve")! * 100,
+        minutes: +form.get("minutes")!,
+      }),
+    });
+    setOpen(false);
+    mutate(`/swapmeet/api/items?stall=${stallId}`);
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger asChild>
+        <button className="btn-secondary w-full">Start auction</button>
+      </DialogTrigger>
+      <DialogContent>
+        <form onSubmit={submit} className="space-y-3">
+          <input
+            name="reserve"
+            type="number"
+            step="0.01"
+            placeholder="Reserve price"
+            className="border px-2 py-1 w-full"
+          />
+          <input
+            name="minutes"
+            type="number"
+            step="1"
+            min="1"
+            placeholder="Duration (min)"
+            className="border px-2 py-1 w-full"
+          />
+          <button className="btn-primary w-full">Create</button>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/app/swapmeet/components/ItemsPane.tsx
+++ b/app/swapmeet/components/ItemsPane.tsx
@@ -3,10 +3,11 @@
 import useSWR from "swr";
 import { Skeleton } from "@/components/ui/skeleton";
 import AuctionBar from "./AuctionBar";
+import CreateAuctionDialog from "./CreateAuctionDialog";
 
 const fetcher = (u: string) => fetch(u).then(r => r.json());
 
-export function ItemsPane({ stallId }: { stallId: number }) {
+export function ItemsPane({ stallId, isOwner = false }: { stallId: number; isOwner?: boolean }) {
   const { data = [{ name: "Mock item", price_cents: 10 }], isLoading } = useSWR(
     stallId ? `/swapmeet/api/items?stall=${stallId}` : null,
     fetcher,
@@ -26,6 +27,8 @@ export function ItemsPane({ stallId }: { stallId: number }) {
               reserve={item.auction.reserve_cents}
               endsAt={item.auction.ends_at}
             />
+          ) : isOwner ? (
+            <CreateAuctionDialog stallId={stallId} itemId={item.id} />
           ) : (
             <>
               <span>{item.name}</span>

--- a/app/swapmeet/components/StallSheet.tsx
+++ b/app/swapmeet/components/StallSheet.tsx
@@ -6,6 +6,7 @@ import { VideoPane } from "./VideoPane";
 import { ItemsPane } from "./ItemsPane";
 import { ChatPane } from "./ChatPane";
 import Link from "next/link";
+import { useAuth } from "@/lib/AuthContext";
 
 const fetcher = (url: string) => fetch(url).then(r => r.json());
 
@@ -21,7 +22,10 @@ export function StallSheet({ stallId, open, onOpenChange }: Props) {
     open ? `/swapmeet/api/stall/${stallId}` : null,
     fetcher
   );
+  const { user } = useAuth();
   const liveSrc = stall && "liveSrc" in stall ? (stall as any).liveSrc : undefined;
+  const isOwner =
+    !!user && !!stall && "owner" in stall && Number((stall as any).owner?.id) === Number(user.userId);
 
   return (
     <Sheet open={open} onOpenChange={onOpenChange}>
@@ -44,7 +48,7 @@ export function StallSheet({ stallId, open, onOpenChange }: Props) {
           View full stall →
         </Link>
         <VideoPane src={liveSrc} open={open} />
-        <ItemsPane stallId={stallId} />
+        <ItemsPane stallId={stallId} isOwner={Boolean(isOwner)} />
         <ChatPane stallId={stallId} />
       </SheetContent>
     </Sheet>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,0 +1,4 @@
+# Changelog
+
+## Unreleased
+- Add CreateAuctionDialog component and item owner check.

--- a/lib/actions/stall.server.ts
+++ b/lib/actions/stall.server.ts
@@ -5,7 +5,7 @@ export async function getStall(id: number) {
     where: { id: BigInt(id) },
     include: {
       items: { select: { id: true, name: true, price_cents: true } },
-      owner: { select: { name: true, image: true } },
+      owner: { select: { id: true, name: true, image: true } },
     },
   });
 }


### PR DESCRIPTION
## Summary
- add seller-side CreateAuctionDialog component
- show dialog in ItemsPane for stall owners
- check ownership in auction create route
- expose owner id from getStall
- document change in changelog

## Testing
- `npm run lint`
- `npm test` *(fails: index.query is not a function, getOrSet is not defined, unsupported redis commands)*

------
https://chatgpt.com/codex/tasks/task_e_68887565b4d88329a69db930743ee6de