### PR TITLE
Improve prediction trade modal

### DIFF
--- a/components/cards/PredictionMarketCard.tsx
+++ b/components/cards/PredictionMarketCard.tsx
@@ -43,7 +43,7 @@ export default function PredictionMarketCard({ post }: Props) {
         <TradePredictionModal
           market={post.predictionMarket}
           onClose={() => setShowTrade(false)}
-          onTraded={() => mutate()}
+          mutate={() => mutate()}
         />
       )}
       {state === "CLOSED" && (

--- a/lib/prediction/lmsr.ts
+++ b/lib/prediction/lmsr.ts
@@ -33,3 +33,18 @@ export function calcSharesForSpend({ yesPool, noPool, b, spend, side }: { yesPoo
   const cost = Math.ceil(costToBuy(side, deltaQ, yesPool, noPool, b));
   return { deltaQ, cost };
 }
+
+export function estimateShares(
+  side: "YES" | "NO",
+  spend: number,
+  market: { yesPool: number; noPool: number; b: number }
+) {
+  const { deltaQ, cost } = calcSharesForSpend({
+    yesPool: market.yesPool,
+    noPool: market.noPool,
+    b: market.b,
+    spend,
+    side,
+  });
+  return { shares: deltaQ, cost };
+}


### PR DESCRIPTION
## Summary
- connect TradePredictionModal to wallet API
- add estimateShares util to lmsr
- use Radix Slider and update PredictionMarketCard

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688af2d1c9548329bceff1e02357f913