### PR TITLE
Handle missing post IDs in like lookup

### DIFF
--- a/lib/actions/feed.actions.ts
+++ b/lib/actions/feed.actions.ts
@@ -215,10 +215,12 @@ export async function fetchFeedPosts() {
     },
   });
 
-  const postIds = rows.map((r) => r.post_id);
+  const postIds = rows
+    .map((r) => r.post_id)
+    .filter((id): id is bigint => id !== null);
 
   let userLikes: Record<string, any> = {};
-  if (currentUserId) {
+  if (currentUserId && postIds.length) {
     const likes = await prisma.like.findMany({
       where: { user_id: currentUserId, post_id: { in: postIds } },
     });
@@ -229,7 +231,9 @@ export async function fetchFeedPosts() {
 
   const rowsWithLike = rows.map((r) => ({
     ...r,
-    currentUserLike: userLikes[r.post_id.toString()] ?? null,
+    currentUserLike: r.post_id
+      ? userLikes[r.post_id.toString()] ?? null
+      : null,
   }));
 
   return rowsWithLike; // mapper will handle null‑checks / defaults


### PR DESCRIPTION
## Summary
- filter out null post IDs before querying likes
- guard user like lookup on empty post list
- handle posts without IDs when computing currentUserLike

## Testing
- `npm run lint` *(fails: React Hook "useMemo" is called conditionally, React Hook "useCallback" is called conditionally, React Hook "useRef" is called conditionally, React Hook "useEffect" is called conditionally)*

------
https://chatgpt.com/codex/tasks/task_e_688e9f29476c83299d0a96d44a55689d