### PR TITLE
Add prediction market tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,3 +14,15 @@ jobs:
       - run: yarn install --frozen-lockfile
       - run: npm run lint
       - run: npm test -- --runInBand
+
+  e2e:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+      - run: yarn install --frozen-lockfile
+      - run: npx playwright install --with-deps
+      - run: npx playwright test

--- a/packages/server/tests/lmsr.test.ts
+++ b/packages/server/tests/lmsr.test.ts
@@ -1,0 +1,38 @@
+import { priceYes, costToBuy, estimateShares } from "@/lib/prediction/lmsr";
+
+describe("lmsr helpers", () => {
+  test("zero pools yields 50/50", () => {
+    expect(priceYes(0, 0, 100)).toBeCloseTo(0.5, 5);
+  });
+
+  test("buy 100¢ YES moves price", () => {
+    const { deltaQ } = estimateShares("YES", 100, { yesPool: 0, noPool: 0, b: 100 });
+    const cost = costToBuy("YES", deltaQ, 0, 0, 100);
+    expect(cost).toBeLessThanOrEqual(100);
+    const newPrice = priceYes(deltaQ, 0, 100);
+    expect(newPrice).toBeGreaterThan(0.55);
+    expect(newPrice).toBeLessThan(0.7);
+  });
+
+  test("price symmetry", () => {
+    const yes = priceYes(5, 3, 50);
+    const no = 1 - priceYes(5, 3, 50);
+    expect(yes + no).toBeCloseTo(1, 9);
+  });
+
+  test("large b keeps price near 0.5", () => {
+    const { deltaQ } = estimateShares("YES", 100, { yesPool: 0, noPool: 0, b: 1e6 });
+    const newPrice = priceYes(deltaQ, 0, 1e6);
+    expect(newPrice).toBeCloseTo(0.5, 3);
+  });
+
+  test("estimateShares converges", () => {
+    const spend = 123;
+    const { shares, cost } = estimateShares("YES", spend, { yesPool: 10, noPool: 5, b: 50 });
+    expect(cost).toBeLessThanOrEqual(spend);
+    expect(cost).toBeGreaterThan(spend - 1);
+    const actualCost = costToBuy("YES", shares, 10, 5, 50);
+    expect(actualCost).toBeLessThanOrEqual(spend);
+    expect(actualCost).toBeGreaterThan(spend - 1);
+  });
+});

--- a/packages/server/tests/market.flow.test.ts
+++ b/packages/server/tests/market.flow.test.ts
@@ -1,0 +1,160 @@
+import express from "express";
+import request from "supertest";
+import { NextRequest } from "next/server";
+
+let currentUser: bigint = BigInt(1);
+const db = {
+  market: null as any,
+  wallets: new Map<bigint, { userId: bigint; balanceCents: number; lockedCents: number }>([
+    [BigInt(1), { userId: BigInt(1), balanceCents: 1000, lockedCents: 0 }],
+    [BigInt(2), { userId: BigInt(2), balanceCents: 1000, lockedCents: 0 }],
+    [BigInt(3), { userId: BigInt(3), balanceCents: 1000, lockedCents: 0 }],
+  ]),
+  trades: [] as any[],
+};
+
+jest.mock("@/lib/prismaclient", () => {
+  const prisma = {
+    $transaction: async (fn: any) => fn(prisma),
+    $executeRaw: async () => {},
+    predictionMarket: {
+      findUniqueOrThrow: async ({ where: { id } }: any) => {
+        if (!db.market || db.market.id !== id) throw new Error("not found");
+        return { ...db.market };
+      },
+      update: async ({ where: { id }, data }: any) => {
+        if (!db.market || db.market.id !== id) throw new Error("not found");
+        if (data.yesPool?.increment) db.market.yesPool += data.yesPool.increment;
+        if (data.noPool?.increment) db.market.noPool += data.noPool.increment;
+        if (data.state) db.market.state = data.state;
+        if (data.outcome) db.market.outcome = data.outcome;
+        if (data.resolvesAt) db.market.resolvesAt = data.resolvesAt;
+        return { ...db.market };
+      },
+    },
+    wallet: {
+      findUnique: async ({ where: { userId } }: any) => {
+        const w = db.wallets.get(userId);
+        return w ? { ...w } : null;
+      },
+      create: async ({ data }: any) => {
+        db.wallets.set(data.userId, { ...data });
+        return { ...data };
+      },
+      update: async ({ where: { userId }, data }: any) => {
+        const w = db.wallets.get(userId)!;
+        if (data.balanceCents?.decrement) w.balanceCents -= data.balanceCents.decrement;
+        if (data.balanceCents?.increment) w.balanceCents += data.balanceCents.increment;
+        return { ...w };
+      },
+    },
+    trade: {
+      create: async ({ data }: any) => {
+        const t = { id: String(db.trades.length + 1), ...data };
+        db.trades.push(t);
+        return t;
+      },
+      findMany: async ({ where: { marketId } }: any) => db.trades.filter(t => t.marketId === marketId),
+    },
+    notification: { create: jest.fn(), createMany: jest.fn() },
+    resolutionLog: { create: jest.fn() },
+  };
+  return { prisma };
+});
+
+jest.mock("@/lib/serverutils", () => ({
+  getUserFromCookies: jest.fn(async () => ({ userId: currentUser })),
+}));
+
+jest.mock("@/lib/actions/prediction.actions", () => ({
+  createMarket: jest.fn(async ({ question, closesAt, liquidity }: any) => {
+    const sanitized = question.replace(/<[^>]+>/g, "");
+    db.market = {
+      id: "m1",
+      question: sanitized,
+      closesAt: new Date(closesAt),
+      b: liquidity ?? 100,
+      state: "OPEN",
+      creatorId: currentUser,
+      oracleId: null,
+      yesPool: 0,
+      noPool: 0,
+    };
+    return { postId: "p1" };
+  }),
+}));
+
+describe("market API flow", () => {
+  beforeEach(() => {
+    currentUser = BigInt(1);
+    db.market = null;
+    db.trades.length = 0;
+    db.wallets.get(BigInt(1))!.balanceCents = 1000;
+    db.wallets.get(BigInt(2))!.balanceCents = 1000;
+    db.wallets.get(BigInt(3))!.balanceCents = 1000;
+    process.env.ENABLE_PREDICTION_MARKETS = "true";
+  });
+
+  it("full lifecycle", async () => {
+    const { POST: createMarketRoute } = await import("@/app/api/market/route");
+    const { POST: tradeRoute } = await import("@/app/api/market/[id]/trade/route");
+    const { POST: resolveRoute } = await import("@/app/api/market/[id]/resolve/route");
+    const { GET: walletGet } = await import("@/app/api/wallet/route");
+
+    const app = express();
+    app.use(express.json());
+
+    app.post("/api/market", async (req, res) => {
+      const r = await createMarketRoute(new NextRequest("http://localhost/api/market", { method: "POST", body: JSON.stringify(req.body) }));
+      res.status(r.status).set(Object.fromEntries(r.headers)).send(await r.text());
+    });
+    app.post("/api/market/:id/trade", async (req, res) => {
+      const r = await tradeRoute(new NextRequest(`http://localhost/api/market/${req.params.id}/trade`, { method: "POST", body: JSON.stringify(req.body) }), { params: { id: req.params.id } });
+      res.status(r.status).set(Object.fromEntries(r.headers)).send(await r.text());
+    });
+    app.post("/api/market/:id/resolve", async (req, res) => {
+      const r = await resolveRoute(new NextRequest(`http://localhost/api/market/${req.params.id}/resolve`, { method: "POST", body: JSON.stringify(req.body) }), { params: { id: req.params.id } });
+      res.status(r.status).set(Object.fromEntries(r.headers)).send(await r.text());
+    });
+    app.get("/api/wallet", async (_req, res) => {
+      const r = await walletGet(new NextRequest("http://localhost/api/wallet"));
+      res.status(r.status).set(Object.fromEntries(r.headers)).send(await r.text());
+    });
+
+    // Create market as user A
+    await request(app).post("/api/market").send({ question: "Q?", closesAt: new Date().toISOString(), b: 100 });
+    const startingTotal = Array.from(db.wallets.values()).reduce((a, w) => a + w.balanceCents, 0);
+
+    // User B trades YES
+    currentUser = BigInt(2);
+    let resp = await request(app).post("/api/market/m1/trade").send({ spendCents: 200, side: "YES" });
+    expect(resp.status).toBe(200);
+    expect(db.wallets.get(BigInt(2))!.balanceCents).toBe(800);
+
+    // Insufficient funds
+    resp = await request(app).post("/api/market/m1/trade").send({ spendCents: 1_000_000, side: "YES" });
+    expect(resp.status).toBe(402);
+
+    // Close market
+    const { prisma } = await import("@/lib/prismaclient");
+    await prisma.predictionMarket.update({ where: { id: "m1" }, data: { state: "CLOSED" } });
+
+    // Resolve by creator
+    currentUser = BigInt(1);
+    resp = await request(app).post("/api/market/m1/resolve").send({ outcome: "YES" });
+    expect(resp.status).toBe(200);
+
+    // Sum of wallets preserved
+    const w1 = await request(app).get("/api/wallet");
+    currentUser = BigInt(2);
+    const w2 = await request(app).get("/api/wallet");
+    currentUser = BigInt(3);
+    const w3 = await request(app).get("/api/wallet");
+    const finalTotal = Number(w1.body.balanceCents) + Number(w2.body.balanceCents) + Number(w3.body.balanceCents);
+    expect(finalTotal).toBe(startingTotal);
+
+    // Unauthorized resolve attempt by user C
+    resp = await request(app).post("/api/market/m1/resolve").send({ outcome: "YES" });
+    expect(resp.status).toBe(403);
+  });
+});

--- a/packages/server/tests/security.test.ts
+++ b/packages/server/tests/security.test.ts
@@ -1,0 +1,109 @@
+import express from "express";
+import request from "supertest";
+import { NextRequest } from "next/server";
+
+let currentUser: bigint = BigInt(1);
+const db = {
+  market: {
+    id: "m1",
+    yesPool: 0,
+    noPool: 0,
+    b: 100,
+    state: "OPEN" as const,
+    creatorId: BigInt(1),
+  },
+  wallets: new Map<bigint, { userId: bigint; balanceCents: number; lockedCents: number }>([
+    [BigInt(1), { userId: BigInt(1), balanceCents: 1000, lockedCents: 0 }],
+  ]),
+};
+
+jest.mock("@/lib/prismaclient", () => {
+  const prisma = {
+    $transaction: async (fn: any) => fn(prisma),
+    $executeRaw: async () => {},
+    predictionMarket: {
+      findUniqueOrThrow: async ({ where: { id } }: any) => {
+        if (db.market.id !== id) throw new Error("not found");
+        return { ...db.market };
+      },
+      update: async ({ where: { id }, data }: any) => {
+        if (db.market.id !== id) throw new Error("not found");
+        if (data.state) db.market.state = data.state;
+        if (data.outcome) (db.market as any).outcome = data.outcome;
+        return { ...db.market };
+      },
+    },
+    wallet: {
+      findUnique: async ({ where: { userId } }: any) => {
+        return db.wallets.get(userId) ?? null;
+      },
+      create: async ({ data }: any) => {
+        db.wallets.set(data.userId, { ...data });
+        return data;
+      },
+      update: async ({ where: { userId }, data }: any) => {
+        const w = db.wallets.get(userId)!;
+        if (data.balanceCents?.decrement) w.balanceCents -= data.balanceCents.decrement;
+        if (data.balanceCents?.increment) w.balanceCents += data.balanceCents.increment;
+        return { ...w };
+      },
+    },
+    trade: { create: jest.fn(), findMany: jest.fn(() => []) },
+    notification: { create: jest.fn(), createMany: jest.fn() },
+    resolutionLog: { create: jest.fn() },
+  };
+  return { prisma };
+});
+
+jest.mock("@/lib/serverutils", () => ({
+  getUserFromCookies: jest.fn(async () => ({ userId: currentUser })),
+}));
+
+jest.mock("@/lib/actions/prediction.actions", () => ({
+  createMarket: jest.fn(async ({ question }: any) => {
+    db.market.question = question.replace(/<[^>]+>/g, "");
+    return { postId: "p1" };
+  }),
+}));
+
+describe("security checks", () => {
+  beforeEach(() => {
+    currentUser = BigInt(1);
+    db.market.state = "OPEN";
+    db.wallets.get(BigInt(1))!.balanceCents = 1000;
+    process.env.ENABLE_PREDICTION_MARKETS = "true";
+  });
+
+  it("validates spend inputs", async () => {
+    const { POST: tradeRoute } = await import("@/app/api/market/[id]/trade/route");
+    const app = express();
+    app.use(express.json());
+    app.post("/t", async (req, res) => {
+      const r = await tradeRoute(new NextRequest("http://x/t", { method: "POST", body: JSON.stringify(req.body) }), { params: { id: "m1" } });
+      res.status(r.status).send(await r.text());
+    });
+    let resp = await request(app).post("/t").send({ spendCents: -5, side: "YES" });
+    expect(resp.status).toBe(400);
+    resp = await request(app).post("/t").send({ spendCents: 1e12, side: "YES" });
+    expect(resp.status).toBe(400);
+  });
+
+  it("sanitizes question", async () => {
+    const { POST: createMarketRoute } = await import("@/app/api/market/route");
+    const app = express();
+    app.use(express.json());
+    app.post("/m", async (req, res) => {
+      const r = await createMarketRoute(new NextRequest("http://x/m", { method: "POST", body: JSON.stringify(req.body) }));
+      res.status(r.status).send(await r.text());
+    });
+    await request(app).post("/m").send({ question: "<script>x</script>?", closesAt: new Date().toISOString() });
+    expect(db.market.question.includes("<script>")).toBe(false);
+  });
+
+  it("rejects SQL injection ids", async () => {
+    const { GET } = await import("@/app/api/market/[id]/route");
+    const url = new URL("http://x/api/market/%27%20OR%201=1");
+    const resp = await GET(new NextRequest(url), { params: { id: "' OR 1=1" } });
+    expect(resp.status).toBe(404);
+  });
+});

--- a/scripts/loadtest.js
+++ b/scripts/loadtest.js
@@ -1,0 +1,37 @@
+import fetch from "node-fetch";
+
+async function main() {
+  const [, , marketId] = process.argv;
+  if (!marketId) throw new Error("Usage: node scripts/loadtest.js <marketId>");
+
+  const latencies = [];
+  const startTotal = Date.now();
+  const requests = Array.from({ length: 100 }, () => {
+    const t0 = Date.now();
+    return fetch(`http://localhost:3000/api/market/${marketId}/trade`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ spendCents: 100, side: "YES" }),
+    }).then((r) => {
+      latencies.push(Date.now() - t0);
+      return r;
+    });
+  });
+
+  const responses = await Promise.all(requests);
+  const p95 = latencies.sort((a, b) => a - b)[Math.floor(latencies.length * 0.95)];
+  console.log("p95 latency", p95);
+  if (p95 > 300) throw new Error("Latency p95 > 300ms");
+  const errors = responses.filter((r) => r.status >= 500);
+  if (errors.length) throw new Error(`${errors.length} server errors`);
+
+  const wallet = await fetch("http://localhost:3000/api/wallet").then((r) => r.json());
+  const market = await fetch(`http://localhost:3000/api/market/${marketId}`).then((r) => r.json());
+  if (wallet.balanceCents !== 0) throw new Error("wallet.balance not zero");
+  if (Math.round(market.market.yesPool) !== 10000) throw new Error("pool mismatch");
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/tests/prediction/createMarket.spec.ts
+++ b/tests/prediction/createMarket.spec.ts
@@ -1,0 +1,7 @@
+import { test, expect } from "@playwright/test";
+
+test.skip("user can create market via UI", async ({ page }) => {
+  // Requires running server with auth
+  await page.goto("/");
+  // steps: fill form, submit, see card
+});

--- a/tests/prediction/tradeAndResolve.spec.ts
+++ b/tests/prediction/tradeAndResolve.spec.ts
@@ -1,0 +1,7 @@
+import { test, expect } from "@playwright/test";
+
+test.skip("trade then resolve via UI", async ({ page }) => {
+  // Requires running server with auth and cron
+  await page.goto("/");
+  // steps: login as B, trade, fast-forward close, creator resolves
+});


### PR DESCRIPTION
## Summary
- add LMSR unit tests
- add market API flow integration test and security checks
- provide a load test script
- add stub Playwright specs
- run e2e tests in CI

## Testing
- `npm run lint` *(fails: React hook rule violations)*
- `npm test --silent` *(fails: several unit and integration tests)*

------
https://chatgpt.com/codex/tasks/task_e_688d162363948329b6407b9619fc5b9e