### PR TITLE
Fix market trade error handling

### DIFF
--- a/app/api/market/[id]/resolve/route.ts
+++ b/app/api/market/[id]/resolve/route.ts
@@ -14,7 +14,10 @@ export async function POST(
   const body = await req.json().catch(() => ({}));
   const parsed = schema.safeParse(body);
   if (!parsed.success) {
-    return NextResponse.json({ error: parsed.error.flatten() }, { status: 400 });
+    return NextResponse.json(
+      { error: "Invalid payload", details: parsed.error.flatten() },
+      { status: 400 },
+    );
   }
   const result = await resolveMarket({
     marketId: params.id,

--- a/app/api/market/[id]/trade/route.ts
+++ b/app/api/market/[id]/trade/route.ts
@@ -28,7 +28,10 @@ export async function POST(
   const body = await req.json().catch(() => ({}));
   const parsed = schema.safeParse(body);
   if (!parsed.success) {
-    return NextResponse.json({ error: parsed.error.flatten() }, { status: 400 });
+    return NextResponse.json(
+      { error: "Invalid payload", details: parsed.error.flatten() },
+      { status: 400 },
+    );
   }
   const { success } = await ratelimit.limit(user.userId.toString());
   if (!success) return new NextResponse("Too Many", { status: 429 });

--- a/app/api/market/route.ts
+++ b/app/api/market/route.ts
@@ -42,7 +42,10 @@ export async function POST(req: NextRequest) {
   const body = await req.json().catch(() => ({}));
   const parsed = schema.safeParse(body);
   if (!parsed.success) {
-    return NextResponse.json({ error: parsed.error.flatten() }, { status: 400 });
+    return NextResponse.json(
+      { error: "Invalid payload", details: parsed.error.flatten() },
+      { status: 400 },
+    );
   }
 
   const { question, closesAt, b: liquidity } = parsed.data;

--- a/components/modals/TradePredictionModal.tsx
+++ b/components/modals/TradePredictionModal.tsx
@@ -76,7 +76,7 @@ export default function TradePredictionModal({ market, onClose, mutateMarket }: 
       });
       if (resp.status !== 200) {
         const data = await resp.json().catch(() => ({}));
-        setError(data.error ?? "Trade failed");
+        setError(typeof data.error === "string" ? data.error : "Trade failed");
         return;
       }
       const result = await resp.json();
@@ -140,7 +140,9 @@ export default function TradePredictionModal({ market, onClose, mutateMarket }: 
           onValueChange={([v]) => setSpend(v)}
           className="w-full"
         />
-        {error && <Alert variant="destructive">{error}</Alert>}
+        {typeof error === "string" && (
+          <Alert variant="destructive">{error}</Alert>
+        )}
         <div className="text-sm text-gray-700" aria-live="polite">
           Cost: {cost} credits — New balance: {maxSpend - cost}
         </div>


### PR DESCRIPTION
## Summary
- sanitize API validation errors in market routes
- guard TradePredictionModal against non-string error payloads

## Testing
- `yarn install --immutable` *(fails: lockfile would have been modified)*
- `npm run lint` *(fails: react-hooks/rules-of-hooks errors)*

------
https://chatgpt.com/codex/tasks/task_e_688d19b5036c83298865ef117f1bd2e8