### PR TITLE
Allow only text reposts

### DIFF
--- a/app/api/feed/replicate/route.ts
+++ b/app/api/feed/replicate/route.ts
@@ -4,7 +4,14 @@ import { replicateFeedPost } from "@/lib/actions/feed.actions";
 
 export async function POST(req: Request) {
   const body = await req.json();
-  // body already contains originalPostId, userId, text, path
-  await replicateFeedPost(body);
-  return NextResponse.json({ ok: true });
+  try {
+    // body already contains originalPostId, userId, text, path
+    await replicateFeedPost(body);
+    return NextResponse.json({ ok: true });
+  } catch (e: any) {
+    return NextResponse.json(
+      { error: e.message },
+      { status: 400 }
+    );
+  }
 }

--- a/components/buttons/ReplicateButton.tsx
+++ b/components/buttons/ReplicateButton.tsx
@@ -3,10 +3,12 @@
 import { replicatePost } from "@/lib/actions/thread.actions";
 import { replicateFeedPost } from "@/lib/actions/feed.client";
 import { replicateRealtimePost } from "@/lib/actions/realtimepost.actions";
+import { canRepost } from "@/lib/repostPolicy";
 import { useAuth } from "@/lib/AuthContext";
 import Image from "next/image";
 import { useRouter, usePathname } from "next/navigation";
 import { useState } from "react";
+import { toast } from "sonner";
 import {
   Dialog,
   DialogContent,
@@ -22,9 +24,10 @@ interface Props {
   postId?: bigint;
   realtimePostId?: string;
   feedPostId?: bigint;
+  type?: string;
 }
 
-const ReplicateButton = ({ postId, realtimePostId, feedPostId }: Props) => {
+const ReplicateButton = ({ postId, realtimePostId, feedPostId, type }: Props) => {
   const user = useAuth();
   const router = useRouter();
   const pathname = usePathname();
@@ -41,6 +44,10 @@ const ReplicateButton = ({ postId, realtimePostId, feedPostId }: Props) => {
       return;
     }
     if (!userObjectId) {
+      return;
+    }
+    if (!canRepost(type)) {
+      toast.error("Only text posts can be replicated.");
       return;
     }
     if (realtimePostId) {

--- a/components/cards/PostCard.tsx
+++ b/components/cards/PostCard.tsx
@@ -7,6 +7,7 @@ import ShareButton from "../buttons/ShareButton";
 import ExpandButton from "../buttons/ExpandButton";
 import TimerButton from "../buttons/TimerButton";
 import ReplicateButton from "../buttons/ReplicateButton";
+import { canRepost } from "@/lib/repostPolicy";
 import ReplicatedPostCard from "./ReplicatedPostCard";
 import ProductReviewCard from "./ProductReviewCard";
 import PortfolioCard from "./PortfolioCard";
@@ -396,13 +397,16 @@ const PostCard = ({
                     commentCount={commentCount}
                   />
                 </>
-                <ReplicateButton
-                  {...(isRealtimePost
-                    ? { realtimePostId: id.toString() }
-                    : isFeedPost
-                    ? { feedPostId: id }
-                    : { postId: id })}
-                />
+                {canRepost(type) && (
+                  <ReplicateButton
+                    type={type}
+                    {...(isRealtimePost
+                      ? { realtimePostId: id.toString() }
+                      : isFeedPost
+                      ? { feedPostId: id }
+                      : { postId: id })}
+                  />
+                )}
                 <ShareButton postId={id} />
         
                   <TimerButton

--- a/lib/actions/feed.actions.ts
+++ b/lib/actions/feed.actions.ts
@@ -3,6 +3,7 @@ import { useSession } from "../useSession";
 import { getUserFromCookies } from "@/lib/serverutils"; // server‑only util
 import { revalidatePath } from "next/cache";
 import { jsonSafe } from "../bigintjson";
+import { canRepost } from "@/lib/repostPolicy";
 export interface CreateFeedPostArgs {
   type:
     | "TEXT"
@@ -167,6 +168,9 @@ export async function replicateFeedPost({
   const uid = BigInt(userId);
   const original = await prisma.feedPost.findUnique({ where: { id: oid } });
   if (!original) throw new Error("Feed post not found");
+  if (!canRepost(original.type)) {
+    throw new Error("Post type not allowed to be replicated");
+  }
   // const payload = JSON.stringify({ id: oid.toString(), text });
   const payload = JSON.stringify({
     id: oid.toString(),

--- a/lib/actions/realtimepost.actions.ts
+++ b/lib/actions/realtimepost.actions.ts
@@ -7,6 +7,7 @@ import { revalidatePath } from "next/cache";
 import { getUserFromCookies } from "@/lib/serverutils";
 import { createProductReview } from "./productreview.actions";
 import { createPortfolioPage } from "./portfolio.actions";
+import { canRepost } from "@/lib/repostPolicy";
 
 export interface PortfolioPayload {
   pageUrl: string;   // “/portfolio/abc123”
@@ -622,6 +623,9 @@ export async function replicateRealtimePost({
       where: { id: oid },
     });
     if (!original) throw new Error("Real-time post not found");
+    if (!canRepost(original.type)) {
+      throw new Error("Post type not allowed to be replicated");
+    }
     // const payload = JSON.stringify({ id: oid.toString(), text });
     const payload = JSON.stringify({
          id: oid.toString(),

--- a/lib/actions/thread.actions.ts
+++ b/lib/actions/thread.actions.ts
@@ -4,6 +4,7 @@
 import { prisma } from "../prismaclient";
 import { revalidatePath } from "next/cache";
 import { getUserFromCookies } from "../serverutils";
+import { canRepost } from "@/lib/repostPolicy";
 
 interface CreatePostParams {
   text: string;
@@ -244,6 +245,9 @@ export async function replicatePost({
       include: { author: true },
     });
     if (!original) throw new Error("Post not found");
+    if (!canRepost(original.type)) {
+      throw new Error("Post type not allowed to be replicated");
+    }
     const payload = JSON.stringify({ id: oid.toString(), text });
     const newPost = await prisma.post.create({
       data: {

--- a/lib/repostPolicy.ts
+++ b/lib/repostPolicy.ts
@@ -1,0 +1,7 @@
+export const REPOSTABLE_TYPES = ["TEXT"] as const;
+
+export type RepostableType = (typeof REPOSTABLE_TYPES)[number];
+
+export function canRepost(type?: string | null): type is RepostableType {
+  return !!type && REPOSTABLE_TYPES.includes(type as RepostableType);
+}


### PR DESCRIPTION
## Summary
- centralize repost policy and limit to text posts
- hide replicate button for non-text posts and validate in button
- enforce repost policy on server actions and feed API

## Testing
- `npm run lint` *(fails: React hook errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_688dc2ed8dd083299e390c40afdbf2d0