### PR TITLE
Add prediction service logic

### DIFF
--- a/lib/prediction/lmsr.ts
+++ b/lib/prediction/lmsr.ts
@@ -17,3 +17,19 @@ export function costToBuy(
   const costAfter = side === "YES" ? C(qYes + delta, qNo) : C(qYes, qNo + delta);
   return costAfter - costBefore;
 }
+
+export function calcSharesForSpend({ yesPool, noPool, b, spend, side }: { yesPool: number; noPool: number; b: number; spend: number; side: "YES" | "NO"; }) {
+  let lo = 0;
+  let hi = 1;
+  while (costToBuy(side, hi, yesPool, noPool, b) < spend) {
+    hi *= 2;
+  }
+  for (let i = 0; i < 30; i++) {
+    const mid = (lo + hi) / 2;
+    const cost = costToBuy(side, mid, yesPool, noPool, b);
+    if (cost > spend) hi = mid; else lo = mid;
+  }
+  const deltaQ = lo;
+  const cost = Math.ceil(costToBuy(side, deltaQ, yesPool, noPool, b));
+  return { deltaQ, cost };
+}

--- a/packages/server/src/prediction/service.ts
+++ b/packages/server/src/prediction/service.ts
@@ -1,0 +1,107 @@
+import { prisma } from "@/lib/prismaclient";
+import { priceYes, calcSharesForSpend } from "@/lib/prediction/lmsr";
+
+export interface PlaceTradeArgs {
+  marketId: string;
+  userId: bigint;
+  spendCents: number;
+  side: "YES" | "NO";
+}
+
+export interface PlaceTradeResult {
+  shares: number;
+  newYesProb: number;
+}
+
+export async function placeTrade({ marketId, userId, spendCents, side }: PlaceTradeArgs): Promise<PlaceTradeResult> {
+  return prisma.$transaction(async (tx) => {
+    await tx.$executeRaw`SELECT lock_wallet(${userId})`;
+
+    const market = await tx.predictionMarket.findUniqueOrThrow({ where: { id: marketId } });
+    if (market.state !== "OPEN") throw new Error("Market closed");
+
+    const wallet = await tx.wallet.findUnique({ where: { userId } });
+    if (!wallet || wallet.balanceCents - wallet.lockedCents < spendCents) {
+      throw new Error("Insufficient funds");
+    }
+
+    const { deltaQ, cost } = calcSharesForSpend({
+      yesPool: market.yesPool,
+      noPool: market.noPool,
+      b: market.b,
+      spend: spendCents,
+      side,
+    });
+
+    if (cost > wallet.balanceCents - wallet.lockedCents) {
+      throw new Error("Insufficient funds");
+    }
+
+    await tx.trade.create({
+      data: {
+        marketId,
+        userId,
+        side,
+        shares: deltaQ,
+        cost,
+        price: cost / deltaQ,
+      },
+    });
+
+    await tx.wallet.update({
+      where: { userId },
+      data: { balanceCents: { decrement: cost } },
+    });
+
+    const poolMutation =
+      side === "YES" ? { yesPool: { increment: deltaQ } } : { noPool: { increment: deltaQ } };
+    const updated = await tx.predictionMarket.update({ where: { id: marketId }, data: poolMutation });
+    const newYesProb = priceYes(updated.yesPool, updated.noPool, updated.b);
+    return { shares: deltaQ, newYesProb };
+  });
+}
+
+export interface ResolveMarketArgs {
+  marketId: string;
+  outcome: "YES" | "NO";
+  resolverId: bigint;
+}
+
+export interface ResolveMarketResult {
+  payouts: number;
+  totalPaid: number;
+}
+
+export async function resolveMarket({ marketId, outcome, resolverId }: ResolveMarketArgs): Promise<ResolveMarketResult> {
+  return prisma.$transaction(async (tx) => {
+    const market = await tx.predictionMarket.findUniqueOrThrow({ where: { id: marketId } });
+
+    if (market.state === "RESOLVED") throw new Error("Already resolved");
+    if (market.creatorId !== resolverId && market.oracleId !== resolverId) {
+      throw new Error("Not authorized");
+    }
+
+    const trades = await tx.trade.findMany({ where: { marketId } });
+
+    let payouts = 0;
+    let totalPaid = 0;
+    for (const trade of trades) {
+      if (trade.side === outcome) {
+        const amount = Math.floor(trade.shares);
+        await tx.$executeRaw`SELECT lock_wallet(${trade.userId})`;
+        await tx.wallet.update({ where: { userId: trade.userId }, data: { balanceCents: { increment: amount } } });
+        payouts++;
+        totalPaid += amount;
+      }
+    }
+
+    await tx.predictionMarket.update({
+      where: { id: marketId },
+      data: { state: "RESOLVED", outcome, resolvesAt: new Date() },
+    });
+
+    await tx.resolutionLog.create({ data: { marketId, resolverId, outcome } });
+
+    return { payouts, totalPaid };
+  });
+}

--- a/tests/prediction.service.test.ts
+++ b/tests/prediction.service.test.ts
@@ -1,0 +1,101 @@
+import { jest } from "@jest/globals";
+import { placeTrade, resolveMarket } from "@/packages/server/src/prediction/service";
+import { calcSharesForSpend, priceYes } from "@/lib/prediction/lmsr";
+
+// Simple in-memory mock of prisma
+const db = {
+  market: {
+    id: "m1",
+    yesPool: 0,
+    noPool: 0,
+    b: 100,
+    state: "OPEN" as const,
+    creatorId: BigInt(1),
+    oracleId: null as bigint | null,
+  },
+  wallet: { userId: BigInt(1), balanceCents: 1000, lockedCents: 0 },
+  trades: [] as any[],
+  logs: [] as any[],
+};
+
+jest.mock("@/lib/prismaclient", () => {
+  const prisma = {
+    $transaction: async (fn: any) => fn(prisma),
+    $executeRaw: async () => {},
+    predictionMarket: {
+      findUniqueOrThrow: async ({ where: { id } }: any) => {
+        if (db.market.id !== id) throw new Error("not found");
+        return { ...db.market };
+      },
+      update: async ({ where: { id }, data }: any) => {
+        if (db.market.id !== id) throw new Error("not found");
+        if (data.yesPool?.increment) db.market.yesPool += data.yesPool.increment;
+        if (data.noPool?.increment) db.market.noPool += data.noPool.increment;
+        if (data.state) db.market.state = data.state;
+        if (data.outcome) (db.market as any).outcome = data.outcome;
+        if (data.resolvesAt) (db.market as any).resolvesAt = data.resolvesAt;
+        return { ...db.market };
+      },
+    },
+    wallet: {
+      findUnique: async ({ where: { userId } }: any) => {
+        return userId === db.wallet.userId ? { ...db.wallet } : null;
+      },
+      update: async ({ where: { userId }, data }: any) => {
+        if (userId !== db.wallet.userId) throw new Error("not found");
+        if (data.balanceCents?.decrement) db.wallet.balanceCents -= data.balanceCents.decrement;
+        if (data.balanceCents?.increment) db.wallet.balanceCents += data.balanceCents.increment;
+        return { ...db.wallet };
+      },
+    },
+    trade: {
+      create: async ({ data }: any) => {
+        const t = { id: String(db.trades.length + 1), ...data };
+        db.trades.push(t);
+        return t;
+      },
+      findMany: async ({ where: { marketId } }: any) => db.trades.filter((t) => t.marketId === marketId),
+    },
+    resolutionLog: {
+      create: async ({ data }: any) => {
+        db.logs.push(data);
+        return data;
+      },
+    },
+  };
+  return { prisma };
+});
+
+describe("prediction service", () => {
+  beforeEach(() => {
+    db.market.yesPool = 0;
+    db.market.noPool = 0;
+    db.market.state = "OPEN";
+    db.wallet.balanceCents = 1000;
+    db.trades.length = 0;
+    db.logs.length = 0;
+  });
+
+  test("buying 100¢ of YES moves price up", async () => {
+    const { newYesProb } = await placeTrade({ marketId: "m1", userId: BigInt(1), spendCents: 100, side: "YES" });
+    expect(newYesProb).toBeGreaterThan(0.5);
+  });
+
+  test("wallet debits equal LMSR bank", async () => {
+    const res = await placeTrade({ marketId: "m1", userId: BigInt(1), spendCents: 100, side: "YES" });
+    const totalDebit = 1000 - db.wallet.balanceCents;
+    const C = (y: number, n: number) => db.market.b * Math.log(Math.exp(y / db.market.b) + Math.exp(n / db.market.b));
+    const liability = C(db.market.yesPool, db.market.noPool) - C(0, 0);
+    expect(totalDebit).toBeCloseTo(liability, 0);
+    expect(res.shares).toBeCloseTo(calcSharesForSpend({ yesPool: 0, noPool: 0, b: 100, spend: 100, side: "YES" }).deltaQ, 3);
+  });
+
+  test("resolution pays per share and preserves credits", async () => {
+    const trade = await placeTrade({ marketId: "m1", userId: BigInt(1), spendCents: 100, side: "YES" });
+    const preTotal = db.wallet.balanceCents;
+    const { payouts, totalPaid } = await resolveMarket({ marketId: "m1", outcome: "YES", resolverId: BigInt(1) });
+    expect(payouts).toBe(1);
+    expect(totalPaid).toBe(Math.floor(trade.shares));
+    expect(db.wallet.balanceCents).toBe(preTotal + Math.floor(trade.shares));
+  });
+});


### PR DESCRIPTION
## Summary
- add LMSR helper to compute share quantities
- implement `placeTrade` and `resolveMarket` service functions
- create tests for prediction service

## Testing
- `npm run lint`
- `pnpm test` *(fails: Invalid `prisma.$executeRawUnsafe()` invocation etc.)*

------
https://chatgpt.com/codex/tasks/task_e_688acfb6b9348329933169c4a75c2271