### PR TITLE
Implement market API and cron job

### DIFF
--- a/.github/workflows/close-markets.yml
+++ b/.github/workflows/close-markets.yml
@@ -1,0 +1,17 @@
+name: Close Markets
+on:
+  schedule:
+    - cron: '*/5 * * * *'
+jobs:
+  close:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+      - run: yarn install --frozen-lockfile
+      - run: npx ts-node scripts/closeMarkets.ts --secret $MARKET_CRON_SECRET
+        env:
+          DATABASE_URL: ${{ secrets.DATABASE_URL }}
+          MARKET_CRON_SECRET: ${{ secrets.MARKET_CRON_SECRET }}

--- a/app/api/market/[id]/resolve/route.ts
+++ b/app/api/market/[id]/resolve/route.ts
@@ -1,11 +1,25 @@
 import { NextRequest, NextResponse } from "next/server";
-import { resolveMarket } from "@/lib/actions/prediction.actions";
+import { resolveMarket } from "@/packages/server/src/prediction/service";
+import { getUserFromCookies } from "@/lib/serverutils";
+import { z } from "zod";
+
+const schema = z.object({ outcome: z.enum(["YES", "NO", "N_A"]) });
 
 export async function POST(
   req: NextRequest,
-  { params }: { params: { id: string } }
+  { params }: { params: { id: string } },
 ) {
-  const body = await req.json();
-  const result = await resolveMarket({ marketId: params.id, outcome: body.outcome });
+  const user = await getUserFromCookies();
+  if (!user) return new NextResponse("Unauthorized", { status: 401 });
+  const body = await req.json().catch(() => ({}));
+  const parsed = schema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json({ error: parsed.error.flatten() }, { status: 400 });
+  }
+  const result = await resolveMarket({
+    marketId: params.id,
+    outcome: parsed.data.outcome,
+    resolverId: user.userId!,
+  });
   return NextResponse.json(result);
 }

--- a/app/api/market/[id]/route.ts
+++ b/app/api/market/[id]/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/lib/prismaclient";
 import { serializeBigInt } from "@/lib/utils";
+import { priceYes } from "@/lib/prediction/lmsr";
 
 export const revalidate = 60;
 
@@ -13,7 +14,9 @@ export async function GET(
     include: { trades: true },
   });
   if (!market) return NextResponse.json({ message: "Not found" }, { status: 404 });
-  return NextResponse.json(serializeBigInt(market), {
-    headers: { "Cache-Control": "public, max-age=60" },
-  });
+  const price = priceYes(market.yesPool, market.noPool, market.b);
+  return NextResponse.json(
+    serializeBigInt({ market, pools: { yes: market.yesPool, no: market.noPool }, price }),
+    { headers: { "Cache-Control": "public, max-age=60" } },
+  );
 }

--- a/app/api/market/[id]/trade/route.ts
+++ b/app/api/market/[id]/trade/route.ts
@@ -1,12 +1,43 @@
 import { NextRequest, NextResponse } from "next/server";
-import { tradeMarket } from "@/lib/actions/prediction.actions";
+import { placeTrade } from "@/packages/server/src/prediction/service";
+import { getUserFromCookies } from "@/lib/serverutils";
+import { Ratelimit } from "@upstash/ratelimit";
+import { Redis } from "@upstash/redis";
+import { z } from "zod";
 
-export async function POST(req: NextRequest, { params }: { params: { id: string } }) {
-  const body = await req.json();
-  const result = await tradeMarket({
+const redisRest = new Redis({
+  url: process.env.UPSTASH_REDIS_REST_URL!,
+  token: process.env.UPSTASH_REDIS_REST_TOKEN!,
+});
+const ratelimit = new Ratelimit({
+  redis: redisRest,
+  limiter: Ratelimit.fixedWindow(10, "1 m"),
+});
+
+const schema = z.object({
+  spendCents: z.number().int().positive(),
+  side: z.enum(["YES", "NO"]),
+});
+
+export async function POST(
+  req: NextRequest,
+  { params }: { params: { id: string } },
+) {
+  const user = await getUserFromCookies();
+  if (!user) return new NextResponse("Unauthorized", { status: 401 });
+  const body = await req.json().catch(() => ({}));
+  const parsed = schema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json({ error: parsed.error.flatten() }, { status: 400 });
+  }
+  const { success } = await ratelimit.limit(user.userId.toString());
+  if (!success) return new NextResponse("Too Many", { status: 429 });
+  const { spendCents, side } = parsed.data;
+  const result = await placeTrade({
     marketId: params.id,
-    side: body.side,
-    credits: body.credits,
+    userId: user.userId!,
+    spendCents,
+    side,
   });
   return NextResponse.json(result);
 }

--- a/scripts/closeMarkets.ts
+++ b/scripts/closeMarkets.ts
@@ -1,6 +1,12 @@
+import "dotenv/config";
 import { prisma } from "@/lib/prismaclient";
 
 async function main() {
+  const idx = process.argv.indexOf("--secret");
+  const provided = idx !== -1 ? process.argv[idx + 1] : undefined;
+  if (process.env.MARKET_CRON_SECRET && provided !== process.env.MARKET_CRON_SECRET) {
+    throw new Error("Invalid secret");
+  }
   const now = new Date();
   await prisma.predictionMarket.updateMany({
     where: { closesAt: { lt: now }, state: "OPEN" },


### PR DESCRIPTION
## Summary
- add POST `/api/market` endpoint
- implement trade and resolve routes with rate limit and validation
- expose GET `/api/market/[id]` with pools and price
- secure cron script for closing markets
- schedule GitHub Action to run cron every 5 min

## Testing
- `npm run lint`
- `npm test -- --runInBand` *(fails: Can't reach database server)*

------
https://chatgpt.com/codex/tasks/task_e_688ad99e9bb883299a0f461be12d4743