### PR TITLE
Add wallet lock migration

### DIFF
--- a/lib/models/schema.prisma
+++ b/lib/models/schema.prisma
@@ -717,18 +717,21 @@ model Wallet {
 }
 
 model ResolutionLog {
-  id        String   @id @default(cuid())
-  marketId  String
-  userId    BigInt
-  amount    Int
-  createdAt DateTime @default(now()) @db.Timestamptz(6)
+  id         BigInt           @id @default(autoincrement())
+  market     PredictionMarket @relation(fields: [marketId], references: [id])
+  marketId   String
+  resolver   User             @relation(fields: [resolverId], references: [id])
+  resolverId BigInt
+  outcome    ResolutionOutcome
+  createdAt  DateTime         @default(now())
 
-  market PredictionMarket @relation(fields: [marketId], references: [id])
-  user   User             @relation(fields: [userId], references: [id])
-
-  @@index([marketId])
-  @@index([userId])
   @@map("resolution_log")
+}
+
+enum ResolutionOutcome {
+  YES
+  NO
+  N_A
 }
 
 enum PredictionState {

--- a/prisma/migrations/add_wallet_lock.sql
+++ b/prisma/migrations/add_wallet_lock.sql
@@ -1,0 +1,6 @@
+CREATE OR REPLACE FUNCTION lock_wallet(p_user_id BIGINT)
+RETURNS BIGINT AS $$
+  SELECT id FROM "VirtualWallet" WHERE "user_id" = p_user_id FOR UPDATE;
+$$ LANGUAGE SQL;
+
+CREATE INDEX trade_market_user_idx ON "Trade" ("marketId","userId");

--- a/tests/walletLock.test.ts
+++ b/tests/walletLock.test.ts
@@ -1,0 +1,37 @@
+import { PrismaClient } from "@prisma/client";
+
+const prisma = new PrismaClient();
+
+beforeAll(async () => {
+  await prisma.$executeRawUnsafe(`CREATE TABLE IF NOT EXISTS "VirtualWallet" (
+    id BIGSERIAL PRIMARY KEY,
+    "user_id" BIGINT UNIQUE
+  );`);
+  await prisma.$executeRawUnsafe(`CREATE OR REPLACE FUNCTION lock_wallet(p_user_id BIGINT)
+RETURNS BIGINT AS $$
+  SELECT id FROM "VirtualWallet" WHERE "user_id" = p_user_id FOR UPDATE;
+$$ LANGUAGE SQL;`);
+  await prisma.$executeRawUnsafe(`INSERT INTO "VirtualWallet" ("user_id") VALUES (1) ON CONFLICT DO NOTHING;`);
+});
+
+afterAll(async () => {
+  await prisma.$executeRawUnsafe(`DROP TABLE IF EXISTS "VirtualWallet";`);
+  await prisma.$disconnect();
+});
+
+test("lock_wallet serializes concurrent txns", async () => {
+  const prisma2 = new PrismaClient();
+  const order: string[] = [];
+  const tx1 = prisma.$transaction(async tx => {
+    await tx.$executeRaw`SELECT lock_wallet(${1})`;
+    await new Promise(r => setTimeout(r, 500));
+    order.push("first");
+  });
+  const tx2 = prisma2.$transaction(async tx => {
+    await tx.$executeRaw`SELECT lock_wallet(${1})`;
+    order.push("second");
+  });
+  await Promise.all([tx1, tx2]);
+  await prisma2.$disconnect();
+  expect(order).toEqual(["first", "second"]);
+});


### PR DESCRIPTION
## Summary
- add wallet locking helper migration
- introduce `ResolutionLog` model and enum
- test wallet locking with concurrent transactions

## Testing
- `npm run lint`
- `npx jest tests/walletLock.test.ts`
- `pnpm prisma migrate dev --name add_resolution_log` *(fails: schema "extensions" does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_688aca6bf79c8329a70412ff17104646