### PR TITLE
Implement group halfway algorithm and map features

### DIFF
--- a/app/api/group-halfway/heatmap/[id]/route.ts
+++ b/app/api/group-halfway/heatmap/[id]/route.ts
@@ -1,0 +1,44 @@
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@/lib/prismaclient";
+import { haversineDistance } from "@/lib/sorters";
+
+export async function GET(_req: NextRequest, { params }: { params: { id: string } }) {
+  const meeting = await prisma.groupMeeting.findUnique({ where: { id: params.id } });
+  if (!meeting) return NextResponse.json({ error: "Not found" }, { status: 404 });
+  const origins = (meeting.origins as any) || {};
+  if (!meeting.participantUids.every((u) => origins[u])) {
+    return NextResponse.json({ error: "Origins incomplete" }, { status: 400 });
+  }
+  const originList = meeting.participantUids.map((u) => origins[u]);
+  const centroid = originList.reduce(
+    (acc: any, cur: any) => ({ lat: acc.lat + cur.lat / originList.length, lng: acc.lng + cur.lng / originList.length }),
+    { lat: 0, lng: 0 }
+  );
+  const radius = Math.max(...originList.map((o: any) => haversineDistance(o, centroid)));
+  const spacing = 150; // meters
+  const latStep = spacing / 111320;
+  const lngStep = spacing / (111320 * Math.cos((centroid.lat * Math.PI) / 180));
+  const maxStep = Math.ceil(radius / spacing);
+
+  const nodes: { lat: number; lng: number; cost: number }[] = [];
+  for (let i = -maxStep; i <= maxStep; i++) {
+    for (let j = -maxStep; j <= maxStep; j++) {
+      const lng = centroid.lng + i * lngStep * 1.5;
+      const lat = centroid.lat + j * latStep + (i % 2 ? latStep / 2 : 0);
+      if (haversineDistance({ lat, lng }, centroid) > radius) continue;
+      const cost = originList.reduce((s: number, o: any) => s + haversineDistance(o, { lat, lng }), 0);
+      nodes.push({ lat, lng, cost });
+      if (nodes.length >= 400) break;
+    }
+    if (nodes.length >= 400) break;
+  }
+  const costs = nodes.map((n) => n.cost);
+  const min = Math.min(...costs);
+  const max = Math.max(...costs);
+  const points = nodes.map((n) => ({
+    lat: n.lat,
+    lng: n.lng,
+    weight: max === min ? 1 : 1 - (n.cost - min) / (max - min),
+  }));
+  return NextResponse.json({ points }, { headers: { "Cache-Control": "s-maxage=300" } });
+}

--- a/components/GroupHalfwayMap.tsx
+++ b/components/GroupHalfwayMap.tsx
@@ -1,0 +1,52 @@
+"use client";
+import { GoogleMap, Marker, HeatmapLayer, useJsApiLoader } from "@react-google-maps/api";
+import { useMemo } from "react";
+import type { LatLng, Candidate } from "@/packages/halfway-utils/groupAlgorithm";
+
+const libs = ["visualization"] as const;
+
+export type HeatPoint = { lat: number; lng: number; weight: number };
+
+export default function GroupHalfwayMap({
+  origins,
+  candidates,
+  heatData,
+}: {
+  origins: LatLng[];
+  candidates: Candidate[];
+  heatData: { points: HeatPoint[] } | null;
+}) {
+  const { isLoaded } = useJsApiLoader({
+    googleMapsApiKey: process.env.NEXT_PUBLIC_GOOGLE_MAPS_API_KEY!,
+    libraries: libs,
+  });
+
+  const center = useMemo(() => {
+    if (origins.length === 0) return { lat: 0, lng: 0 };
+    return origins.reduce(
+      (acc, cur) => ({ lat: acc.lat + cur.lat / origins.length, lng: acc.lng + cur.lng / origins.length }),
+      { lat: 0, lng: 0 }
+    );
+  }, [origins]);
+
+  const heatArray = useMemo(() => {
+    if (!heatData) return [] as google.maps.visualization.WeightedLocation[];
+    return heatData.points.map((p) => ({ location: new google.maps.LatLng(p.lat, p.lng), weight: p.weight }));
+  }, [heatData]);
+
+  const letters = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
+
+  if (!isLoaded) return <div className="h-96 w-full bg-gray-200" />;
+
+  return (
+    <GoogleMap center={center} zoom={13} mapContainerStyle={{ width: "100%", height: "500px" }}>
+      {heatArray.length > 0 && <HeatmapLayer data={heatArray} options={{ radius: 20 }} />}
+      {origins.map((o, i) => (
+        <Marker key={i} position={o} label={letters[i] || String(i + 1)} />
+      ))}
+      {candidates.map((c, i) => (
+        <Marker key={c.id} position={c.location} label={String(i + 1)} />
+      ))}
+    </GoogleMap>
+  );
+}

--- a/packages/halfway-utils/groupAlgorithm.ts
+++ b/packages/halfway-utils/groupAlgorithm.ts
@@ -1,0 +1,119 @@
+export type LatLng = { lat: number; lng: number };
+export type Candidate = {
+  id: string;
+  name: string;
+  address: string;
+  location: LatLng;
+  rating?: number;
+  price_level?: number;
+  durations?: number[];
+  cost?: number;
+};
+
+import { haversineDistance } from "../../lib/sorters";
+
+const GOOGLE_KEY = process.env.GOOGLE_MAPS_API_KEY!;
+
+async function candidateGeneration(origins: LatLng[], type = "restaurant"): Promise<Candidate[]> {
+  const centroid = origins.reduce(
+    (acc, cur) => ({ lat: acc.lat + cur.lat / origins.length, lng: acc.lng + cur.lng / origins.length }),
+    { lat: 0, lng: 0 }
+  );
+  const radius = Math.min(
+    5000,
+    Math.max(...origins.map((o) => haversineDistance(o, centroid)))
+  );
+
+  let results: any[] = [];
+  let pageToken: string | undefined;
+  while (results.length < 50) {
+    const url =
+      `https://maps.googleapis.com/maps/api/place/nearbysearch/json?location=${centroid.lat},${centroid.lng}` +
+      `&radius=${radius}&type=${type}&key=${GOOGLE_KEY}` +
+      (pageToken ? `&pagetoken=${pageToken}` : "");
+    const res = await fetch(url);
+    if (!res.ok) break;
+    const data = await res.json();
+    results = results.concat(data.results || []);
+    pageToken = data.next_page_token;
+    if (!pageToken) break;
+    await new Promise((r) => setTimeout(r, 2000));
+  }
+  results = results.slice(0, 50);
+
+  const candidates: Candidate[] = [];
+  for (const place of results) {
+    const detailUrl =
+      `https://maps.googleapis.com/maps/api/place/details/json?place_id=${place.place_id}` +
+      `&fields=name,formatted_address,rating,price_level,geometry&key=${GOOGLE_KEY}`;
+    const det = await fetch(detailUrl);
+    const d = det.ok ? await det.json() : { result: {} };
+    const info = { ...place, ...d.result };
+    candidates.push({
+      id: place.place_id,
+      name: info.name,
+      address: info.formatted_address || place.vicinity,
+      location: {
+        lat: info.geometry?.location?.lat ?? place.geometry.location.lat,
+        lng: info.geometry?.location?.lng ?? place.geometry.location.lng,
+      },
+      rating: info.rating,
+      price_level: info.price_level,
+    });
+  }
+  return candidates;
+}
+
+async function travelMatrix(origins: LatLng[], candidates: Candidate[]): Promise<number[][]> {
+  const originChunks = chunk(origins, 25);
+  const destChunks = chunk(candidates.map((c) => c.location), 25);
+  const matrix: number[][] = Array.from({ length: origins.length }, () => Array(candidates.length).fill(Infinity));
+  for (let oi = 0; oi < originChunks.length; oi++) {
+    for (let di = 0; di < destChunks.length; di++) {
+      const oStr = originChunks[oi].map((o) => `${o.lat},${o.lng}`).join("|");
+      const dStr = destChunks[di].map((d) => `${d.lat},${d.lng}`).join("|");
+      const url =
+        `https://maps.googleapis.com/maps/api/distancematrix/json?key=${GOOGLE_KEY}` +
+        `&origins=${oStr}&destinations=${dStr}`;
+      const res = await fetch(url);
+      if (!res.ok) continue;
+      const data = await res.json();
+      data.rows.forEach((row: any, rIdx: number) => {
+        row.elements.forEach((el: any, cIdx: number) => {
+          const origIndex = oi * 25 + rIdx;
+          const destIndex = di * 25 + cIdx;
+          if (origIndex < origins.length && destIndex < candidates.length) {
+            matrix[origIndex][destIndex] = el.duration?.value ?? Infinity;
+          }
+        });
+      });
+    }
+  }
+  return matrix;
+}
+
+function scoreCandidates(origins: LatLng[], candidates: Candidate[], matrix: number[][], topN = 10): Candidate[] {
+  const scored: Candidate[] = candidates.map((c, j) => {
+    const durations = matrix.map((row) => row[j]);
+    const mean = durations.reduce((a, b) => a + b, 0) / durations.length;
+    const variance = durations.reduce((s, d) => s + (d - mean) ** 2, 0) / durations.length;
+    const total = durations.reduce((a, b) => a + b, 0);
+    const cost = variance + total / durations.length;
+    return { ...c, durations, cost };
+  });
+  return scored.sort((a, b) => (a.cost ?? 0) - (b.cost ?? 0)).slice(0, topN);
+}
+
+function chunk<T>(arr: T[], size: number): T[][] {
+  const chunks: T[][] = [];
+  for (let i = 0; i < arr.length; i += size) {
+    chunks.push(arr.slice(i, i + size));
+  }
+  return chunks;
+}
+
+export async function findBestVenues(origins: LatLng[], type = "restaurant", topN = 10): Promise<Candidate[]> {
+  const candidates = await candidateGeneration(origins, type);
+  const matrix = await travelMatrix(origins, candidates);
+  return scoreCandidates(origins, candidates, matrix, topN);
+}

--- a/tests/groupAlgorithm.test.ts
+++ b/tests/groupAlgorithm.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { findBestVenues, LatLng, Candidate } from "../packages/halfway-utils/groupAlgorithm";
+
+const mockFetch = vi.fn();
+
+beforeEach(() => {
+  mockFetch.mockReset();
+  global.fetch = mockFetch as any;
+});
+
+describe("findBestVenues", () => {
+  it("orders venues by cost", async () => {
+    const origins: LatLng[] = [
+      { lat: 0, lng: 0 },
+      { lat: 0.001, lng: 0.001 },
+    ];
+    // First call: nearbysearch
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        results: [
+          { place_id: "p1", geometry: { location: { lat: 0, lng: 0 } } },
+          { place_id: "p2", geometry: { location: { lat: 0, lng: 0 } } },
+        ],
+      }),
+    } as any);
+    // details p1
+    mockFetch.mockResolvedValueOnce({ ok: true, json: async () => ({ result: { name: "A", formatted_address: "a" } }) } as any);
+    // details p2
+    mockFetch.mockResolvedValueOnce({ ok: true, json: async () => ({ result: { name: "B", formatted_address: "b" } }) } as any);
+    // distance matrix
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        rows: [
+          { elements: [{ duration: { value: 600 } }, { duration: { value: 700 } }] },
+          { elements: [{ duration: { value: 1200 } }, { duration: { value: 700 } }] },
+        ],
+      }),
+    } as any);
+
+    const res = await findBestVenues(origins, "restaurant", 2);
+    expect(res).toHaveLength(2);
+    expect(res[0].id).toBe("p2");
+    expect(res[1].id).toBe("p1");
+  });
+});


### PR DESCRIPTION
## Summary
- add groupAlgorithm utility to score meeting venues
- expose heatmap API endpoint for group halfway
- render markers and heat layer via GroupHalfwayMap component
- test candidate scoring with vitest

## Testing
- `npm run lint`
- `npx vitest run tests/groupAlgorithm.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_688bad526ee08329a1481ee82cdcbd12