### PR TITLE
Fix comment creation

### DIFF
--- a/lib/actions/thread.actions.ts
+++ b/lib/actions/thread.actions.ts
@@ -202,22 +202,14 @@ export async function addCommentToPost({
     if (!originalPost) {
       throw new Error("Post not found");
     }
-    const commentPost = await prisma.feedPost.create({
+    await prisma.feedPost.create({
       data: {
         content: commentText,
         type: "TEXT",
         author_id: userId,
-        parent_id: parentPostId,
-      },
-    });
-    await prisma.feedPost.update({
-      where: {
-        id: parentPostId,
-      },
-      data: {
-        children: {
+        feedPost: {
           connect: {
-            id: commentPost.id,
+            id: parentPostId,
           },
         },
       },


### PR DESCRIPTION
## Summary
- avoid duplicate ID errors when adding comments by connecting parent post during creation

## Testing
- `npm run lint` *(fails: React hook errors in unrelated files)*
- `npx eslint lib/actions/thread.actions.ts`


------
https://chatgpt.com/codex/tasks/task_e_688f0b731d1c8329871f5cccd742f0b2