### PR TITLE
Add trade preview util and update modal

### DIFF
--- a/lib/prediction/tradePreview.ts
+++ b/lib/prediction/tradePreview.ts
@@ -1,0 +1,24 @@
+import { costToBuy } from "./lmsr";
+
+export function estimateShares(
+  side: "YES" | "NO",
+  spend: number,
+  yes: number,
+  no: number,
+  b: number
+): { shares: number; cost: number } {
+  if (spend <= 0) return { shares: 0, cost: 0 };
+  let lo = 0;
+  let hi = 1;
+  while (costToBuy(side, hi, yes, no, b) < spend) {
+    hi *= 2;
+  }
+  for (let i = 0; i < 30; i++) {
+    const mid = (lo + hi) / 2;
+    const c = costToBuy(side, mid, yes, no, b);
+    if (c > spend) hi = mid; else lo = mid;
+  }
+  const shares = lo;
+  const cost = Math.ceil(costToBuy(side, shares, yes, no, b));
+  return { shares, cost };
+}

--- a/tests/tradePreview.test.ts
+++ b/tests/tradePreview.test.ts
@@ -1,0 +1,15 @@
+import { estimateShares } from "@/lib/prediction/tradePreview";
+import { priceYes } from "@/lib/prediction/lmsr";
+
+describe("trade preview", () => {
+  test("spend 0 yields no shares", () => {
+    const { shares } = estimateShares("YES", 0, 0, 0, 100);
+    expect(shares).toBe(0);
+  });
+
+  test("large spend pushes price near 100%", () => {
+    const { shares } = estimateShares("YES", 1_000_000, 0, 0, 100);
+    const price = priceYes(shares, 0, 100);
+    expect(price).toBeGreaterThan(0.99);
+  });
+});


### PR DESCRIPTION
## Summary
- support trading preview logic with `estimateShares`
- fetch wallet balance for max spend in trade modal
- display updated LMSR preview information and disable trade button when overspending
- test new `estimateShares` helper

## Testing
- `npx next lint`
- `npm test` *(fails: PrismaClientInitializationError and other missing env vars)*

------
https://chatgpt.com/codex/tasks/task_e_688c06e778388329a859c3d77261a63c