### PR TITLE
Show comment counts on realtime posts

### DIFF
--- a/components/buttons/ExpandButton.tsx
+++ b/components/buttons/ExpandButton.tsx
@@ -1,51 +1,27 @@
 "use client";
 
-import { dislikePost, likePost, unlikePost } from "@/lib/actions/like.actions";
-import { useAuth } from "@/lib/AuthContext";
-import { Like } from "@prisma/client";
 import Image from "next/image";
-import { useRouter } from "next/navigation";
-import { useState } from "react";
 import Link from "next/link";
-// interface Props {
-//   postId?: bigint;
-//   realtimePostId?: string;
-//   commentCount?: number;
-// }
+
 interface ExpandButtonProps {
   targetId: bigint;
-  commentCount: number;
 }
 
-
-export default function ExpandButton({ targetId, commentCount }: ExpandButtonProps) {
-  const user = useAuth();
-  const router = useRouter();
-  const isUserSignedIn = !!user.user;
-  const userObjectId = user?.user?.userId;
-
-
- 
-  // const href = realtimePostId ? `/post/${realtimePostId}` : `/thread/${postId}`;
-
+export default function ExpandButton({ targetId }: ExpandButtonProps) {
   return (
-    <button className="flex items-center gap-1">
-      <Link       href={`/thread/${targetId}`}
-   data-testid="expand"
+    <Link
+      href={`/thread/${targetId}`}
+      data-testid="expand"
       data-id={targetId.toString()}
->        <Image
-          src="/assets/add-comment.svg"
-          alt="reply"
-          width={28}
-          height={28}
-          className="cursor-pointer object-contain likebutton"
-        />
-      </Link>
-      <span className="text-subtle-medium text-black">{commentCount}</span>
-    </button>
+      className="flex items-center gap-1"
+    >
+      <Image
+        src="/assets/add-comment.svg"
+        alt="reply"
+        width={28}
+        height={28}
+        className="cursor-pointer object-contain likebutton"
+      />
+    </Link>
   );
-  
-};
-
-
-// export default ExpandButton;
+}

--- a/components/cards/PostCard.tsx
+++ b/components/cards/PostCard.tsx
@@ -357,17 +357,14 @@ const PostCard = ({
                   likeCount={likeCount}
                   initialLikeState={currentUserLike}
                 />
-                <>
-                  <ExpandButton
-                    // {...(isRealtimePost
-                    //   ? { realtimePostId: id.toString() }
-                    //   : isFeedPost
-                    //   ? { postId: id }
-                    //   : { postId: id })}
-                    targetId={canonicalId}      // ← always the post table PK
-                    commentCount={commentCount}
-                  />
-                </>
+                <ExpandButton
+                  // {...(isRealtimePost
+                  //   ? { realtimePostId: id.toString() }
+                  //   : isFeedPost
+                  //   ? { postId: id }
+                  //   : { postId: id })}
+                  targetId={canonicalId}      // ← always the post table PK
+                />
                 {canRepost(type) && (
                   <ReplicateButton
                     type={type}
@@ -400,6 +397,12 @@ const PostCard = ({
                   />
                 )}
               </div>
+              {commentCount > 0 && (
+                <div className="flex items-center gap-1 ml-2 text-gray-600 text-sm">
+                  <Image src="/assets/comment.svg" width={18} height={18} alt="" />
+                  {commentCount}
+                </div>
+              )}
             </div>
           </div>
         </div>

--- a/lib/transform/post.ts
+++ b/lib/transform/post.ts
@@ -17,7 +17,7 @@ export const mapRealtimePost = (dbRow: any): BasePost => ({
   claimIds:
     dbRow.productReview?.claims?.map((c: any) => c.id.toString()) ?? [],
   likeCount: dbRow.like_count ?? dbRow.likeCount ?? 0,
-  commentCount: dbRow.commentCount ?? 0,
+  commentCount: dbRow._count?.children ?? dbRow.commentCount ?? 0,
   expirationDate: dbRow.expiration_date ?? null,
   createdAt: dbRow.created_at
   ? new Date(dbRow.created_at).toISOString()


### PR DESCRIPTION
## Summary
- derive realtime post comment counts from child count metadata
- display comment count badge beneath post actions
- simplify expand button to a link with a comment icon

## Testing
- `npm run lint` *(fails: React Hook "useMemo" is called conditionally, and more)*

------
https://chatgpt.com/codex/tasks/task_e_688eca2151d08329aefb9bb16f7f8389