### PR TITLE
Add geocode fallback logic

### DIFF
--- a/app/(root)/(standard)/halfway/page.tsx
+++ b/app/(root)/(standard)/halfway/page.tsx
@@ -183,22 +183,49 @@ export default function HalfwayPage() {
 
   // Calculate midpoint and fetch venues
   const handleFindMidpoint = async () => {
-    if (!coord1 || !coord2) {
-      setError("Please enter both addresses correctly.");
+    let c1 = coord1;
+    let c2 = coord2;
+
+    if (!c1 && address1) {
+      try {
+        const res = await fetch(`/api/geocode?address=${encodeURIComponent(address1)}`);
+        if (res.ok) {
+          c1 = await res.json();
+          setCoord1(c1);
+        }
+      } catch (err) {
+        console.error("Error geocoding address1", err);
+      }
+    }
+
+    if (!c2 && address2) {
+      try {
+        const res = await fetch(`/api/geocode?address=${encodeURIComponent(address2)}`);
+        if (res.ok) {
+          c2 = await res.json();
+          setCoord2(c2);
+        }
+      } catch (err) {
+        console.error("Error geocoding address2", err);
+      }
+    }
+
+    if (!c1 || !c2) {
+      setError("Address not recognised");
       return;
     }
     setError(null);
     // Calculate simple geometric midpoint
     const avg = {
-      lat: (coord1.lat + coord2.lat) / 2,
-      lng: (coord1.lng + coord2.lng) / 2,
+      lat: (c1.lat + c2.lat) / 2,
+      lng: (c1.lng + c2.lng) / 2,
     };
     console.log("Average midpoint:", avg);
     setAvgMidpoint(avg);
 
     try {
       const res = await fetch(
-        `/api/routeMidpoint?lat1=${coord1.lat}&lng1=${coord1.lng}&lat2=${coord2.lat}&lng2=${coord2.lng}`
+        `/api/routeMidpoint?lat1=${c1.lat}&lng1=${c1.lng}&lat2=${c2.lat}&lng2=${c2.lng}`
       );
       if (!res.ok) throw new Error("Failed to fetch midpoint");
       const mid: LatLng = await res.json();

--- a/pages/api/geocode.ts
+++ b/pages/api/geocode.ts
@@ -1,0 +1,28 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  const address = req.query.address as string | undefined;
+  if (!address) {
+    res.status(400).json({ error: "Missing address" });
+    return;
+  }
+
+  const apiKey = process.env.GOOGLE_MAPS_API_KEY;
+  const url = `https://maps.googleapis.com/maps/api/geocode/json?address=${encodeURIComponent(address)}&key=${apiKey}&libraries=drawing`;
+
+  try {
+    const response = await fetch(url);
+    if (!response.ok) {
+      res.status(response.status).json({ error: "Failed to fetch from Google API" });
+      return;
+    }
+    const data = await response.json();
+    if (!data.results || data.results.length === 0) {
+      res.status(404).json({ error: "No results found" });
+      return;
+    }
+    res.status(200).json(data.results[0].geometry.location);
+  } catch (err) {
+    res.status(500).json({ error: "Server error" });
+  }
+}


### PR DESCRIPTION
## Summary
- create a pages/api geocode proxy
- fallback to geocode lookup when midpoint coordinates missing

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688b3baff08c83298889622715e48120