### PR TITLE
Fix feed like duplication and sync counts

### DIFF
--- a/app/api/feed/like/route.ts
+++ b/app/api/feed/like/route.ts
@@ -1,9 +1,0 @@
-// app/api/feed/like/route.ts
-import { NextResponse } from "next/server";
-import { likeFeedPost } from "@/lib/actions/feed.actions";
-
-export async function POST(req: Request) {
-  const { id } = await req.json();
-  await likeFeedPost({ id: BigInt(id) });
-  return NextResponse.json({ ok: true });
-}

--- a/app/api/feed/route.ts
+++ b/app/api/feed/route.ts
@@ -1,28 +1,10 @@
 import { NextResponse } from "next/server";
-import { prisma } from "@/lib/prismaclient";
 import { serializeBigInt } from "@/lib/utils";
-import { createFeedPost } from "@/lib/actions/feed.actions";
+import { createFeedPost, fetchFeedPosts } from "@/lib/actions/feed.actions";
 
 
 export async function GET() {
-  const posts = await prisma.feedPost.findMany({
-    where: { isPublic: true },
-    orderBy: { created_at: "desc" },
-    include: {
-      predictionMarket: {
-        select: {
-          id: true,
-          question: true,
-          yesPool: true,
-          noPool: true,
-          b: true,
-          state: true,
-          outcome: true,
-          closesAt: true,
-        },
-      },
-    },
-  });
+  const posts = await fetchFeedPosts();
   return NextResponse.json(serializeBigInt(posts));
 }
 

--- a/app/api/feed/unlike/route.ts
+++ b/app/api/feed/unlike/route.ts
@@ -1,9 +1,0 @@
-// app/api/feed/like/route.ts
-import { NextResponse } from "next/server";
-import { likeFeedPost, unlikeFeedPost } from "@/lib/actions/feed.actions";
-
-export async function POST(req: Request) {
-  const { id } = await req.json();
-  await unlikeFeedPost({ id: BigInt(id) });
-  return NextResponse.json({ ok: true });
-}

--- a/components/buttons/LikeButton.tsx
+++ b/components/buttons/LikeButton.tsx
@@ -8,22 +8,19 @@ import {
   unlikeRealtimePost,
   dislikeRealtimePost,
 } from "@/lib/actions/like.actions";
-import { likeFeedPost, unlikeFeedPost } from "@/lib/actions/feed.client";
 import { useAuth } from "@/lib/AuthContext";
 import { Like, RealtimeLike } from "@prisma/client";
 import Image from "next/image";
 import { useRouter } from "next/navigation";
 import { useState } from "react";
-import { Button } from "@/components/ui/button";
 interface Props {
   postId?: bigint;
   realtimePostId?: string;
-  feedPostId?: bigint;
   likeCount: number;
   initialLikeState?: Like | RealtimeLike | null;
 }
 
-const LikeButton = ({ postId, realtimePostId, feedPostId, likeCount, initialLikeState }: Props) => {
+const LikeButton = ({ postId, realtimePostId, likeCount, initialLikeState }: Props) => {
   const user = useAuth();
   const router = useRouter();
   const isUserSignedIn = !!user.user;
@@ -49,9 +46,6 @@ const LikeButton = ({ postId, realtimePostId, feedPostId, likeCount, initialLike
       if (realtimePostId) {
         unlikeRealtimePost({ userId: userObjectId, realtimePostId });
       }
-      if (feedPostId) {
-        unlikeFeedPost({ id: feedPostId });
-      }
       setCurrentLikeType("NONE");
       setDisplayLikeCount(displayLikeCount - 1);
     } else {
@@ -60,9 +54,6 @@ const LikeButton = ({ postId, realtimePostId, feedPostId, likeCount, initialLike
       }
       if (realtimePostId) {
         likeRealtimePost({ userId: userObjectId, realtimePostId });
-      }
-      if (feedPostId) {
-        likeFeedPost({ id: feedPostId });
       }
       if (currentLikeType === "NONE") {
         setDisplayLikeCount(displayLikeCount + 1);
@@ -89,9 +80,6 @@ const LikeButton = ({ postId, realtimePostId, feedPostId, likeCount, initialLike
       if (realtimePostId) {
         unlikeRealtimePost({ userId: userObjectId, realtimePostId });
       }
-      if (feedPostId) {
-        unlikeFeedPost({ id: feedPostId });
-      }
       setCurrentLikeType("NONE");
       setDisplayLikeCount(displayLikeCount + 1);
     } else {
@@ -105,9 +93,6 @@ const LikeButton = ({ postId, realtimePostId, feedPostId, likeCount, initialLike
         setDisplayLikeCount(displayLikeCount - 1);
       } else if (currentLikeType === "LIKE") {
         setDisplayLikeCount(displayLikeCount - 2);
-      }
-      if (feedPostId) {
-        unlikeFeedPost({ id: feedPostId });
       }
       setCurrentLikeType("DISLIKE");
     }

--- a/components/cards/PostCard.tsx
+++ b/components/cards/PostCard.tsx
@@ -353,9 +353,7 @@ const PostCard = ({
                 <LikeButton
                   {...(isRealtimePost
                     ? { realtimePostId: id.toString() }
-                    : isFeedPost
-                    ? { feedPostId: id }
-                    : { postId: id })}
+                    : { postId: canonicalId })}
                   likeCount={likeCount}
                   initialLikeState={currentUserLike}
                 />

--- a/components/shared/RealtimeFeed.tsx
+++ b/components/shared/RealtimeFeed.tsx
@@ -64,6 +64,7 @@ export default function RealtimeFeed({
         <PostCard
           {...mapped}
           currentUserId={currentUserId}
+          currentUserLike={mapped.currentUserLike}
           {...(isRealtime ? { isRealtimePost: true } : {})}
           {...(isFeed ? { isFeedPost: true } : {})}
         />

--- a/lib/actions/feed.actions.ts
+++ b/lib/actions/feed.actions.ts
@@ -1,5 +1,4 @@
 import { prisma } from "../prismaclient";
-import { useSession } from "../useSession";
 import { getUserFromCookies } from "@/lib/serverutils"; // server‑only util
 import { revalidatePath } from "next/cache";
 import { jsonSafe } from "../bigintjson";
@@ -169,6 +168,9 @@ await prisma.$transaction([
 export async function fetchFeedPosts() {
   await archiveExpiredFeedPosts();
 
+  const user = await getUserFromCookies();
+  const currentUserId = user?.userId ? BigInt(user.userId) : null;
+
   const rows = await prisma.feedPost.findMany({
     where: {
       isPublic: true,
@@ -211,7 +213,24 @@ export async function fetchFeedPosts() {
     },
   });
 
-  return rows;          // mapper will handle null‑checks / defaults
+  const postIds = rows.map((r) => r.post_id);
+
+  let userLikes: Record<string, any> = {};
+  if (currentUserId) {
+    const likes = await prisma.like.findMany({
+      where: { user_id: currentUserId, post_id: { in: postIds } },
+    });
+    userLikes = Object.fromEntries(
+      likes.map((l) => [l.post_id.toString(), l])
+    );
+  }
+
+  const rowsWithLike = rows.map((r) => ({
+    ...r,
+    currentUserLike: userLikes[r.post_id.toString()] ?? null,
+  }));
+
+  return rowsWithLike; // mapper will handle null‑checks / defaults
 }
 export async function deleteFeedPost({
   id,
@@ -264,16 +283,3 @@ export async function replicateFeedPost({
   return newPost;
 }
 
-export async function likeFeedPost({ id }: { id: bigint }) {
-  await prisma.feedPost.update({
-    where: { id },
-    data: { like_count: { increment: 1 } },
-  });
-}
-
-export async function unlikeFeedPost({ id }: { id: bigint }) {
-  await prisma.feedPost.update({
-    where: { id },
-    data: { like_count: { decrement: 1 } },
-  });
-}

--- a/lib/actions/feed.client.ts
+++ b/lib/actions/feed.client.ts
@@ -1,44 +1,26 @@
+export async function deleteFeedPost({
+  id,
+  path,
+}: {
+  id: bigint;
+  path: string;
+}) {
+  await fetch("/api/feed/delete", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ id: id.toString(), path }),
+  });
+}
 
-
-export async function likeFeedPost({ id }: { id: bigint }) {
-    await fetch("/api/feed/like", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ id: id.toString() }),
-    });
-  }
-  export async function unlikeFeedPost(id: bigint) {
-    await fetch("/api/feed/unlike", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ id: id.toString() }),
-    });
-  }
-
-
-  export async function deleteFeedPost({
-    id,
-    path,
-  }: {
-    id: bigint;
-    path: string;
-  }) {
-    await fetch("/api/feed/delete", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ id: id.toString(), path }),
-    });
-  }
-  
 export async function replicateFeedPost(args: {
-    originalPostId: string | number | bigint;
-    userId: string | number | bigint;
-    path: string;
-    text?: string;
-  }) {
-    await fetch("/api/feed/replicate", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify(args),
-    });
-  }
+  originalPostId: string | number | bigint;
+  userId: string | number | bigint;
+  path: string;
+  text?: string;
+}) {
+  await fetch("/api/feed/replicate", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(args),
+  });
+}

--- a/lib/actions/like.actions.ts
+++ b/lib/actions/like.actions.ts
@@ -77,6 +77,10 @@ export async function likePost({ userId, postId }: likePostParams) {
           },
         },
       }),
+      prisma.feedPost.updateMany({
+        where: { post_id: pid },
+        data: { like_count: { increment: likeChangeAmount } },
+      }),
     ]);
     await generateFriendSuggestions(uid);
   } catch (error: any) {
@@ -124,6 +128,10 @@ export async function unlikePost({ userId, postId }: likePostParams) {
             increment: likeChangeAmount,
           },
         },
+      }),
+      prisma.feedPost.updateMany({
+        where: { post_id: pid },
+        data: { like_count: { increment: likeChangeAmount } },
       }),
     ]);
   } catch (error: any) {
@@ -193,6 +201,10 @@ export async function dislikePost({ userId, postId }: likePostParams) {
             increment: likeChangeAmount,
           },
         },
+      }),
+      prisma.feedPost.updateMany({
+        where: { post_id: pid },
+        data: { like_count: { increment: likeChangeAmount } },
       }),
     ]);
   } catch (error: any) {

--- a/lib/transform/post.ts
+++ b/lib/transform/post.ts
@@ -43,6 +43,7 @@ export const mapFeedPost = (dbRow: any): BasePost => ({
   likeCount: dbRow.like_count ?? dbRow.likeCount ?? 0,
   commentCount: dbRow.commentCount ?? 0,
   expirationDate: dbRow.expiration_date ?? null,
+  currentUserLike: (dbRow as any).currentUserLike ?? null,
   createdAt: dbRow.created_at
   ? new Date(dbRow.created_at).toISOString()
   : new Date().toISOString(),

--- a/lib/types/post.ts
+++ b/lib/types/post.ts
@@ -1,4 +1,5 @@
 import type { Node, Edge } from "@xyflow/react";
+import type { Like, RealtimeLike } from "@prisma/client";
 
 export interface CanvasState {
   nodes: Node[];
@@ -26,6 +27,7 @@ export interface BasePost {
   likeCount: number;
   commentCount: number;
   expirationDate?: string | null;
+  currentUserLike?: Like | RealtimeLike | null;
   //createdAt: Date;
-  createdAt: string;   
+  createdAt: string;
 }


### PR DESCRIPTION
## Summary
- remove feed-specific like helpers and routes
- map feed items to canonical post IDs so likes persist per user
- sync feed_post like counts with post likes and include current user's like in feed queries

## Testing
- `npm run lint` *(fails: React Hook "useMemo" is called conditionally, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_688e9a02bfbc8329b0bd6ba773cedabb