### PR TITLE
Add optimistic SWR flow for markets

### DIFF
--- a/components/cards/PredictionMarketCard.tsx
+++ b/components/cards/PredictionMarketCard.tsx
@@ -2,6 +2,7 @@
 import TradePredictionModal from "../modals/TradePredictionModal";
 import ResolveMarketDialog from "../modals/ResolveMarketDialog";
 import { useMarket } from "@/hooks/useMarket";
+import { priceYes } from "@/lib/prediction/lmsr";
 import { timeUntil } from "@/lib/utils";
 import { useState } from "react";
 
@@ -10,19 +11,18 @@ interface Props {
 }
 
 export default function PredictionMarketCard({ post }: Props) {
-  const { market, mutate } = useMarket(post.predictionMarket.id);
-  const price = market?.price ?? 0.5;
+  const { data: market, mutate } = useMarket(post.predictionMarket.id);
+  const price = market ? priceYes(market.yesPool, market.noPool, market.b) : 0.5;
   // const closesAt =
   //   market?.market.closesAt ? market.market.closesAt
   //                           : post.predictionMarket.closesAt;  
-  const closesAt =
-  market?.market.closesAt ?? post.predictionMarket?.closesAt;
+  const closesAt = market?.closesAt ?? post.predictionMarket?.closesAt;
 
 const countdown =
   closesAt ? timeUntil(closesAt) : '--';
 
-    const state = market?.market.state ?? post.predictionMarket.state;
-  const outcome = market?.market.outcome ?? post.predictionMarket.outcome;
+    const state = market?.state ?? post.predictionMarket.state;
+  const outcome = market?.outcome ?? post.predictionMarket.outcome;
   const canResolve = market?.canResolve ?? false;
   const [showTrade, setShowTrade] = useState(false);
   const [showResolve, setShowResolve] = useState(false);
@@ -59,11 +59,11 @@ const countdown =
       {state === "OPEN" && (
   <span className="text-xs p-4 mt-4">Closes in {countdown}</span>
   )}
-      {showTrade && post.predictionMarket && (
+      {showTrade && market && (
         <TradePredictionModal
-          market={post.predictionMarket}
+          market={market}
           onClose={() => setShowTrade(false)}
-          mutate={() => mutate()}
+          mutateMarket={mutate}
         />
       )}
       {state === "CLOSED" && !canResolve && (

--- a/hooks/useMarket.ts
+++ b/hooks/useMarket.ts
@@ -3,11 +3,5 @@ import useSWR from "swr";
 
 const fetcher = (url: string) => fetch(url).then((r) => r.json());
 
-export function useMarket(id: string) {
-  const { data, mutate } = useSWR(
-    `/api/market/${id}`,
-    fetcher,
-    { refreshInterval: 5000 }
-  );
-  return { market: data, mutate };
-}
+export const useMarket = (id: string) =>
+  useSWR(`/api/market/${id}`, fetcher, { refreshInterval: 5000 });


### PR DESCRIPTION
## Summary
- update `useMarket` to return SWR response
- calculate price from pool balances in `PredictionMarketCard`
- pass mutate down and optimistically update pools in `TradePredictionModal`

## Testing
- `npm run lint` *(fails: React Hooks must be called in the exact same order)*
- `npm test` *(fails to connect to database and other test errors)*

------
https://chatgpt.com/codex/tasks/task_e_688c31cc6ce083298224d5ff4f2d6716