### PR TITLE
Fix product review post creation

### DIFF
--- a/components/forms/CreateFeedPost.tsx
+++ b/components/forms/CreateFeedPost.tsx
@@ -495,6 +495,14 @@ const CreateFeedPost = ({ roomId = "global" }: Props) => {
                     claims: filtered,
                   }),
                   imageUrl: urls[0],
+                  productReview: {
+                    productName: vals.productName,
+                    rating: vals.rating,
+                    summary: vals.summary,
+                    productLink: vals.productLink,
+                    images: urls,
+                    claims: filtered,
+                  },
                 });
               } else {
                 await createRealtimePost({

--- a/components/forms/ProductReviewNodeForm.tsx
+++ b/components/forms/ProductReviewNodeForm.tsx
@@ -13,8 +13,6 @@ import {
   FormMessage,
 } from "../ui/form";
 import { Input } from "../ui/input";
-import { createFeedPost } from "@/lib/actions/feedpost.actions";
-import { feed_post_type }  from "@prisma/client";
 
 interface Props {
   onSubmit: (values: z.infer<typeof ProductReviewValidation>) => void;


### PR DESCRIPTION
## Summary
- store content and product review details when creating feed posts
- include product review payload in product review modal submit
- clean up unused imports in product review form

## Testing
- `npm run lint` *(fails: React hook order errors in app/(root)/(standard)/halfway/page.tsx)*
- `npx eslint components/forms/CreateFeedPost.tsx components/forms/ProductReviewNodeForm.tsx lib/actions/feedpost.actions.ts`


------
https://chatgpt.com/codex/tasks/task_e_688fe897f588832990c9f25efdd96641