### PR TITLE
Improve trade modal error handling

### DIFF
--- a/components/modals/TradePredictionModal.tsx
+++ b/components/modals/TradePredictionModal.tsx
@@ -5,6 +5,7 @@ import { estimateShares } from "@/lib/prediction/tradePreview";
 import { Button } from "../ui/button";
 import { Slider } from "../ui/slider";
 import Spinner from "../ui/spinner";
+import { Alert } from "../ui/alert";
 import { toast } from "sonner";
 
 interface Market {
@@ -73,10 +74,9 @@ export default function TradePredictionModal({ market, onClose, mutateMarket }: 
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ side, spendCents: cost }),
       });
-      if (!resp.ok) {
-        const text = await resp.text();
-        toast.error(text);
-        setPending(false);
+      if (resp.status !== 200) {
+        const data = await resp.json().catch(() => ({}));
+        setError(data.error ?? "Trade failed");
         return;
       }
       const result = await resp.json();
@@ -96,8 +96,8 @@ export default function TradePredictionModal({ market, onClose, mutateMarket }: 
         `Bought ${tradedShares.toFixed(2)} shares @ ${(priceAfter * 100).toFixed(2)} %`
       );
       onClose();
-    } catch (e: any) {
-      toast.error("Trade failed");
+    } catch {
+      toast.error("Network error");
     } finally {
       setPending(false);
     }
@@ -140,7 +140,7 @@ export default function TradePredictionModal({ market, onClose, mutateMarket }: 
           onValueChange={([v]) => setSpend(v)}
           className="w-full"
         />
-        {error && <div className="text-red-500 text-sm">{error}</div>}
+        {error && <Alert variant="destructive">{error}</Alert>}
         <div className="text-sm text-gray-700" aria-live="polite">
           Cost: {cost} credits — New balance: {maxSpend - cost}
         </div>

--- a/components/ui/alert.tsx
+++ b/components/ui/alert.tsx
@@ -1,0 +1,39 @@
+"use client"
+
+import * as React from "react"
+import { cva, type VariantProps } from "class-variance-authority"
+
+import { cn } from "@/lib/utils"
+
+const alertVariants = cva(
+  "w-full rounded-md border p-4 text-sm",
+  {
+    variants: {
+      variant: {
+        default: "bg-background text-foreground",
+        destructive: "border-destructive/50 text-destructive"
+      }
+    },
+    defaultVariants: {
+      variant: "default"
+    }
+  }
+)
+
+export interface AlertProps
+  extends React.HTMLAttributes<HTMLDivElement>,
+    VariantProps<typeof alertVariants> {}
+
+const Alert = React.forwardRef<HTMLDivElement, AlertProps>(
+  ({ className, variant, ...props }, ref) => (
+    <div
+      ref={ref}
+      role="alert"
+      className={cn(alertVariants({ variant }), className)}
+      {...props}
+    />
+  )
+)
+Alert.displayName = "Alert"
+
+export { Alert }


### PR DESCRIPTION
## Summary
- add `Alert` UI component
- handle trade API errors and network failures in `TradePredictionModal`

## Testing
- `yarn install --frozen-lockfile`
- `npm run lint` *(fails: react-hooks)*

------
https://chatgpt.com/codex/tasks/task_e_688c36ee25948329b39904252ca78308