### PR TITLE
Unify thread and feed post card rendering

### DIFF
--- a/app/(root)/(realtime)/post/[id]/page.tsx
+++ b/app/(root)/(realtime)/post/[id]/page.tsx
@@ -6,6 +6,7 @@ import { fetchRealtimeLikeForCurrentUser } from "@/lib/actions/like.actions";
 import Modal from "@/components/modals/Modal";
 import Comment from "@/components/forms/Comment";
 import CommentTree from "@/components/shared/CommentTree";
+import { mapRealtimePost } from "@/lib/transform/post";
 
 const Page = async ({ params }: { params: { id: string } }) => {
   if (!params?.id && params?.id?.length !== 1) return notFound();
@@ -26,6 +27,7 @@ const Page = async ({ params }: { params: { id: string } }) => {
         userId: user.userId,
       })
     : null;
+  const mappedPost = mapRealtimePost(post);
 
   return (
     <section className="relative">
@@ -35,28 +37,8 @@ const Page = async ({ params }: { params: { id: string } }) => {
           key={post.id.toString()}
           currentUserId={user?.userId}
           currentUserLike={currentUserLike}
-          id={post.id}
+          {...mappedPost}
           isRealtimePost
-          likeCount={post.like_count}
-          commentCount={post.commentCount}
-          content={
-            post.type === "TEXT" || post.type === "GALLERY"
-              ? post.content!
-              : undefined
-          }
-          image_url={
-            post.type === "IMAGE" || post.type === "IMAGE_COMPUTE"
-              ? post.image_url!
-              : undefined
-          }
-          caption={(post as any).caption ?? null}
-          video_url={post.type === "VIDEO" ? post.video_url! : undefined}
-          pluginType={(post as any).pluginType ?? null}
-          pluginData={(post as any).pluginData ?? null}
-          type={post.type}
-          author={post.author!}
-          createdAt={post.created_at.toDateString()}
-          claimIds={post.productReview?.claims.map((c) => c.id.toString()) ?? []}
         />
       </div>
       <div className="flex-1 flex-row w-full mt-6 ml-4">

--- a/app/(root)/(standard)/thread/[id]/page.tsx
+++ b/app/(root)/(standard)/thread/[id]/page.tsx
@@ -6,7 +6,7 @@ import { getUserFromCookies } from "@/lib/serverutils";
 import PostCard from "@/components/cards/PostCard";
 import { fetchLikeForCurrentUser } from "@/lib/actions/like.actions";
 import Modal from "@/components/modals/Modal";
-import ThreadCard from "@/components/cards/ThreadCard";
+import { mapFeedPost } from "@/lib/transform/post";
 const Page = async ({ params }: { params: { id: string } }) => {
   if (!params?.id && params?.id?.length !== 1) return notFound();
   const user = await getUserFromCookies();
@@ -16,6 +16,7 @@ const Page = async ({ params }: { params: { id: string } }) => {
   const currentUserLike = user
     ? await fetchLikeForCurrentUser({ postId: post.id, userId: user.userId })
     : null;
+  const mappedPost = mapFeedPost(post);
   
   return (
     <section className="sticky ">
@@ -24,21 +25,11 @@ const Page = async ({ params }: { params: { id: string } }) => {
       <Modal />
 
       <div className="flex flex-row">
-        <ThreadCard
+        <PostCard
           key={post.id.toString()}
           currentUserId={user?.userId}
           currentUserLike={currentUserLike}
-          id={post.id}
-          content={post.content ?? undefined}
-          image_url={post.image_url ?? undefined}
-          video_url={post.video_url ?? undefined}
-          type={post.type}
-          comments={post.children}
-          author={post.author!}
-          createdAt={post.created_at.toDateString()}
-          likeCount={post.like_count}
-          commentCount={post.commentCount}
-          expirationDate={post.expiration_date?.toISOString() ?? null}
+          {...mappedPost}
         />
       </div>
       

--- a/components/cards/PostCard.tsx
+++ b/components/cards/PostCard.tsx
@@ -18,59 +18,29 @@ import SoundCloudPlayer from "../players/SoundCloudPlayer";
 import Spline from "@splinetool/react-spline";
 import dynamic from "next/dynamic";
 import PredictionMarketCard from "./PredictionMarketCard";
-import { PortfolioPayload } from "@/lib/actions/realtimepost.actions";
-//import EmbeddedCanvas from "./EmbeddedCanvas";
 import type { Like, RealtimeLike } from "@prisma/client";
 import React from "react";
 import localFont from "next/font/local";
+import type { BasePost, CanvasState } from "@/lib/types/post";
 
-import type { Node, Edge } from "@xyflow/react"; // if you have these types
 const EmbeddedCanvas = dynamic(() => import("./EmbeddedCanvas"), {
   ssr: false,
 });
-
-interface CanvasState {
-  nodes: Node[];
-  edges: Edge[];
-  viewport?: { x: number; y: number; zoom: number };
-  roomId?: string;
-}
 
 const founders = localFont({ src: "./NewEdgeTest-RegularRounded.otf" });
 const DrawCanvas = dynamic(() => import("./DrawCanvas"), { ssr: false });
 const LivechatCard = dynamic(() => import("./LivechatCard"), { ssr: false });
 const EntropyCard = dynamic(() => import("./EntropyCard"), { ssr: false });
 
-interface Props {
-  id: bigint;
+interface ExtraUIProps {
   currentUserId?: bigint | null;
   currentUserLike?: Like | RealtimeLike | null;
-  image_url?: string;
-  video_url?: string;
-  portfolio?: PortfolioPayload;
-  content?: string;
-  roomPostContent?: CanvasState | null;
-  type: string;
-
-  caption?: string | null;
-
-  author: {
-    name: string | null;
-    image: string | null;
-    id: bigint;
-  };
-  createdAt: string;
   isRealtimePost?: boolean;
   isFeedPost?: boolean;
-  likeCount?: number;
-  commentCount?: number;
-  expirationDate?: string | null;
   embedPost?: React.ReactNode;
-  pluginType?: string | null;
-  pluginData?: Record<string, any> | null;
-  claimIds?: (string | number | bigint)[];
-  predictionMarket?: any | null;
 }
+
+type PostCardProps = BasePost & ExtraUIProps;
 
 const PostCard = ({
   id,
@@ -81,7 +51,6 @@ const PostCard = ({
   author,
   image_url,
   video_url,
-  portfolio,
   caption,
   type,
   createdAt,
@@ -95,7 +64,7 @@ const PostCard = ({
   pluginData = null,
   claimIds,
   predictionMarket = null,
-}: Props) => {
+}: PostCardProps) => {
   if (content && content.startsWith("REPLICATE:")) {
     const dataStr = content.slice("REPLICATE:".length);
     // let originalId: bigint | null = null;
@@ -163,7 +132,7 @@ const PostCard = ({
               </div>
             </Link>
             <div className="relative right-[.25rem] text-[.75rem] text-gray-500">
-              {createdAt}
+              {createdAt.toDateString()}
             </div>
 
             <hr className="mt-2 mb-3 w-full h-px border-t-0 bg-transparent bg-gradient-to-r from-transparent via-slate-100 to-transparent opacity-55" />

--- a/components/cards/ThreadCard.tsx
+++ b/components/cards/ThreadCard.tsx
@@ -1,87 +1,37 @@
 import { fetchLikeForCurrentUser, fetchRealtimeLikeForCurrentUser } from "@/lib/actions/like.actions";
 import type { Like, RealtimeLike } from "@prisma/client";
 import PostCard from "./PostCard";
-import localFont from "next/font/local";
-const founders = localFont({ src: "./NewEdgeTest-RegularRounded.otf" });
+import type { BasePost } from "@/lib/types/post";
 
 interface Props {
-  id: bigint;
+  post: BasePost;
   currentUserId?: bigint | null;
-  parentId: bigint | null;
-  content?: string;
-  image_url?: string;
-  video_url?: string;
-  type?: string;
-
-  author: {
-    name: string | null;
-    image: string | null;
-    id: bigint;
-  };
-  createdAt: string;
-  comments: {
-    author: {
-      image: string | null;
-    } | null;
-  }[];
-  isComment?: boolean;
   isRealtimePost?: boolean;
-  likeCount: number;
-  commentCount?: number;
-  expirationDate?: string | null;
-  pluginType?: string | null;
-  pluginData?: Record<string, any> | null;
-  claimIds?: (string | number | bigint)[];
+  isFeedPost?: boolean;
 }
 
 const ThreadCard = async ({
-  id,
+  post,
   currentUserId,
-  parentId,
-  content,
-  image_url,
-  video_url,
-  type = "",
-  author,
-  createdAt,
-  comments,
-  isComment,
   isRealtimePost = false,
-  likeCount,
-  commentCount = 0,
-  expirationDate = null,
-  pluginType = null,
-  pluginData = null,
-  claimIds,
+  isFeedPost = false,
 }: Props) => {
-  let currentUserLike: Like | RealtimeLike | null = null;
-  if (currentUserId) {
-    currentUserLike = isRealtimePost
+  const currentUserLike: Like | RealtimeLike | null = currentUserId
+    ? isRealtimePost
       ? await fetchRealtimeLikeForCurrentUser({
-          realtimePostId: id,
+          realtimePostId: post.id,
           userId: currentUserId,
         })
-      : await fetchLikeForCurrentUser({ postId: id, userId: currentUserId });
-  }
+      : await fetchLikeForCurrentUser({ postId: post.id, userId: currentUserId })
+    : null;
 
   return (
     <PostCard
-      id={id}
+      {...post}
       currentUserId={currentUserId}
       currentUserLike={currentUserLike}
-      image_url={image_url}
-      video_url={video_url}
-      content={content}
-      type={type}
-      author={author}
-      createdAt={createdAt}
-      isRealtimePost={isRealtimePost}
-      likeCount={likeCount}
-      commentCount={commentCount}
-      expirationDate={expirationDate ?? undefined}
-      pluginType={pluginType}
-      pluginData={pluginData}
-      claimIds={claimIds}
+      {...(isRealtimePost ? { isRealtimePost: true } : {})}
+      {...(isFeedPost ? { isFeedPost: true } : {})}
     />
   );
 };

--- a/components/shared/CommentTree.tsx
+++ b/components/shared/CommentTree.tsx
@@ -1,5 +1,6 @@
 import ThreadCard from "@/components/cards/ThreadCard";
 import Comment from "@/components/forms/Comment";
+import { mapFeedPost, mapRealtimePost } from "@/lib/transform/post";
 
 interface CommentTreeProps {
   comments: any[];
@@ -19,57 +20,44 @@ const CommentTree = ({ comments, currentUserId, currentUserImg, depth = 0, isRea
       
       {comments.map((comment) => {
         const indent = Math.min(depth, MAX_DEPTH) * INDENT_PX;
+        const mapped = isRealtimePost
+          ? mapRealtimePost(comment)
+          : mapFeedPost(comment);
         return (
           <div
             key={comment.id.toString()}
             className="mt-0"
             style={{ marginLeft: indent, width: `calc(100% - ${indent}px)` }}
           >
-
-          <ThreadCard
-            id={comment.id}
-            currentUserId={currentUserId}
-            parentId={comment.parent_id}
-            content={comment.content}
-            image_url={comment.image_url}
-            video_url={comment.video_url}
-            type={comment.type}
-            author={comment.author}
-            createdAt={comment.created_at.toDateString()}
-            comments={comment.children}
-            isComment
-            likeCount={comment.like_count}
-            commentCount={comment.commentCount}
-            expirationDate={comment.expiration_date?.toISOString?.() ?? null}
-            pluginType={comment.pluginType}
-            pluginData={comment.pluginData}
-            claimIds={comment.productReview?.claims?.map((c: any) => c.id.toString())}
-            {...(isRealtimePost ? { isRealtimePost: true } : {})}
-          />
-          
-
-          <div
-            className="mt-4"
-            style={{ marginLeft: indent, width: `calc(100% - ${indent}px)` }}
-          >
-
-            <Comment
-              {...(isRealtimePost ? { realtimePostId: comment.id.toString() } : { postId: comment.id })}
-              currentUserImg={currentUserImg}
+            <ThreadCard
+              post={mapped}
               currentUserId={currentUserId}
+              {...(isRealtimePost ? { isRealtimePost: true } : {})}
             />
-                  <hr className="mt-4 mb-3 w-full h-px border-t-0 bg-transparent bg-gradient-to-r from-transparent via-slate-500 to-transparent opacity-75" />
 
-            {comment.children && comment.children.length > 0 && (
-              <CommentTree
-                comments={comment.children}
-                currentUserId={currentUserId}
+            <div
+              className="mt-4"
+              style={{ marginLeft: indent, width: `calc(100% - ${indent}px)` }}
+            >
+              <Comment
+                {...(isRealtimePost
+                  ? { realtimePostId: comment.id.toString() }
+                  : { postId: comment.id })}
                 currentUserImg={currentUserImg}
-                depth={depth + 1}
-                isRealtimePost={isRealtimePost}
+                currentUserId={currentUserId}
               />
-            )}
-          </div>
+              <hr className="mt-4 mb-3 w-full h-px border-t-0 bg-transparent bg-gradient-to-r from-transparent via-slate-500 to-transparent opacity-75" />
+
+              {comment.children && comment.children.length > 0 && (
+                <CommentTree
+                  comments={comment.children}
+                  currentUserId={currentUserId}
+                  currentUserImg={currentUserImg}
+                  depth={depth + 1}
+                  isRealtimePost={isRealtimePost}
+                />
+              )}
+            </div>
           </div>
         );
       })}

--- a/components/shared/RealtimePostsTab.tsx
+++ b/components/shared/RealtimePostsTab.tsx
@@ -2,6 +2,7 @@ import PostCard from "@/components/cards/PostCard";
 import { fetchUserRealtimePosts } from "@/lib/actions/realtimepost.actions";
 import { fetchRealtimeLikeForCurrentUser } from "@/lib/actions/like.actions";
 import { redirect } from "next/navigation";
+import { mapRealtimePost } from "@/lib/transform/post";
 
 interface Props {
   currentUserId: bigint;
@@ -25,7 +26,7 @@ const RealtimePostsTab = async ({ currentUserId, accountId }: Props) => {
             userId: currentUserId,
           })
         : null;
-      return { post, like };
+      return { post: mapRealtimePost(post), like };
     })
   );
 
@@ -40,19 +41,8 @@ const RealtimePostsTab = async ({ currentUserId, accountId }: Props) => {
               key={post.id.toString()}
               currentUserId={currentUserId}
               currentUserLike={like}
-              id={post.id}
+              {...post}
               isRealtimePost
-              likeCount={post.like_count}
-              commentCount={post.commentCount}
-              content={post.content ? post.content : undefined}
-              image_url={post.image_url ? post.image_url : undefined}
-              video_url={post.video_url ? post.video_url : undefined}
-              pluginType={(post as any).pluginType ?? null}
-              pluginData={(post as any).pluginData ?? null}
-              type={post.type}
-              author={post.author!}
-              createdAt={post.created_at.toDateString()}
-              claimIds={post.productReview?.claims.map((c) => c.id.toString()) ?? []}
             />
           ))}
         </>

--- a/components/shared/ThreadsTab.tsx
+++ b/components/shared/ThreadsTab.tsx
@@ -1,6 +1,7 @@
 import { fetchUserThreads } from "@/lib/actions/user.actions";
 import { redirect } from "next/navigation";
 import ThreadCard from "@/components/cards/ThreadCard";
+import { mapFeedPost } from "@/lib/transform/post";
 interface Props {
   currentUserId: bigint;
   accountId: bigint;
@@ -15,21 +16,9 @@ const ThreadsTab = async ({ currentUserId, accountId }: Props) => {
       {result.posts.map((post) => (
         <ThreadCard
           key={post.id.toString()}
-          id={post.id}
+          post={mapFeedPost(post)}
           currentUserId={currentUserId}
-          parentId={post.parent_id}
-          content={post.content}
-          author={{
-            name: post.author.name,
-            image: post.author.image,
-            id: post.author.id,
-          }}
-          createdAt={post.created_at.toString()}
-          comments={post.children}
-          likeCount={post.like_count}
-          commentCount={post.commentCount}
         />
-        
       ))}
     </section>
   );

--- a/lib/transform/post.ts
+++ b/lib/transform/post.ts
@@ -1,0 +1,45 @@
+import type { BasePost } from "@/lib/types/post";
+
+export const mapRealtimePost = (dbRow: any): BasePost => ({
+  id: dbRow.id,
+  author: dbRow.author,
+  type: dbRow.type,
+  content: dbRow.content ?? null,
+  roomPostContent: dbRow.room_post_content ?? dbRow.roomPostContent ?? null,
+  image_url: dbRow.image_url ?? null,
+  video_url: dbRow.video_url ?? null,
+  caption: (dbRow as any).caption ?? null,
+  pluginType: (dbRow as any).pluginType ?? null,
+  pluginData: (dbRow as any).pluginData ?? null,
+  predictionMarket: (dbRow as any).predictionMarket ?? null,
+  claimIds:
+    dbRow.productReview?.claims?.map((c: any) => c.id.toString()) ?? [],
+  likeCount: dbRow.like_count ?? dbRow.likeCount ?? 0,
+  commentCount: dbRow.commentCount ?? 0,
+  expirationDate: dbRow.expiration_date ?? null,
+  createdAt: dbRow.created_at
+    ? new Date(dbRow.created_at)
+    : new Date(),
+});
+
+export const mapFeedPost = (dbRow: any): BasePost => ({
+  id: dbRow.id,
+  author: dbRow.author,
+  type: dbRow.type,
+  content: dbRow.content ?? null,
+  roomPostContent: dbRow.room_post_content ?? dbRow.roomPostContent ?? null,
+  image_url: dbRow.image_url ?? null,
+  video_url: dbRow.video_url ?? null,
+  caption: (dbRow as any).caption ?? null,
+  pluginType: (dbRow as any).pluginType ?? null,
+  pluginData: (dbRow as any).pluginData ?? null,
+  predictionMarket: (dbRow as any).predictionMarket ?? null,
+  claimIds:
+    dbRow.productReview?.claims?.map((c: any) => c.id.toString()) ?? [],
+  likeCount: dbRow.like_count ?? dbRow.likeCount ?? 0,
+  commentCount: dbRow.commentCount ?? 0,
+  expirationDate: dbRow.expiration_date ?? null,
+  createdAt: dbRow.created_at
+    ? new Date(dbRow.created_at)
+    : new Date(),
+});

--- a/lib/types/post.ts
+++ b/lib/types/post.ts
@@ -1,0 +1,27 @@
+import type { Node, Edge } from "@xyflow/react";
+
+export interface CanvasState {
+  nodes: Node[];
+  edges: Edge[];
+  viewport?: { x: number; y: number; zoom: number };
+  roomId?: string;
+}
+
+export interface BasePost {
+  id: bigint;
+  author: { id: bigint; name: string | null; image: string | null };
+  type: string;
+  content?: string | null;
+  roomPostContent?: CanvasState | null;
+  image_url?: string | null;
+  video_url?: string | null;
+  caption?: string | null;
+  pluginType?: string | null;
+  pluginData?: Record<string, unknown> | null;
+  predictionMarket?: any | null;
+  claimIds?: (string | number | bigint)[];
+  likeCount: number;
+  commentCount: number;
+  expirationDate?: string | null;
+  createdAt: Date;
+}


### PR DESCRIPTION
## Summary
- introduce `BasePost` DTO and mapping helpers for feed and realtime records
- update `PostCard` to consume `BasePost` with extra UI props
- simplify `ThreadCard` and thread pages to spread mapped posts through `PostCard`

## Testing
- `npm run lint` *(fails: React Hooks used conditionally in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_688e7de3aaa08329a382977f12dc784b