### PR TITLE
Add venue deduplication

### DIFF
--- a/app/(root)/(standard)/halfway/page.tsx
+++ b/app/(root)/(standard)/halfway/page.tsx
@@ -27,6 +27,7 @@ import {
   CardTitle,
   CardDescription,
 } from "@/components/ui/card";
+import { dedupeByPlaceId } from "@/lib/dedupeVenues";
 
 const libraries: Libraries = ["places", "geometry"];
 const mapContainerStyle = { width: "100%", height: "400px" };
@@ -165,7 +166,7 @@ export default function HalfwayPage() {
             types: place.types,
           }))
           .sort((a: Venue, b: Venue) => (b.rating ?? 0) - (a.rating ?? 0));
-        setVenues(newVenues);
+        setVenues(dedupeByPlaceId(newVenues));
         console.log("Venues within radius:", newVenues);
       } else {
         setVenues([]);

--- a/lib/dedupeVenues.ts
+++ b/lib/dedupeVenues.ts
@@ -1,0 +1,32 @@
+import uniqBy from "lodash/uniqBy";
+import { get as levenshtein } from "fast-levenshtein";
+
+export type Venue = {
+  id: string;
+  name: string;
+  address: string;
+  location: { lat: number; lng: number };
+  rating?: number;
+  openingHours?: string[];
+  types?: string[];
+};
+
+export const dedupeByPlaceId = (arr: Venue[]): Venue[] => {
+  const uniqueById = uniqBy(arr, "id");
+
+  const deduped: Venue[] = [];
+  for (const venue of uniqueById) {
+    const duplicate = deduped.find(
+      (v) =>
+        levenshtein(
+          (v.name + v.address).toLowerCase(),
+          (venue.name + venue.address).toLowerCase()
+        ) < 3
+    );
+    if (!duplicate) {
+      deduped.push(venue);
+    }
+  }
+
+  return deduped;
+};


### PR DESCRIPTION
## Summary
- add `dedupeByPlaceId` helper to remove duplicate Google venues
- use the helper in HalfwayPage before saving venues

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_688b2a947e308329a93d115d585dd02c