### PR TITLE
Add market resolution UI

### DIFF
--- a/apps/web/src/components/modals/ResolveMarketDialog.tsx
+++ b/apps/web/src/components/modals/ResolveMarketDialog.tsx
@@ -1,0 +1,52 @@
+"use client";
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import Spinner from "@/components/ui/spinner";
+import { toast } from "sonner";
+
+interface Props {
+  marketId: string;
+  onResolved: () => void;
+}
+
+export default function ResolveMarketDialog({ marketId, onResolved }: Props) {
+  const [outcome, setOutcome] = useState<"YES" | "NO" | null>(null);
+  const [pending, setPending] = useState(false);
+
+  async function handleConfirm() {
+    if (!outcome) return;
+    setPending(true);
+    try {
+      const resp = await fetch(`/api/market/${marketId}/resolve`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ outcome }),
+      });
+      if (resp.ok) {
+        onResolved();
+      } else {
+        toast.error("Resolution failed");
+      }
+    } catch {
+      toast.error("Resolution failed");
+    } finally {
+      setPending(false);
+    }
+  }
+
+  return (
+    <div className="border-[1px] border-white px-8 py-6 space-y-4 bg-white bg-opacity-20 rounded-xl shadow-md">
+      <div className="space-y-2">
+        {(["YES", "NO"] as const).map((o) => (
+          <label key={o} className="flex items-center gap-2">
+            <input type="radio" checked={outcome === o} onChange={() => setOutcome(o)} />
+            {o}
+          </label>
+        ))}
+      </div>
+      <Button onClick={handleConfirm} disabled={pending || !outcome} className="w-fit px-6 py-2 likebutton bg-white bg-opacity-40">
+        {pending ? <Spinner className="h-4 w-4" /> : "Confirm"}
+      </Button>
+    </div>
+  );
+}

--- a/components/cards/PredictionMarketCard.tsx
+++ b/components/cards/PredictionMarketCard.tsx
@@ -1,6 +1,6 @@
 "use client";
 import TradePredictionModal from "../modals/TradePredictionModal";
-import ResolveMarketDialog from "../modals/ResolveMarketDialog";
+import ResolveMarketDialog from "@/apps/web/src/components/modals/ResolveMarketDialog";
 import { useMarket } from "@/hooks/useMarket";
 import { priceYes } from "@/lib/prediction/lmsr";
 import { timeUntil } from "@/lib/utils";
@@ -72,12 +72,14 @@ const countdown =
       {showResolve && (
         <ResolveMarketDialog
           marketId={post.predictionMarket.id}
-          onClose={() => setShowResolve(false)}
-          mutate={() => mutate()}
+          onResolved={() => {
+            mutate();
+            setShowResolve(false);
+          }}
         />
       )}
       {state === "RESOLVED" && (
-        <div className="text-[sm] font-medium">Outcome: {outcome}</div>
+        <div className="text-[sm] font-medium">Resolved: {outcome}</div>
       )}
     </div>
   );

--- a/tests/prediction/resolve-ui.e2e.ts
+++ b/tests/prediction/resolve-ui.e2e.ts
@@ -1,0 +1,8 @@
+import { test, expect } from "@playwright/test";
+
+test.skip("creator resolves closed market via UI", async ({ page }) => {
+  // This test requires a running server with authentication.
+  // The workflow: create market, fast-forward close, resolve to YES,
+  // then verify UI shows resolved outcome and no Trade button.
+  await page.goto("/");
+});


### PR DESCRIPTION
## Summary
- implement ResolveMarketDialog component under apps/web
- update PredictionMarketCard to use new dialog
- show resolved outcome in card
- add skeleton Playwright test for resolve UI

## Testing
- `yarn lint` *(fails: React hook rule errors)*
- `npx playwright test` *(fails: prisma runtime errors)*

------
https://chatgpt.com/codex/tasks/task_e_688c464f669c8329a17e13f4ae1f2ba4