### PR TITLE
Add ephemeral side-pane chat spike

### DIFF
--- a/app/(root)/(standard)/layout.tsx
+++ b/app/(root)/(standard)/layout.tsx
@@ -15,6 +15,7 @@ import { AuthProvider } from "@/components/shared/AuthProvider";
 import ScrollAnalytics from "@/components/shared/ScrollAnalytics";
 import { getRoomsForUser } from "@/lib/actions/realtimeroom.actions";
 import { RealtimeRoom } from "@prisma/client";
+import { PrivateChatManagerProvider } from "@/contexts/PrivateChatManager";
 
 export const metadata = {
   title: "Mesh",
@@ -53,20 +54,22 @@ export default async function StandardLayout({
     <html className="bg-gradient-to-r from-zinc-200 from-0% via-indigo-300 via-50% to-rose-200 to-100%">
     <body className={`${founderslight.className}`}>
       <AuthProvider user={user}>
-        <ScrollAnalytics />
-        <main className="flex flex-row">
-          <LeftSidebar userRooms={userRooms} />
-          <section className="main-container ">
-            
-            <div className="w-full max-w-4xl">
-              <AuthProvider user={user}>{children}</AuthProvider>
-            </div>
+        <PrivateChatManagerProvider>
+          <ScrollAnalytics />
+          <main className="flex flex-row">
+            <LeftSidebar userRooms={userRooms} />
+            <section className="main-container ">
 
-          </section>
-          <RightSidebar/>
+              <div className="w-full max-w-4xl">
+                <AuthProvider user={user}>{children}</AuthProvider>
+              </div>
 
-        </main>
-        
+            </section>
+            <RightSidebar/>
+
+          </main>
+        </PrivateChatManagerProvider>
+
       </AuthProvider>
     </body>
   </html>

--- a/app/api/esp/open/route.ts
+++ b/app/api/esp/open/route.ts
@@ -1,0 +1,16 @@
+import { NextRequest, NextResponse } from "next/server";
+import { espSessions } from "@/lib/espSessionStore";
+import { supabase } from "@/lib/supabaseclient";
+
+export async function POST(req: NextRequest) {
+  const { targetUserId, roomId } = await req.json();
+  const userId = 0n; // TODO: auth
+  const paneId = crypto.randomUUID();
+  espSessions.set(paneId, { users: [userId, BigInt(targetUserId)], touched: Date.now() });
+  await supabase.channel("esp-open").send({
+    type: "broadcast",
+    event: "open",
+    payload: { paneId, roomId, users: [userId, BigInt(targetUserId)] },
+  });
+  return NextResponse.json({ paneId });
+}

--- a/components/PrivateChatPane.tsx
+++ b/components/PrivateChatPane.tsx
@@ -1,0 +1,62 @@
+"use client";
+import Draggable from "react-draggable";
+import { useState } from "react";
+import { usePrivateChatSocket } from "@/hooks/usePrivateChatSocket";
+import { usePrivateChatManager, Msg } from "@/contexts/PrivateChatManager";
+
+export default function PrivateChatPane({ pane }: { pane: { id: string; peerId: bigint; msgs: Msg[]; minimised: boolean; pos: { x: number; y: number } } }) {
+  const { dispatch } = usePrivateChatManager();
+  const [text, setText] = useState("");
+  const send = usePrivateChatSocket(pane.id, (m) => dispatch({ type: "ADD_MSG", id: pane.id, msg: m }));
+
+  const handleSend = () => {
+    if (!text.trim()) return;
+    const msg: Msg = { paneId: pane.id, from: 0n, body: text, ts: Date.now() };
+    dispatch({ type: "ADD_MSG", id: pane.id, msg });
+    send(text, 0n);
+    setText("");
+  };
+
+  return (
+    <Draggable
+      handle=".esp-header"
+      position={pane.pos}
+      onStop={(_, data) => dispatch({ type: "SET_POS", id: pane.id, pos: { x: data.x, y: data.y } })}
+    >
+      <div className="fixed z-50 w-80 h-[420px] bg-white border shadow flex flex-col">
+        <div className="esp-header flex justify-between items-center bg-gray-200 px-2 py-1">
+          <span>Chat</span>
+          <div className="space-x-1">
+            <button onClick={() => dispatch({ type: "MINIMISE", id: pane.id })}>_</button>
+            <button onClick={() => dispatch({ type: "CLOSE", id: pane.id })}>×</button>
+          </div>
+        </div>
+        {!pane.minimised && (
+          <>
+            <div className="flex-1 overflow-y-auto p-2 space-y-1">
+              {pane.msgs.map((m, i) => (
+                <div key={i}>{m.body}</div>
+              ))}
+            </div>
+            <div className="p-2 border-t flex">
+              <input
+                className="flex-1 border px-2 py-1"
+                value={text}
+                onChange={(e) => setText(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter") {
+                    e.preventDefault();
+                    handleSend();
+                  }
+                }}
+              />
+              <button className="ml-2" onClick={handleSend}>
+                Send
+              </button>
+            </div>
+          </>
+        )}
+      </div>
+    </Draggable>
+  );
+}

--- a/components/chat/ChatRoom.tsx
+++ b/components/chat/ChatRoom.tsx
@@ -6,7 +6,13 @@ import {
   ChatMessageAvatar,
   ChatMessageContent,
 } from "@/components/ui/chat-message";
-import Image from "next/image";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { usePrivateChatManager } from "@/contexts/PrivateChatManager";
 
 interface UserLite {
   name: string;
@@ -33,6 +39,7 @@ export default function ChatRoom({
   initialMessages,
 }: Props) {
   const [messages, setMessages] = useState<MessageData[]>(initialMessages);
+  const { open } = usePrivateChatManager();
 
   useEffect(() => {
     const channel = supabase.channel(`conversation-${conversationId.toString()}`);
@@ -56,7 +63,22 @@ export default function ChatRoom({
           id={m.id}
         >
           <ChatMessageContent content={m.text} />
-          <ChatMessageAvatar imageSrc={m.sender.image || "/assets/user-helsinki.svg"} />
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <ChatMessageAvatar
+                imageSrc={m.sender.image || "/assets/user-helsinki.svg"}
+                className="cursor-pointer"
+              />
+            </DropdownMenuTrigger>
+            <DropdownMenuContent>
+              <DropdownMenuItem
+                onClick={() => open(BigInt(m.sender_id), conversationId)}
+                disabled={m.sender_id === currentUserId.toString()}
+              >
+                💬 Chat
+              </DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
 
         </ChatMessage>
       ))}

--- a/contexts/PrivateChatManager.tsx
+++ b/contexts/PrivateChatManager.tsx
@@ -1,0 +1,115 @@
+"use client";
+import { createContext, useContext, useReducer } from "react";
+import PrivateChatPane from "@/components/PrivateChatPane";
+
+export interface Msg {
+  paneId: string;
+  from: bigint;
+  body: string;
+  ts: number;
+}
+
+interface Pane {
+  id: string;
+  peerId: bigint;
+  msgs: Msg[];
+  minimised: boolean;
+  pos: { x: number; y: number };
+}
+
+interface State {
+  panes: Pane[];
+}
+
+const Context = createContext<{
+  panes: Pane[];
+  open: (targetUserId: bigint, roomId: bigint) => Promise<void>;
+  dispatch: React.Dispatch<Action>;
+}>({ panes: [], open: async () => {}, dispatch: () => {} });
+
+interface OpenAction {
+  type: "OPEN";
+  pane: Pane;
+}
+interface CloseAction {
+  type: "CLOSE";
+  id: string;
+}
+interface AddMsgAction {
+  type: "ADD_MSG";
+  id: string;
+  msg: Msg;
+}
+interface MinimiseAction {
+  type: "MINIMISE";
+  id: string;
+}
+interface SetPosAction {
+  type: "SET_POS";
+  id: string;
+  pos: { x: number; y: number };
+}
+
+type Action = OpenAction | CloseAction | AddMsgAction | MinimiseAction | SetPosAction;
+
+function reducer(state: State, action: Action): State {
+  switch (action.type) {
+    case "OPEN":
+      return { panes: [...state.panes, action.pane] };
+    case "CLOSE":
+      return { panes: state.panes.filter((p) => p.id !== action.id) };
+    case "ADD_MSG":
+      return {
+        panes: state.panes.map((p) =>
+          p.id === action.id ? { ...p, msgs: [...p.msgs, action.msg] } : p,
+        ),
+      };
+    case "MINIMISE":
+      return {
+        panes: state.panes.map((p) =>
+          p.id === action.id ? { ...p, minimised: !p.minimised } : p,
+        ),
+      };
+    case "SET_POS":
+      return {
+        panes: state.panes.map((p) =>
+          p.id === action.id ? { ...p, pos: action.pos } : p,
+        ),
+      };
+    default:
+      return state;
+  }
+}
+
+export function PrivateChatManagerProvider({ children }: { children: React.ReactNode }) {
+  const [state, dispatch] = useReducer(reducer, { panes: [] });
+
+  const open = async (targetUserId: bigint, roomId: bigint) => {
+    const res = await fetch("/api/esp/open", {
+      method: "POST",
+      body: JSON.stringify({ targetUserId, roomId }),
+    });
+    const { paneId } = await res.json();
+    dispatch({
+      type: "OPEN",
+      pane: {
+        id: paneId,
+        peerId: targetUserId,
+        msgs: [],
+        minimised: false,
+        pos: { x: 20, y: 20 },
+      },
+    });
+  };
+
+  return (
+    <Context.Provider value={{ panes: state.panes, open, dispatch }}>
+      {children}
+      {state.panes.map((p) => (
+        <PrivateChatPane key={p.id} pane={p} />
+      ))}
+    </Context.Provider>
+  );
+}
+
+export const usePrivateChatManager = () => useContext(Context);

--- a/hooks/usePrivateChatSocket.ts
+++ b/hooks/usePrivateChatSocket.ts
@@ -1,0 +1,21 @@
+import { useEffect } from "react";
+import { supabase } from "@/lib/supabaseclient";
+import { Msg } from "@/contexts/PrivateChatManager";
+
+export function usePrivateChatSocket(paneId: string, onMsg: (m: Msg) => void) {
+  useEffect(() => {
+    const ch = supabase.channel(`esp-${paneId}`);
+    ch.on("broadcast", { event: "msg" }, ({ payload }) => onMsg(payload as Msg));
+    ch.subscribe();
+    return () => {
+      supabase.removeChannel(ch);
+    };
+  }, [paneId, onMsg]);
+  return (body: string, from: bigint) => {
+    supabase.channel(`esp-${paneId}`).send({
+      type: "broadcast",
+      event: "msg",
+      payload: { paneId, from, body, ts: Date.now() },
+    });
+  };
+}

--- a/lib/espSessionStore.ts
+++ b/lib/espSessionStore.ts
@@ -1,0 +1,17 @@
+type Session = { users: [bigint, bigint]; touched: number };
+export const espSessions = new Map<string, Session>();
+export const TTL_MS = 10 * 60 * 1000;
+export function touch(id: string) {
+  const s = espSessions.get(id);
+  if (s) {
+    s.touched = Date.now();
+  }
+}
+setInterval(() => {
+  const now = Date.now();
+  espSessions.forEach((s, id) => {
+    if (now - s.touched > TTL_MS) {
+      espSessions.delete(id);
+    }
+  });
+}, 30_000);


### PR DESCRIPTION
## Summary
- add in-memory session store and API route for ephemeral side-pane chats
- create PrivateChatManager, socket hook, and draggable chat pane component
- wire avatar dropdown to open chat panes and wrap layout with manager provider

## Testing
- `npm run lint` *(fails: React Hook "useMemo" is called conditionally, etc. in unrelated files)*


------
https://chatgpt.com/codex/tasks/task_e_689039af79e8832980c110a87ca7d50f