### PR TITLE
Add group meeting wizard

### DIFF
--- a/app/api/group-halfway/create/route.ts
+++ b/app/api/group-halfway/create/route.ts
@@ -1,0 +1,23 @@
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@/lib/prismaclient";
+import { getUserFromCookies } from "@/lib/serverutils";
+import { signGroupToken } from "@/lib/jwtHelpers";
+
+export async function POST(req: NextRequest) {
+  const user = await getUserFromCookies();
+  if (!user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+  const { title, uids } = await req.json();
+  if (!Array.isArray(uids) || uids.length === 0) {
+    return NextResponse.json({ error: "Invalid uids" }, { status: 400 });
+  }
+
+  const meeting = await prisma.groupMeeting.create({
+    data: { title: title ?? null, participantUids: uids },
+  });
+
+  const token = signGroupToken({ uid: user.uid, id: meeting.id });
+  const joinUrl = `/g-halfway/${meeting.id}?token=${token}`;
+
+  return NextResponse.json({ joinUrl });
+}

--- a/app/api/group-halfway/info/[id]/route.ts
+++ b/app/api/group-halfway/info/[id]/route.ts
@@ -1,0 +1,14 @@
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@/lib/prismaclient";
+import { verifyGroupToken } from "@/lib/jwtHelpers";
+
+export async function GET(req: NextRequest, { params }: { params: { id: string } }) {
+  const token = req.nextUrl.searchParams.get("token") || "";
+  const payload = verifyGroupToken(token);
+  if (!payload || payload.id !== params.id) {
+    return NextResponse.json({ error: "Invalid token" }, { status: 401 });
+  }
+  const meeting = await prisma.groupMeeting.findUnique({ where: { id: params.id } });
+  if (!meeting) return NextResponse.json({ error: "Not found" }, { status: 404 });
+  return NextResponse.json(meeting);
+}

--- a/app/api/group-halfway/origins/[id]/route.ts
+++ b/app/api/group-halfway/origins/[id]/route.ts
@@ -1,0 +1,22 @@
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@/lib/prismaclient";
+import { verifyGroupToken } from "@/lib/jwtHelpers";
+
+export async function POST(req: NextRequest, { params }: { params: { id: string } }) {
+  const token = req.nextUrl.searchParams.get("token") || "";
+  const payload = verifyGroupToken(token);
+  if (!payload || payload.id !== params.id) {
+    return NextResponse.json({ error: "Invalid token" }, { status: 401 });
+  }
+
+  const { address, lat, lng } = await req.json();
+  const meeting = await prisma.groupMeeting.findUnique({ where: { id: params.id } });
+  if (!meeting) return NextResponse.json({ error: "Not found" }, { status: 404 });
+
+  const origins = (meeting.origins as any) || {};
+  origins[payload.uid] = { address, lat, lng };
+
+  await prisma.groupMeeting.update({ where: { id: params.id }, data: { origins } });
+
+  return NextResponse.json({ ok: true });
+}

--- a/app/group-halfway/[id]/page.tsx
+++ b/app/group-halfway/[id]/page.tsx
@@ -1,0 +1,34 @@
+import { prisma } from "@/lib/prismaclient";
+import { verifyGroupToken } from "@/lib/jwtHelpers";
+import { notFound } from "next/navigation";
+import OriginWizard from "./wizard";
+
+type Props = { params: { id: string }; searchParams: { token?: string } };
+
+export default async function Page({ params, searchParams }: Props) {
+  const token = searchParams.token;
+  const payload = token ? verifyGroupToken(token) : null;
+  if (!payload || payload.id !== params.id) notFound();
+
+  const meeting = await prisma.groupMeeting.findUnique({ where: { id: params.id } });
+  if (!meeting) notFound();
+
+  const origins = (meeting.origins as any) || {};
+  const allSet = meeting.participantUids.every((uid) => origins[uid]);
+
+  return (
+    <div className="p-4">
+      {allSet ? (
+        <p>All participants have set their origins.</p>
+      ) : (
+        <OriginWizard
+          meetingId={meeting.id}
+          token={token!}
+          currentUid={payload.uid}
+          participantUids={meeting.participantUids}
+          initialOrigins={origins}
+        />
+      )}
+    </div>
+  );
+}

--- a/app/group-halfway/[id]/wizard.tsx
+++ b/app/group-halfway/[id]/wizard.tsx
@@ -1,0 +1,84 @@
+"use client";
+import { useState, useEffect, useRef } from "react";
+import { useLoadScript, Autocomplete } from "@react-google-maps/api";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+
+const libraries = ["places"] as const;
+
+export default function OriginWizard({
+  meetingId,
+  token,
+  currentUid,
+  participantUids,
+  initialOrigins,
+}: {
+  meetingId: string;
+  token: string;
+  currentUid: string;
+  participantUids: string[];
+  initialOrigins: Record<string, any>;
+}) {
+  const [origins, setOrigins] = useState<Record<string, any>>(initialOrigins);
+  const [address, setAddress] = useState("");
+  const autocompleteRef = useRef<google.maps.places.Autocomplete | null>(null);
+  const { isLoaded } = useLoadScript({
+    googleMapsApiKey: process.env.NEXT_PUBLIC_GOOGLE_MAPS_API_KEY!,
+    libraries,
+  });
+
+  useEffect(() => {
+    const interval = setInterval(async () => {
+      const res = await fetch(`/api/group-halfway/info/${meetingId}?token=${token}`);
+      if (res.ok) {
+        const data = await res.json();
+        setOrigins(data.origins || {});
+      }
+    }, 3000);
+    return () => clearInterval(interval);
+  }, [meetingId, token]);
+
+  const handlePlaceChanged = () => {
+    const place = autocompleteRef.current?.getPlace();
+    if (place?.geometry?.location) {
+      setAddress(place.formatted_address || "");
+      const loc = place.geometry.location;
+      fetch(`/api/group-halfway/origins/${meetingId}?token=${token}`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ address: place.formatted_address, lat: loc.lat(), lng: loc.lng() }),
+      }).then(() => {
+        setOrigins((o) => ({ ...o, [currentUid]: { address: place.formatted_address } }));
+      });
+    }
+  };
+
+  const copyLink = async () => {
+    await navigator.clipboard.writeText(window.location.href);
+  };
+
+  const allSet = participantUids.every((uid) => origins[uid]);
+
+  return (
+    <div className="space-y-4">
+      {!origins[currentUid] && isLoaded && (
+        <Autocomplete onLoad={(a) => (autocompleteRef.current = a)} onPlaceChanged={handlePlaceChanged}>
+          <Input value={address} onChange={(e) => setAddress(e.target.value)} placeholder="Enter your start address" />
+        </Autocomplete>
+      )}
+      <Button onClick={copyLink}>Copy invite link</Button>
+      <div>
+        <h2 className="font-bold">Participants</h2>
+        <ul>
+          {participantUids.map((uid) => (
+            <li key={uid} className="flex items-center space-x-2">
+              <span>{uid}</span>
+              <span>{origins[uid] ? "✅" : "❌"}</span>
+            </li>
+          ))}
+        </ul>
+        {allSet && <p>All set!</p>}
+      </div>
+    </div>
+  );
+}

--- a/lib/jwtHelpers.ts
+++ b/lib/jwtHelpers.ts
@@ -1,0 +1,17 @@
+import jwt from "jsonwebtoken";
+
+const SECRET = process.env.JWT_SECRET || "secret";
+
+type Payload = { uid: string; id: string };
+
+export function signGroupToken(payload: Payload) {
+  return jwt.sign(payload, SECRET);
+}
+
+export function verifyGroupToken(token: string): Payload | null {
+  try {
+    return jwt.verify(token, SECRET) as Payload;
+  } catch {
+    return null;
+  }
+}

--- a/lib/models/schema.prisma
+++ b/lib/models/schema.prisma
@@ -1029,3 +1029,14 @@ model StallHeat {
   @@unique([stall_id, cell], name: "stall_id_cell")
   @@map("stall_heat")
 }
+
+model GroupMeeting {
+  id             String   @id @default(uuid())
+  title          String?
+  participantUids String[]
+  origins        Json?
+  status         String   @default("init")
+  createdAt      DateTime @default(now())
+
+  @@map("group_meetings")
+}


### PR DESCRIPTION
## Summary
- add `GroupMeeting` table to Prisma schema
- add JWT helper for group tokens
- implement group meeting create/info/origins API routes
- add server page with wizard UI for group setup

## Testing
- `yarn install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688ba3b65bb883298da490167934486c