### PR TITLE
Add caption support for images and galleries

### DIFF
--- a/app/(root)/(realtime)/post/[id]/page.tsx
+++ b/app/(root)/(realtime)/post/[id]/page.tsx
@@ -42,6 +42,7 @@ const Page = async ({ params }: { params: { id: string } }) => {
               ? post.image_url!
               : undefined
           }
+          caption={(post as any).caption ?? null}
           video_url={post.type === "VIDEO" ? post.video_url! : undefined}
           pluginType={(post as any).pluginType ?? null}
           pluginData={(post as any).pluginData ?? null}

--- a/components/cards/GalleryCarousel.tsx
+++ b/components/cards/GalleryCarousel.tsx
@@ -10,9 +10,10 @@ import ViewImageModal from "../modals/ViewImageModal";
 
 interface Props {
   urls: string[];
+  caption?: string;
 }
 
-const GalleryCarousel = ({ urls }: Props) => {
+const GalleryCarousel = ({ urls, caption }: Props) => {
   const [currentIndex, setCurrentIndex] = useState(0);
   const [loaded, setLoaded] = useState(false);
   const [open,   setOpen]   = useState(false);
@@ -99,7 +100,7 @@ const GalleryCarousel = ({ urls }: Props) => {
     </div>
     <div className="mt-4 w-full justify-center items-center  w-full ">
     <hr className="w-full h-px border-t-0 bg-transparent bg-gradient-to-r from-transparent via-slate-100 to-transparent opacity-55" />
-    <p className="text-center tracking-wide mb-0 pt-3">hello</p>
+    <p className="text-center tracking-wide mb-0 pt-3">{caption}</p>
     </div>
     </div>
   );

--- a/components/cards/ImageCard.tsx
+++ b/components/cards/ImageCard.tsx
@@ -10,9 +10,10 @@ import ViewImageModal from "../modals/ViewImageModal";
 interface Props {
   id: bigint;           // keeping it in case you later support “edit”
   imageurl: string;
+  caption?: string;
 }
 
-export default function ImageCard({ id, imageurl }: Props) {
+export default function ImageCard({ id, imageurl, caption }: Props) {
   const [loaded, setLoaded] = useState(false);
   const [open,   setOpen]   = useState(false);
 
@@ -50,7 +51,7 @@ export default function ImageCard({ id, imageurl }: Props) {
     </Dialog>
      <div className="mt-4 w-full justify-center items-center  w-full ">
      <hr className="w-full h-px border-t-0 bg-transparent bg-gradient-to-r from-transparent via-slate-100 to-transparent opacity-55" />
-     <p className="text-center tracking-wide mb-0 pt-3">hello</p>
+     <p className="text-center tracking-wide mb-0 pt-3">{caption}</p>
      </div>
      </div>
   );

--- a/components/cards/PostCard.tsx
+++ b/components/cards/PostCard.tsx
@@ -51,6 +51,8 @@ interface Props {
   roomPostContent?: CanvasState | null;
   type: string;
 
+  caption?: string | null;
+
   author: {
     name: string | null;
     image: string | null;
@@ -78,6 +80,7 @@ const PostCard = ({
   image_url,
   video_url,
   portfolio,
+  caption,
   type,
   createdAt,
   isRealtimePost = false,
@@ -167,7 +170,7 @@ const PostCard = ({
               </p>
             )}
             {(type === "IMAGE" || type === "IMAGE_COMPUTE") && image_url && (
-              <ImageCard id={id} imageurl={image_url}></ImageCard>
+              <ImageCard id={id} imageurl={image_url} caption={caption || undefined} />
 
               // <Image
               //   className=" flex img-feed-frame ml-[19%] mr-[19%] rounded-sm mt-[1rem] mb-[1rem] "
@@ -196,7 +199,7 @@ const PostCard = ({
             )}
             {type === "GALLERY" && content && (
               // <div className="ml-[7rem] w-[500px] justify-center items-center">
-              <GalleryCarousel urls={JSON.parse(content)} />
+              <GalleryCarousel urls={JSON.parse(content)} caption={caption || undefined} />
               // </div>
             )}
             {type === "LIVECHAT" &&

--- a/components/forms/CreateFeedPost.tsx
+++ b/components/forms/CreateFeedPost.tsx
@@ -126,10 +126,12 @@ const CreateFeedPost = ({ roomId = "global" }: Props) => {
         await createFeedPost({
           type: "IMAGE",
           imageUrl: result.fileURL,
+          content: values.caption,
         });
       } else {
         await createRealtimePost({
           imageUrl: result.fileURL,
+          text: values.caption,
           path: "/",
           coordinates: { x: 0, y: 0 },
           type: "IMAGE",
@@ -190,6 +192,7 @@ const CreateFeedPost = ({ roomId = "global" }: Props) => {
           type: "GALLERY",
           imageUrl: urls[0],
           content: JSON.stringify(urls),
+          caption: values.caption,
           isPublic: values.isPublic,
         });
       } else {
@@ -201,6 +204,7 @@ const CreateFeedPost = ({ roomId = "global" }: Props) => {
           isPublic: values.isPublic,
           imageUrl: urls[0],
           text: JSON.stringify(urls),
+          caption: values.caption,
         });
       }
       reset();
@@ -293,6 +297,7 @@ const CreateFeedPost = ({ roomId = "global" }: Props) => {
           <ImageNodeModal
             isOwned={true}
             currentImageURL=""
+            currentCaption=""
             onSubmit={handleImageSubmit}
           />
         );
@@ -338,6 +343,7 @@ const CreateFeedPost = ({ roomId = "global" }: Props) => {
             isOwned={true}
             isPublic={false}
             currentImages={[]}
+            currentCaption=""
             onSubmit={handleGallerySubmit}
           />
         );

--- a/components/forms/GalleryNodeForm.tsx
+++ b/components/forms/GalleryNodeForm.tsx
@@ -27,6 +27,7 @@ interface Props {
   currentImages: string[];
   currentIsPublic: boolean;
   isOwned: boolean;
+  currentCaption?: string;
 }
 
 const GalleryNodeForm = ({
@@ -41,7 +42,7 @@ const GalleryNodeForm = ({
     resolver: zodResolver(
       isEditing ? GalleryEditValidation : GalleryPostValidation
     ),
-    defaultValues: { images: [] as File[], isPublic: currentIsPublic },
+    defaultValues: { images: [] as File[], isPublic: currentIsPublic, caption: currentCaption || "" },
   });
 
   const handleImages = (
@@ -101,6 +102,19 @@ const GalleryNodeForm = ({
                   className="account-form_image-input w-min"
                   onChange={(e) => handleImages(e, field.onChange)}
                 />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+        <FormField
+          control={form.control}
+          name="caption"
+          render={({ field }) => (
+            <FormItem className="mb-4">
+              <FormLabel>Caption</FormLabel>
+              <FormControl>
+                <Input type="text" placeholder="Caption (optional)" {...field} />
               </FormControl>
               <FormMessage />
             </FormItem>

--- a/components/forms/ImageNodeForm.tsx
+++ b/components/forms/ImageNodeForm.tsx
@@ -20,14 +20,16 @@ import clockicon from "/public/assets/clock.svg";
 interface Props {
   onSubmit: (values: z.infer<typeof ImagePostValidation>) => void;
   currentImageURL: string;
+  currentCaption: string;
 }
 
-const ImageNodeForm = ({ onSubmit, currentImageURL }: Props) => {
+const ImageNodeForm = ({ onSubmit, currentImageURL, currentCaption }: Props) => {
   const [imageURL, setImageURL] = useState(currentImageURL);
   const form = useForm({
     resolver: zodResolver(ImagePostValidation),
     defaultValues: {
       image: new File([""], "filename"),
+      caption: currentCaption,
     },
   });
 
@@ -79,6 +81,19 @@ const ImageNodeForm = ({ onSubmit, currentImageURL }: Props) => {
                   className="account-form_image-input h-min w-min"
                   onChange={(e) => handleImage(e, field.onChange)}
                 />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+        <FormField
+          control={form.control}
+          name="caption"
+          render={({ field }) => (
+            <FormItem className="mb-2">
+              <FormLabel>Caption</FormLabel>
+              <FormControl>
+                <Input type="text" placeholder="Caption (optional)" {...field} />
               </FormControl>
               <FormMessage />
             </FormItem>

--- a/components/modals/GalleryNodeModal.tsx
+++ b/components/modals/GalleryNodeModal.tsx
@@ -17,14 +17,17 @@ interface Props {
   isPublic: boolean;
   onSubmit?: (values: z.infer<typeof GalleryPostValidation>) => void;
   currentImages: string[];
+  currentCaption?: string;
 }
 
 const renderCreate = ({
   onSubmit,
   currentIsPublic,
+  currentCaption,
 }: {
   onSubmit?: (values: z.infer<typeof GalleryPostValidation>) => void;
   currentIsPublic: boolean;
+  currentCaption?: string;
 }) => (
   <div >
     <DialogHeader className="dialog-header text-white text-lg py-4 mt-[-4rem]">
@@ -36,6 +39,7 @@ const renderCreate = ({
       currentImages={[]}
       currentIsPublic={currentIsPublic}
       isOwned={true}
+      currentCaption={currentCaption}
     />
   </div>
 );
@@ -45,11 +49,13 @@ const renderEdit = ({
   currentImages,
   isOwned,
   currentIsPublic,
+  currentCaption,
 }: {
   onSubmit?: (values: z.infer<typeof GalleryPostValidation>) => void;
   currentImages: string[];
   isOwned: boolean;
   currentIsPublic: boolean;
+  currentCaption?: string;
 }) => (
   <div>
     <DialogHeader className="dialog-header text-white text-lg py-4 mt-[-4rem]">
@@ -61,6 +67,7 @@ const renderEdit = ({
       currentImages={currentImages}
       currentIsPublic={currentIsPublic}
       isOwned={isOwned}
+      currentCaption={currentCaption}
     />
   </div>
 );
@@ -85,7 +92,7 @@ const renderView = (images: string[]) => (
   </div>
 );
 
-const GalleryNodeModal = ({ id, isOwned, isPublic, onSubmit, currentImages }: Props) => {
+const GalleryNodeModal = ({ id, isOwned, isPublic, onSubmit, currentImages, currentCaption }: Props) => {
   const isCreate = !id && isOwned;
   const isEdit = id && (isOwned || isPublic);
   const isView = id && !isOwned && !isPublic;
@@ -93,13 +100,14 @@ const GalleryNodeModal = ({ id, isOwned, isPublic, onSubmit, currentImages }: Pr
     <div>
       <DialogContent className="max-w-[57rem] w-fit bg-slate-800 border-[2px] border-blue">
         <div className="grid rounded-md px-4 py-8 mt-10">
-          {isCreate && renderCreate({ onSubmit, currentIsPublic: isPublic })}
+          {isCreate && renderCreate({ onSubmit, currentIsPublic: isPublic, currentCaption })}
           {isEdit &&
             renderEdit({
               onSubmit,
               currentImages,
               isOwned,
               currentIsPublic: isPublic,
+              currentCaption,
             })}
           {isView && renderView(currentImages)}
         </div>

--- a/components/modals/ImageNodeModal.tsx
+++ b/components/modals/ImageNodeModal.tsx
@@ -17,6 +17,7 @@ interface Props {
   isOwned: boolean;
   onSubmit?: (values: z.infer<typeof ImagePostValidation>) => void;
   currentImageURL: string;
+  currentCaption?: string;
 }
 
 const renderCreate = ({
@@ -30,7 +31,7 @@ const renderCreate = ({
         <b> Create Post</b>
       </DialogHeader>
       <hr />
-      <ImageNodeForm onSubmit={onSubmit!} currentImageURL={""} />
+      <ImageNodeForm onSubmit={onSubmit!} currentImageURL={""} currentCaption="" />
     </div>
   );
 };
@@ -38,9 +39,11 @@ const renderCreate = ({
 const renderEdit = ({
   onSubmit,
   currentImageURL,
+  currentCaption,
 }: {
   onSubmit?: (values: z.infer<typeof ImagePostValidation>) => void;
   currentImageURL: string;
+  currentCaption?: string;
 }) => {
   return (
     <div>
@@ -48,7 +51,7 @@ const renderEdit = ({
         <b> Edit Post</b>
       </DialogHeader>
       <hr />
-      <ImageNodeForm onSubmit={onSubmit!} currentImageURL={currentImageURL} />
+      <ImageNodeForm onSubmit={onSubmit!} currentImageURL={currentImageURL} currentCaption={currentCaption || ""} />
     </div>
   );
 };
@@ -85,7 +88,7 @@ const renderView = (currentImageURL: string) => {
   );
 };
 
-const ImageNodeModal = ({ id, isOwned, onSubmit, currentImageURL }: Props) => {
+const ImageNodeModal = ({ id, isOwned, onSubmit, currentImageURL, currentCaption }: Props) => {
   const isCreate = !id && isOwned;
   const isEdit = id && isOwned;
   const isView = id && !isOwned;
@@ -94,7 +97,7 @@ const ImageNodeModal = ({ id, isOwned, onSubmit, currentImageURL }: Props) => {
       <DialogContent className="max-w-[50%] bg-slate-800 border-blue">
         <div className="mt-12 grid rounded-md px-4 py-2">
           {isCreate && renderCreate({ onSubmit })}
-          {isEdit && renderEdit({ onSubmit, currentImageURL })}
+          {isEdit && renderEdit({ onSubmit, currentImageURL, currentCaption })}
           {isView && renderView(currentImageURL)}
         </div>
       </DialogContent>

--- a/components/nodes/GalleryNode.tsx
+++ b/components/nodes/GalleryNode.tsx
@@ -25,6 +25,7 @@ function GalleryNode({ id, data }: NodeProps<GalleryNodeData>) {
     }))
   );
   const [images, setImages] = useState<string[]>(data.images || []);
+  const [caption, setCaption] = useState(data.caption || "");
   const [currentIndex, setCurrentIndex] = useState(0);
 
   useEffect(() => {
@@ -59,7 +60,9 @@ function GalleryNode({ id, data }: NodeProps<GalleryNodeData>) {
           text: JSON.stringify(updatedGallery),
         }),
         ...(isOwned && { isPublic: values.isPublic }),
+        ...(values.caption && { caption: values.caption }),
       });
+      setCaption(values.caption || "");
       store.closeModal();
     } catch (e) {
       console.error(e);
@@ -83,6 +86,7 @@ function GalleryNode({ id, data }: NodeProps<GalleryNodeData>) {
           isOwned={isOwned}
           isPublic={isPublic}
           currentImages={images}
+          currentCaption={caption}
           onSubmit={onGallerySubmit}
         />
       }
@@ -104,6 +108,9 @@ function GalleryNode({ id, data }: NodeProps<GalleryNodeData>) {
             height={0}
             sizes="200vw"
           />
+          {caption && (
+            <p className="text-center mt-2 text-white text-sm">{caption}</p>
+          )}
           {images.length > 1 && (
             <>
               <button

--- a/components/nodes/ImageURLNode.tsx
+++ b/components/nodes/ImageURLNode.tsx
@@ -25,6 +25,7 @@ function ImageURLNode({ id, data }: NodeProps<ImageUNode>) {
     }))
   );
   const [imageURL, setImageURL] = useState(data.imageurl);
+  const [caption, setCaption] = useState(data.caption || "");
   const [author, setAuthor] = useState(data.author);
   useEffect(() => {
     setImageURL(data.imageurl);
@@ -46,9 +47,11 @@ function ImageURLNode({ id, data }: NodeProps<ImageUNode>) {
         return;
       }
       setImageURL(result.fileURL);
+      setCaption(values.caption || "");
       updateRealtimePost({
         id,
         imageUrl: result.fileURL,
+        ...(values.caption && { caption: values.caption }),
         path,
       });
       store.closeModal();
@@ -61,6 +64,7 @@ function ImageURLNode({ id, data }: NodeProps<ImageUNode>) {
           id={id}
           isOwned={isOwned}
           currentImageURL={imageURL}
+          currentCaption={caption}
           onSubmit={onSubmit}
         />
       }
@@ -80,6 +84,9 @@ function ImageURLNode({ id, data }: NodeProps<ImageUNode>) {
             height={0}
             sizes="200vw"
           />
+          {caption && (
+            <p className="text-center mt-2 text-white text-sm">{caption}</p>
+          )}
         </div>
       </div>
     </BaseNode>

--- a/components/shared/RealtimeFeed.tsx
+++ b/components/shared/RealtimeFeed.tsx
@@ -65,6 +65,7 @@ export default function RealtimeFeed({
         video_url={realtimePost.video_url ? realtimePost.video_url : undefined}
         pluginType={(realtimePost as any).pluginType ?? null}
         pluginData={(realtimePost as any).pluginData ?? null}
+        caption={(realtimePost as any).caption ?? null}
         type={realtimePost.type}
         author={realtimePost.author!}
         createdAt={new Date(realtimePost.created_at).toDateString()}

--- a/lib/actions/feed.actions.ts
+++ b/lib/actions/feed.actions.ts
@@ -8,6 +8,7 @@ export interface CreateFeedPostArgs {
   content?: string;
   imageUrl?: string;
   videoUrl?: string;
+  caption?: string;
   isPublic?: boolean;
 }
 
@@ -27,6 +28,7 @@ export async function createFeedPost(args: CreateFeedPostArgs): Promise<{ postId
       ...(rest.content && { content: rest.content }),
       ...(rest.imageUrl && { image_url: rest.imageUrl }),
       ...(rest.videoUrl && { video_url: rest.videoUrl }),
+      ...(rest.caption && { caption: rest.caption }),
     },
   });
 

--- a/lib/actions/realtimepost.actions.ts
+++ b/lib/actions/realtimepost.actions.ts
@@ -18,6 +18,7 @@ export interface CreateRealtimePostParams {
   imageUrl?: string;
   videoUrl?: string;
   portfolio?: PortfolioPayload;
+  caption?: string;
   path: string;
   coordinates: { x: number; y: number };
   type: realtime_post_type | "MUSIC";
@@ -37,6 +38,7 @@ interface UpdateRealtimePostParams {
   imageUrl?: string;
   videoUrl?: string;
   portfolio?: PortfolioPayload;
+  caption?: string;
 
   coordinates?: { x: number; y: number };
   path: string;
@@ -82,7 +84,8 @@ export async function createRealtimePost({
       data: {
         ...(text && { content: text }),
         ...(imageUrl && { image_url: imageUrl }),
-        ...(videoUrl && { video_url: videoUrl }),
+       ...(videoUrl && { video_url: videoUrl }),
+        ...(caption && { caption }),
         ...[portfolio && { pageUrl: portfolio }],
         author_id: user.userId!,
         x_coordinate: new Prisma.Decimal(coordinates.x),
@@ -156,6 +159,7 @@ export async function updateRealtimePost({
   text,
   videoUrl,
   imageUrl,
+  caption,
   coordinates,
   path,
   isPublic,
@@ -201,6 +205,7 @@ export async function updateRealtimePost({
       ...(text && { content: text }),
       ...(imageUrl && { image_url: imageUrl }),
       ...(videoUrl && { video_url: videoUrl }),
+      ...(caption && { caption }),
       ...(content && { content }),
       ...(collageLayoutStyle && { collageLayoutStyle }),
       ...(collageColumns !== undefined && { collageColumns }),
@@ -276,6 +281,7 @@ export async function archiveOldRealtimePosts(days = 30) {
         content: p.content ?? undefined,
         image_url: p.image_url ?? undefined,
         video_url: p.video_url ?? undefined,
+        caption: (p as any).caption ?? undefined,
         author_id: p.author_id,
         updated_at: p.updated_at ?? undefined,
         like_count: p.like_count,

--- a/lib/models/migrations/20251115000000_add_caption.sql
+++ b/lib/models/migrations/20251115000000_add_caption.sql
@@ -1,0 +1,3 @@
+ALTER TABLE "feed_posts" ADD COLUMN IF NOT EXISTS "caption" TEXT;
+ALTER TABLE "realtime_posts" ADD COLUMN IF NOT EXISTS "caption" TEXT;
+ALTER TABLE "archived_realtime_posts" ADD COLUMN IF NOT EXISTS "caption" TEXT;

--- a/lib/models/schema.prisma
+++ b/lib/models/schema.prisma
@@ -134,6 +134,7 @@ model FeedPost {
   content          String?
   image_url        String?
   video_url        String?
+  caption          String?
   isPublic         Boolean           @default(true)
   like_count       Int               @default(0)
   author           User              @relation(fields: [author_id], references: [id])
@@ -209,6 +210,7 @@ model RealtimePost {
   content            String?
   image_url          String?
   video_url          String?
+  caption            String?
   author_id          BigInt
   updated_at         DateTime?          @default(now()) @updatedAt @db.Timestamptz(6)
   like_count         Int                @default(0)
@@ -316,6 +318,7 @@ model ArchivedRealtimePost {
   content            String?
   image_url          String?
   video_url          String?
+  caption            String?
   author_id          BigInt
   updated_at         DateTime?          @db.Timestamptz(6)
   like_count         Int                @default(0)

--- a/lib/reactflow/reactflowutils.ts
+++ b/lib/reactflow/reactflowutils.ts
@@ -92,6 +92,7 @@ export function convertPostToNode(
         type: realtimePost.type,
         data: {
           imageurl: realtimePost.image_url,
+          caption: (realtimePost as any).caption ?? undefined,
           author: authorToSet,
           locked: realtimePost.locked,
         },
@@ -150,15 +151,16 @@ export function convertPostToNode(
             galleryImages = [];
           }
         }
-        return {
-          id: realtimePost.id.toString(),
-          type: realtimePost.type,
-          data: {
-            images: galleryImages,
-            author: authorToSet,
-            locked: realtimePost.locked,
-            isPublic: (realtimePost as any).isPublic ?? false,
-          },
+      return {
+        id: realtimePost.id.toString(),
+        type: realtimePost.type,
+        data: {
+          images: galleryImages,
+          caption: (realtimePost as any).caption ?? undefined,
+          author: authorToSet,
+          locked: realtimePost.locked,
+          isPublic: (realtimePost as any).isPublic ?? false,
+        },
           position: {
             x: realtimePost.x_coordinate,
             y: realtimePost.y_coordinate,

--- a/lib/reactflow/types.ts
+++ b/lib/reactflow/types.ts
@@ -44,6 +44,7 @@ export type YoutubeVidNode = Node<
 export type ImageUNode = Node<
   {
     imageurl: string;
+    caption?: string;
     author: AuthorOrAuthorId;
     locked: boolean;
   },
@@ -83,6 +84,7 @@ export type CollageNodeData = Node<
 export type GalleryNodeData = Node<
   {
     images: string[];
+    caption?: string;
     author: AuthorOrAuthorId;
     locked: boolean;
     isPublic: boolean;

--- a/lib/validations/thread.ts
+++ b/lib/validations/thread.ts
@@ -78,6 +78,7 @@ export const ImagePostValidation = z.object({
       (file) => isAcceptedImage(file),
       "Only .jpg, .jpeg, .png and .webp formats are supported."
     ),
+  caption: z.string().max(200).optional(),
 });
 
 export const GalleryPostValidation = z.object({
@@ -92,6 +93,7 @@ export const GalleryPostValidation = z.object({
         )
     )
     .min(1),
+  caption: z.string().max(200).optional(),
   isPublic: z.boolean().optional(),
 });
 
@@ -107,6 +109,7 @@ export const GalleryEditValidation = z.object({
         )
     )
     .optional(),
+  caption: z.string().max(200).optional(),
   isPublic: z.boolean().optional(),
 });
 export const CommentValidation = z.object({


### PR DESCRIPTION
## Summary
- add optional `caption` column to Prisma schema and migrations
- allow captions in ImageNode and GalleryNode forms and modals
- persist captions via feed and realtime actions
- render captions in `ImageCard` and `GalleryCarousel`
- pass caption data through post components and feeds

## Testing
- `next lint` *(fails: requires interactive dependency installation)*

------
https://chatgpt.com/codex/tasks/task_e_688a9c209a288329937776469f07ad49