### PR TITLE
Handle BigInt serialization in chat

### DIFF
--- a/app/api/esp/open/route.ts
+++ b/app/api/esp/open/route.ts
@@ -3,14 +3,22 @@ import { espSessions } from "@/lib/espSessionStore";
 import { supabase } from "@/lib/supabaseclient";
 
 export async function POST(req: NextRequest) {
-  const { targetUserId, roomId } = await req.json();
+  const { targetUserId, roomId } = (await req.json()) as {
+    targetUserId: string;
+    roomId: string;
+  };
   const userId = 0n; // TODO: auth
+  const targetId = BigInt(targetUserId);
   const paneId = crypto.randomUUID();
-  espSessions.set(paneId, { users: [userId, BigInt(targetUserId)], touched: Date.now() });
+  espSessions.set(paneId, { users: [userId, targetId], touched: Date.now() });
   await supabase.channel("esp-open").send({
     type: "broadcast",
     event: "open",
-    payload: { paneId, roomId, users: [userId, BigInt(targetUserId)] },
+    payload: {
+      paneId,
+      roomId,
+      users: [userId.toString(), targetId.toString()],
+    },
   });
   return NextResponse.json({ paneId });
 }

--- a/contexts/PrivateChatManager.tsx
+++ b/contexts/PrivateChatManager.tsx
@@ -87,7 +87,11 @@ export function PrivateChatManagerProvider({ children }: { children: React.React
   const open = async (targetUserId: bigint, roomId: bigint) => {
     const res = await fetch("/api/esp/open", {
       method: "POST",
-      body: JSON.stringify({ targetUserId, roomId }),
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        targetUserId: targetUserId.toString(),
+        roomId: roomId.toString(),
+      }),
     });
     const { paneId } = await res.json();
     dispatch({

--- a/hooks/usePrivateChatSocket.ts
+++ b/hooks/usePrivateChatSocket.ts
@@ -5,7 +5,9 @@ import { Msg } from "@/contexts/PrivateChatManager";
 export function usePrivateChatSocket(paneId: string, onMsg: (m: Msg) => void) {
   useEffect(() => {
     const ch = supabase.channel(`esp-${paneId}`);
-    ch.on("broadcast", { event: "msg" }, ({ payload }) => onMsg(payload as Msg));
+    ch.on("broadcast", { event: "msg" }, ({ payload }) =>
+      onMsg({ ...payload, from: BigInt(payload.from) } as Msg),
+    );
     ch.subscribe();
     return () => {
       supabase.removeChannel(ch);
@@ -15,7 +17,7 @@ export function usePrivateChatSocket(paneId: string, onMsg: (m: Msg) => void) {
     supabase.channel(`esp-${paneId}`).send({
       type: "broadcast",
       event: "msg",
-      payload: { paneId, from, body, ts: Date.now() },
+      payload: { paneId, from: from.toString(), body, ts: Date.now() },
     });
   };
 }


### PR DESCRIPTION
## Summary
- stringified BigInt IDs before POSTing in PrivateChatManager to avoid JSON serialization errors
- parse string IDs to BigInt in /api/esp/open route and send IDs as strings to Supabase
- ensure usePrivateChatSocket serializes BigInt fields to strings and parses them back on receipt

## Testing
- `npm run lint` *(fails: React Hooks must be called in the exact same order in every component render)*

------
https://chatgpt.com/codex/tasks/task_e_68903f32651c832984d700e4b3a84032