### PR TITLE
Add closedAt support for prediction markets

### DIFF
--- a/app/api/market/[id]/route.ts
+++ b/app/api/market/[id]/route.ts
@@ -2,6 +2,8 @@ import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/lib/prismaclient";
 import { serializeBigInt } from "@/lib/utils";
 
+export const revalidate = 60;
+
 export async function GET(
   req: NextRequest,
   { params }: { params: { id: string } }
@@ -11,5 +13,7 @@ export async function GET(
     include: { trades: true },
   });
   if (!market) return NextResponse.json({ message: "Not found" }, { status: 404 });
-  return NextResponse.json(serializeBigInt(market));
+  return NextResponse.json(serializeBigInt(market), {
+    headers: { "Cache-Control": "public, max-age=60" },
+  });
 }

--- a/database/migrations/20261013000000_add_market_closed_at.sql
+++ b/database/migrations/20261013000000_add_market_closed_at.sql
@@ -1,0 +1,3 @@
+-- Add closedAt column to prediction_markets
+ALTER TABLE prediction_markets
+  ADD COLUMN IF NOT EXISTS closed_at TIMESTAMPTZ;

--- a/lib/actions/prediction.actions.ts
+++ b/lib/actions/prediction.actions.ts
@@ -132,6 +132,9 @@ export async function resolveMarket({ marketId, outcome }:{ marketId:string; out
   if (market.creatorId !== user.userId && market.oracleId !== user.userId) {
     throw new Error("Not authorized");
   }
+  if (market.state !== "CLOSED") {
+    throw new Error("Market not closed");
+  }
   if (market.state === "RESOLVED") {
     throw new Error("Already resolved");
   }

--- a/lib/models/schema.prisma
+++ b/lib/models/schema.prisma
@@ -664,6 +664,7 @@ model PredictionMarket {
   postId     BigInt          @unique
   question   String          @db.VarChar(140)
   closesAt   DateTime
+  closedAt   DateTime?
   resolvesAt DateTime?
   state      PredictionState @default(OPEN)
   outcome    MarketOutcome?

--- a/scripts/closeMarkets.ts
+++ b/scripts/closeMarkets.ts
@@ -2,18 +2,10 @@ import { prisma } from "@/lib/prismaclient";
 
 async function main() {
   const now = new Date();
-  const markets = await prisma.predictionMarket.findMany({
-    where: {
-      closesAt: { lt: now },
-      state: "OPEN",
-    },
+  await prisma.predictionMarket.updateMany({
+    where: { closesAt: { lt: now }, state: "OPEN" },
+    data: { state: "CLOSED", closedAt: now },
   });
-  for (const market of markets) {
-    await prisma.predictionMarket.update({
-      where: { id: market.id },
-      data: { state: "CLOSED" },
-    });
-  }
 }
 
 main()

--- a/supabase/migrations/20261013000000_add_market_closed_at.sql
+++ b/supabase/migrations/20261013000000_add_market_closed_at.sql
@@ -1,0 +1,3 @@
+-- Add closedAt column to prediction_markets
+ALTER TABLE prediction_markets
+  ADD COLUMN IF NOT EXISTS "closedAt" TIMESTAMPTZ;


### PR DESCRIPTION
## Summary
- extend `PredictionMarket` with `closedAt` timestamp
- mark auto-closed markets with `closedAt`
- require markets be closed before resolving
- cache GET `/api/market/[id]` responses for 60s
- add migrations for new column

## Testing
- `npm run lint`
- `npm test` *(fails: explain_api.test.ts, friend-suggestions.test.ts, feature_store.test.ts, discovery-candidates.integration.test.ts, explain_integration.test.ts, spotify.test.ts, favorites_builder.test.ts, embed_worker.integration.test.ts, pivotGenerator.test.ts)*

------
https://chatgpt.com/codex/tasks/task_e_688a804621148329a1752fbc4f0b9c6a