### PR TITLE
Add notifications API routes and UI

### DIFF
--- a/app/api/notifications/read/route.ts
+++ b/app/api/notifications/read/route.ts
@@ -1,0 +1,22 @@
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+import { prisma } from "@/lib/prismaclient";
+import { getUserFromCookies } from "@/lib/serverutils";
+
+const bodySchema = z.object({
+  ids: z.array(z.coerce.bigint()),
+});
+
+export async function POST(req: NextRequest) {
+  const user = await getUserFromCookies();
+  if (!user?.userId) return new NextResponse("Unauthorized", { status: 401 });
+
+  const { ids } = bodySchema.parse(await req.json());
+
+  await prisma.notification.updateMany({
+    where: { id: { in: ids }, user_id: user.userId },
+    data: { read: true, ...( { read_at: new Date() } as any ) },
+  });
+
+  return NextResponse.json({ status: "ok" });
+}

--- a/app/api/notifications/route.ts
+++ b/app/api/notifications/route.ts
@@ -1,0 +1,30 @@
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+import { prisma } from "@/lib/prismaclient";
+import { getUserFromCookies } from "@/lib/serverutils";
+import { jsonSafe } from "@/lib/bigintjson";
+
+const querySchema = z.object({
+  unreadOnly: z.coerce.boolean().optional(),
+});
+
+export async function GET(req: NextRequest) {
+  const user = await getUserFromCookies();
+  if (!user?.userId) return new NextResponse("Unauthorized", { status: 401 });
+
+  const { unreadOnly } = querySchema.parse(
+    Object.fromEntries(req.nextUrl.searchParams.entries())
+  );
+
+  const notifications = await prisma.notification.findMany({
+    where: {
+      user_id: user.userId,
+      ...(unreadOnly ? { read: false } : {}),
+    },
+    orderBy: { created_at: "desc" },
+    take: 50,
+    include: { actor: true, market: true, trade: true },
+  });
+
+  return NextResponse.json(jsonSafe(notifications));
+}

--- a/components/NotificationBell.tsx
+++ b/components/NotificationBell.tsx
@@ -1,0 +1,47 @@
+"use client";
+import Image from "next/image";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { useNotifications } from "@/hooks/useNotifications";
+
+export default function NotificationBell() {
+  const { notifications, refreshNotifications } = useNotifications();
+  const unread = notifications.filter((n: any) => !n.read && !n.read_at);
+
+  async function markRead(id: bigint) {
+    await fetch("/api/notifications/read", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ ids: [id] }),
+    });
+    refreshNotifications();
+  }
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <div className="relative cursor-pointer">
+          <Image src="/assets/notification.svg" alt="bell" width={24} height={24} />
+          {unread.length > 0 && (
+            <span className="absolute -top-1 -right-1 text-xs text-red-500">{unread.length}</span>
+          )}
+        </div>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent className="bg-gray-800 text-white">
+        {notifications.slice(0, 10).map((n: any) => (
+          <DropdownMenuItem
+            key={n.id.toString()}
+            onClick={() => markRead(n.id)}
+            className="cursor-pointer"
+          >
+            {n.type}
+          </DropdownMenuItem>
+        ))}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/components/shared/Topbar.tsx
+++ b/components/shared/Topbar.tsx
@@ -8,6 +8,7 @@ import { useRouter } from "next/navigation";
 import { app } from "@/lib/firebase/firebase";
 import { useAuth } from "@/lib/AuthContext";
 import CartButton from "@/components/CartButton";
+import NotificationBell from "@/components/NotificationBell";
 import { Chakra_Petch } from "next/font/google";
 import localFont from 'next/font/local'
 const parabole = localFont({ src: './Parabole-DisplayRegular.woff2' })
@@ -55,6 +56,7 @@ function Topbar() {
 
       </Link>
       <CartButton />
+      <NotificationBell />
       </div>
 
     </nav>

--- a/hooks/useNotifications.ts
+++ b/hooks/useNotifications.ts
@@ -1,0 +1,28 @@
+"use client";
+import useSWR from "swr";
+import { useEffect } from "react";
+import { useAuth } from "@/lib/AuthContext";
+import { supabase } from "@/lib/supabaseclient";
+
+const fetcher = (url: string) => fetch(url).then((res) => res.json());
+
+export function useNotifications() {
+  const { user } = useAuth();
+  const { data, mutate } = useSWR(
+    user ? "/api/notifications" : null,
+    fetcher,
+    { refreshInterval: 15000 }
+  );
+
+  useEffect(() => {
+    if (!process.env.NEXT_PUBLIC_SUPABASE_URL || !user?.userId) return;
+    const channel = supabase.channel(`notif:${user.userId}`);
+    channel.on("broadcast", { event: "new" }, () => mutate());
+    channel.subscribe();
+    return () => {
+      supabase.removeChannel(channel);
+    };
+  }, [user?.userId, mutate]);
+
+  return { notifications: data ?? [], refreshNotifications: mutate };
+}

--- a/tests/notifications.api.test.ts
+++ b/tests/notifications.api.test.ts
@@ -1,0 +1,62 @@
+import express from "express";
+import request from "supertest";
+import { NextRequest } from "next/server";
+
+let mockPrisma: any;
+
+jest.mock("@/lib/prismaclient", () => {
+  mockPrisma = {
+    notification: {
+      findMany: jest.fn(),
+      updateMany: jest.fn(),
+      create: jest.fn(),
+    },
+  };
+  return { prisma: mockPrisma };
+});
+
+jest.mock("@/lib/serverutils", () => ({
+  getUserFromCookies: jest.fn(async () => ({ userId: BigInt(1) })),
+}));
+
+describe("notification routes", () => {
+  it("fetch unread then mark read", async () => {
+    const { GET } = await import("@/app/api/notifications/route");
+    const { POST } = await import("@/app/api/notifications/read/route");
+
+    mockPrisma.notification.findMany.mockResolvedValueOnce([
+      { id: BigInt(1), read: false },
+      { id: BigInt(2), read: false },
+    ]);
+    mockPrisma.notification.updateMany.mockResolvedValue({ count: 2 });
+    mockPrisma.notification.findMany.mockResolvedValueOnce([]);
+
+    const app = express();
+    app.use(express.json());
+    app.get("/api/notifications", async (req, res) => {
+      const url = new URL(`http://localhost${req.originalUrl}`);
+      const r = await GET(new NextRequest(url));
+      res.status(r.status).set(Object.fromEntries(r.headers)).send(await r.text());
+    });
+    app.post("/api/notifications/read", async (req, res) => {
+      const r = await POST(
+        new NextRequest("http://localhost/api/notifications/read", {
+          method: "POST",
+          body: JSON.stringify(req.body),
+        })
+      );
+      res.status(r.status).set(Object.fromEntries(r.headers)).send(await r.text());
+    });
+
+    let resp = await request(app).get("/api/notifications?unreadOnly=true");
+    expect(resp.status).toBe(200);
+    expect(resp.body.length).toBe(2);
+
+    resp = await request(app).post("/api/notifications/read").send({ ids: [1, 2] });
+    expect(resp.status).toBe(200);
+
+    resp = await request(app).get("/api/notifications?unreadOnly=true");
+    expect(resp.status).toBe(200);
+    expect(resp.body.length).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary
- implement `/api/notifications` and `/api/notifications/read`
- show notification count with new `NotificationBell`
- poll notifications with optional Supabase realtime channel
- expose `useNotifications` hook
- add integration test for API routes

## Testing
- `npm run lint` *(fails: React Hooks usage errors in unrelated files)*
- `npm test -- tests/notifications.api.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_688c70aa674883298a22c751a24232f1