### PR TITLE
Add settings foundation

### DIFF
--- a/__tests__/roles.test.ts
+++ b/__tests__/roles.test.ts
@@ -1,0 +1,19 @@
+import { isAdmin, canManageWorkspace } from "../lib/auth/roles";
+
+describe("roles helpers", () => {
+  test("isAdmin returns true for ADMIN or OWNER", () => {
+    expect(isAdmin({ role: "ADMIN" })).toBe(true);
+    expect(isAdmin({ role: "OWNER" })).toBe(true);
+    expect(isAdmin({ role: "USER" })).toBe(false);
+  });
+
+  test("canManageWorkspace allows admins or owners", () => {
+    const admin = { id: 1n, role: "ADMIN" };
+    const owner = { id: 2n, role: "USER" };
+    const workspace = { ownerId: 2n };
+
+    expect(canManageWorkspace(admin, workspace)).toBe(true);
+    expect(canManageWorkspace(owner, workspace)).toBe(true);
+    expect(canManageWorkspace({ id: 3n, role: "USER" }, workspace)).toBe(false);
+  });
+});

--- a/app/(settings)/admin/page.tsx
+++ b/app/(settings)/admin/page.tsx
@@ -1,0 +1,3 @@
+export default function AdminSettingsPage() {
+  return <div />;
+}

--- a/app/(settings)/layout.tsx
+++ b/app/(settings)/layout.tsx
@@ -1,0 +1,8 @@
+export default function SettingsLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <section className="max-w-[720px] mx-auto py-8">
+      {/* tab nav placeholder */}
+      {children}
+    </section>
+  );
+}

--- a/app/(settings)/page.tsx
+++ b/app/(settings)/page.tsx
@@ -1,0 +1,5 @@
+import { redirect } from "next/navigation";
+
+export default function SettingsIndex() {
+  redirect("/settings/profile");
+}

--- a/app/(settings)/profile/page.tsx
+++ b/app/(settings)/profile/page.tsx
@@ -1,0 +1,3 @@
+export default function ProfileSettingsPage() {
+  return <div />;
+}

--- a/lib/auth/roles.ts
+++ b/lib/auth/roles.ts
@@ -1,0 +1,10 @@
+export function isAdmin(user: { role: string }): boolean {
+  return user.role === "ADMIN" || user.role === "OWNER";
+}
+
+export function canManageWorkspace(
+  user: { id: bigint; role: string },
+  workspace: { ownerId: bigint }
+): boolean {
+  return isAdmin(user) || user.id === workspace.ownerId;
+}

--- a/lib/models/schema.prisma
+++ b/lib/models/schema.prisma
@@ -64,6 +64,7 @@ model User {
   StallMessage             StallMessage[]
   cartItems                CartItem[]
   carts                    Cart[]
+  settings                 UserSettings?
 
   @@map("users")
 }
@@ -1083,4 +1084,22 @@ model GroupMeeting {
   createdAt       DateTime @default(now())
 
   @@map("group_meetings")
+}
+
+model UserSettings {
+  user_id    BigInt   @id
+  prefs      Json     @default("{}")
+  updated_at DateTime @updatedAt
+
+  user User @relation(fields: [user_id], references: [id], onDelete: Cascade)
+
+  @@map("user_settings")
+}
+
+model WorkspaceSettings {
+  workspace_id BigInt   @id
+  prefs        Json     @default("{}")
+  updated_at   DateTime @updatedAt
+
+  @@map("workspace_settings")
 }

--- a/lib/settings/schema.ts
+++ b/lib/settings/schema.ts
@@ -1,0 +1,28 @@
+import { z } from "zod";
+
+export const userSettingsSchema = z.object({
+  account: z
+    .object({
+      displayName: z.string().min(2).max(40).optional(),
+      handle: z.string().regex(/^@[a-z0-9_]{3,}$/i).optional(),
+      bio: z.string().max(200).optional(),
+      photoUrl: z.string().url().optional(),
+    })
+    .optional(),
+
+  privacy: z
+    .object({
+      profileVisibility: z.enum(["PUBLIC", "FOLLOWERS", "PRIVATE"]).optional(),
+      blockedIds: z.array(z.bigint()).optional(),
+    })
+    .optional(),
+
+  notifications: z
+    .object({
+      push: z.boolean().optional(),
+      email: z.boolean().optional(),
+      sms: z.boolean().optional(),
+      digestFrequency: z.enum(["NONE", "DAILY", "WEEKLY"]).optional(),
+    })
+    .optional(),
+}).strict();

--- a/lib/settings/service.ts
+++ b/lib/settings/service.ts
@@ -1,0 +1,32 @@
+import { prisma } from "@/lib/prismaclient";
+import { userSettingsSchema } from "./schema";
+
+export async function getUserSettings(userId: bigint) {
+  const row = await prisma.userSettings.findUnique({ where: { user_id: userId } });
+  return row?.prefs ?? {};
+}
+
+export async function updateUserSettings(userId: bigint, patch: unknown) {
+  const data = userSettingsSchema.partial().parse(patch);
+  await prisma.userSettings.upsert({
+    where: { user_id: userId },
+    create: { user_id: userId, prefs: data },
+    update: { prefs: { ...(await getUserSettings(userId)), ...data } },
+  });
+  return data;
+}
+
+export async function getWorkspaceSettings(workspaceId: bigint) {
+  const row = await prisma.workspaceSettings.findUnique({ where: { workspace_id: workspaceId } });
+  return row?.prefs ?? {};
+}
+
+export async function updateWorkspaceSettings(workspaceId: bigint, patch: unknown) {
+  const data = userSettingsSchema.partial().parse(patch);
+  await prisma.workspaceSettings.upsert({
+    where: { workspace_id: workspaceId },
+    create: { workspace_id: workspaceId, prefs: data },
+    update: { prefs: { ...(await getWorkspaceSettings(workspaceId)), ...data } },
+  });
+  return data;
+}

--- a/prisma/migrations/init_settings.sql
+++ b/prisma/migrations/init_settings.sql
@@ -1,0 +1,13 @@
+-- USER SETTINGS (one row per user)
+CREATE TABLE user_settings (
+  user_id  bigint PRIMARY KEY REFERENCES users(id) ON DELETE CASCADE,
+  prefs    jsonb       NOT NULL DEFAULT '{}',
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+-- WORKSPACE SETTINGS (one row per workspace / site)
+CREATE TABLE workspace_settings (
+  workspace_id bigint PRIMARY KEY REFERENCES workspaces(id) ON DELETE CASCADE,
+  prefs        jsonb  NOT NULL DEFAULT '{}',
+  updated_at   timestamptz NOT NULL DEFAULT now()
+);


### PR DESCRIPTION
## Summary
- add SQL migration for user and workspace settings tables
- extend Prisma schema with settings models and user link
- add role helpers, settings service/schema, and settings layout shell

## Testing
- `npx prisma migrate dev` *(fails: Can't reach database server)*
- `npm run lint` *(fails: React Hooks must be called in the exact same order...)*
- `npx eslint lib/auth/roles.ts lib/settings/schema.ts lib/settings/service.ts __tests__/roles.test.ts app/(settings)/layout.tsx app/(settings)/page.tsx app/(settings)/profile/page.tsx app/(settings)/admin/page.tsx`
- `npx jest __tests__/roles.test.ts --runTestsByPath --testMatch="**/__tests__/**/*.test.ts"`


------
https://chatgpt.com/codex/tasks/task_e_688ee17013e083298c82e95260b25148