### PR TITLE
Add profile settings account form

### DIFF
--- a/app/(root)/(standard)/profile/settings/page.tsx
+++ b/app/(root)/(standard)/profile/settings/page.tsx
@@ -1,4 +1,2 @@
-export default function Page() {
-    return <div>Settings coming soon</div>;
-  }
-  
+export { default } from "@/app/(settings)/profile/page";
+

--- a/app/(settings)/profile/(client)/AccountForm.tsx
+++ b/app/(settings)/profile/(client)/AccountForm.tsx
@@ -1,0 +1,78 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { toast } from "sonner";
+
+interface AccountData {
+  displayName?: string;
+  handle?: string;
+  bio?: string;
+  photoUrl?: string;
+}
+
+export default function AccountForm({ initial }: { initial: AccountData }) {
+  const [form, setForm] = useState<AccountData>(initial);
+  const first = useRef(true);
+
+  useEffect(() => {
+    if (first.current) {
+      first.current = false;
+      return;
+    }
+    const handle = setTimeout(async () => {
+      const resp = await fetch("/api/settings/me", {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ account: form }),
+      });
+      if (resp.ok) toast.success("Saved");
+    }, 750);
+    return () => clearTimeout(handle);
+  }, [form]);
+
+  function onChange(
+    e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>
+  ) {
+    const { name, value } = e.target;
+    setForm((f) => ({ ...f, [name]: value }));
+  }
+
+  function onFile(e: React.ChangeEvent<HTMLInputElement>) {
+    const file = e.target.files?.[0];
+    if (file) {
+      const url = URL.createObjectURL(file);
+      setForm((f) => ({ ...f, photoUrl: url }));
+    }
+  }
+
+  return (
+    <form className="flex flex-col gap-4">
+      <input
+        aria-label="display name"
+        name="displayName"
+        value={form.displayName ?? ""}
+        onChange={onChange}
+        className="textinputfield"
+        placeholder="Display name"
+      />
+      <input
+        aria-label="handle"
+        name="handle"
+        value={form.handle ?? ""}
+        onChange={onChange}
+        className="textinputfield"
+        placeholder="@handle"
+      />
+      <textarea
+        aria-label="bio"
+        name="bio"
+        value={form.bio ?? ""}
+        onChange={onChange}
+        className="textinputfield"
+        placeholder="Bio"
+      />
+      <input aria-label="photo" type="file" onChange={onFile} />
+    </form>
+  );
+}
+

--- a/app/(settings)/profile/page.tsx
+++ b/app/(settings)/profile/page.tsx
@@ -1,3 +1,13 @@
-export default function ProfileSettingsPage() {
-  return <div />;
+import { redirect } from "next/navigation";
+import { getUserFromCookies } from "@/lib/serverutils";
+import { getUserSettings } from "@/lib/settings/service";
+import AccountForm from "./(client)/AccountForm";
+
+export default async function Page() {
+  const user = await getUserFromCookies();
+  if (!user) redirect("/login");
+
+  const settings = await getUserSettings(user.userId);
+  return <AccountForm initial={settings.account ?? {}} />;
 }
+

--- a/app/api/settings/me/route.ts
+++ b/app/api/settings/me/route.ts
@@ -1,0 +1,16 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getUserFromCookies } from "@/lib/serverutils";
+import { updateUserSettings } from "@/lib/settings/service";
+
+export async function PATCH(req: NextRequest) {
+  const user = await getUserFromCookies();
+  if (!user) return NextResponse.json({}, { status: 401 });
+  const payload = await req.json();
+  await updateUserSettings(user.userId, payload);
+  return NextResponse.json({ ok: true });
+}
+
+export async function POST(req: NextRequest) {
+  return PATCH(req);
+}
+

--- a/tests/accountForm.test.tsx
+++ b/tests/accountForm.test.tsx
@@ -1,0 +1,34 @@
+/** @jest-environment jsdom */
+import { act, fireEvent, render } from "@testing-library/react";
+import AccountForm from "@/app/(settings)/profile/(client)/AccountForm";
+
+jest.mock("sonner", () => ({ toast: { success: jest.fn() } }));
+
+describe("AccountForm", () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    global.fetch = jest.fn(() => Promise.resolve({ ok: true })) as any;
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+    (fetch as jest.Mock).mockReset();
+  });
+
+  it("debounces changes and calls fetch", async () => {
+    const { getByLabelText } = render(<AccountForm initial={{}} />);
+    fireEvent.change(getByLabelText("display name"), {
+      target: { value: "Alice" },
+    });
+
+    await act(async () => {
+      jest.advanceTimersByTime(800);
+    });
+
+    expect(fetch).toHaveBeenCalledWith(
+      "/api/settings/me",
+      expect.objectContaining({ method: "PATCH" })
+    );
+  });
+});
+


### PR DESCRIPTION
## Summary
- load user settings and guard access to settings page
- add client AccountForm with debounced autosave and toast
- expose `/api/settings/me` PATCH endpoint and unit test

## Testing
- `yarn lint` *(fails: React Hook "useMemo" is called conditionally...)*
- `yarn test tests/accountForm.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_688ef23e70b883298d95ae5998520353