### PR TITLE
Surface live and auction activity on SwapMeet minimap

### DIFF
--- a/app/swapmeet/components/Minimap.tsx
+++ b/app/swapmeet/components/Minimap.tsx
@@ -15,24 +15,53 @@ export function Minimap({ cx, cy }: { cx: number; cy: number }) {
     const ctx = canvas.current.getContext("2d");
     if (!ctx) return;
     ctx.clearRect(0, 0, 200, 200);
-    data.forEach(({ x, y, visitors }: { x: number; y: number; visitors: number }) => {
-      const relX = x - cx + 5;
-      const relY = cy - y + 5;
-      const alpha = Math.min(visitors / 20, 1);
-      ctx.fillStyle = `hsla(${120 - alpha * 120} 80% 50% / ${0.2 + alpha * 0.8})`;
-      ctx.fillRect(relX * 18, relY * 18, 16, 16);
-    });
+    ctx.font = "14px sans-serif";
+    data.forEach(
+      ({
+        x,
+        y,
+        visitors,
+        liveCount,
+        auctionCount,
+      }: {
+        x: number;
+        y: number;
+        visitors: number;
+        liveCount: number;
+        auctionCount: number;
+      }) => {
+        const relX = x - cx + 5;
+        const relY = cy - y + 5;
+        const alpha = Math.min(visitors / 20, 1);
+        ctx.fillStyle = `hsla(${120 - alpha * 120} 80% 50% / ${0.2 + alpha * 0.8})`;
+        ctx.fillRect(relX * 18, relY * 18, 16, 16);
+        if (liveCount > 0) {
+          ctx.fillStyle = "#16a34a";
+          ctx.fillText("⧉", relX * 18 + 4, relY * 18 + 14);
+        }
+        if (auctionCount > 0) {
+          ctx.fillStyle = "#eab308";
+          ctx.fillText("⚡", relX * 18 + 4, relY * 18 + 14);
+        }
+      },
+    );
     ctx.strokeStyle = "#000";
     ctx.lineWidth = 2;
     ctx.strokeRect(5 * 18, 5 * 18, 16, 16);
   }, [data, cx, cy]);
 
   return (
-    <canvas
-      ref={canvas}
-      width={200}
-      height={200}
-      className="fixed bottom-4 right-4 bg-white/70 rounded shadow"
-    />
+    <div className="fixed bottom-4 right-4">
+      <canvas
+        ref={canvas}
+        width={200}
+        height={200}
+        className="bg-white/70 rounded shadow"
+      />
+      <div className="mt-1 flex gap-2 text-xs bg-white/70 rounded px-1">
+        <span className="text-green-600">⧉ live</span>
+        <span className="text-yellow-500">⚡ auction</span>
+      </div>
+    </div>
   );
 }

--- a/lib/models/schema.prisma
+++ b/lib/models/schema.prisma
@@ -789,7 +789,10 @@ model Section {
   x          Int
   y          Int
   visitors   Int      @default(0)
+  liveCount  Int      @default(0)
+  auctionCount Int   @default(0)
   created_at DateTime @default(now()) @db.Timestamptz(6)
+  updated_at DateTime @default(now()) @updatedAt @db.Timestamptz(6)
   stalls     Stall[]
 
   @@unique([x, y])

--- a/services/swapmeet-api/src/__tests__/heatmap.test.ts
+++ b/services/swapmeet-api/src/__tests__/heatmap.test.ts
@@ -18,15 +18,25 @@ beforeEach(() => {
 
 describe("getHeatmap", () => {
   it("queries sections within bounds", async () => {
-    mockFindMany.mockResolvedValue([{ x: 1, y: 2, visitors: 3 }]);
+    mockFindMany.mockResolvedValue([
+      { x: 1, y: 2, visitors: 3, liveCount: 1, auctionCount: 0 },
+    ]);
     const result = await getHeatmap(0, 2, 0, 3);
     expect(mockFindMany).toHaveBeenCalledWith({
       where: {
         x: { gte: 0, lte: 2 },
         y: { gte: 0, lte: 3 },
       },
-      select: { x: true, y: true, visitors: true },
+      select: {
+        x: true,
+        y: true,
+        visitors: true,
+        liveCount: true,
+        auctionCount: true,
+      },
     });
-    expect(result).toEqual([{ x: 1, y: 2, visitors: 3 }]);
+    expect(result).toEqual([
+      { x: 1, y: 2, visitors: 3, liveCount: 1, auctionCount: 0 },
+    ]);
   });
 });

--- a/services/swapmeet-api/src/heatmap.ts
+++ b/services/swapmeet-api/src/heatmap.ts
@@ -11,7 +11,13 @@ export async function getHeatmap(
       x: { gte: xMin, lte: xMax },
       y: { gte: yMin, lte: yMax },
     },
-    select: { x: true, y: true, visitors: true },
+    select: {
+      x: true,
+      y: true,
+      visitors: true,
+      liveCount: true,
+      auctionCount: true,
+    },
   });
 }
 

--- a/workers/index.ts
+++ b/workers/index.ts
@@ -8,6 +8,7 @@ import "@/workers/scrollRealtime";
 import '@/workers/tasteVector';
 import "@/workers/candidate-builder";
 import "@/workers/user-knn-builder";
+import "@/workers/sectionHeat";
 
 
 console.log('All workers bootstrapped');

--- a/workers/sectionHeat.ts
+++ b/workers/sectionHeat.ts
@@ -1,0 +1,34 @@
+import { prisma } from "@/lib/prismaclient";
+
+async function updateCounts() {
+  await prisma.$executeRaw`UPDATE section SET "liveCount" = 0, "auctionCount" = 0`;
+  await prisma.$executeRaw`
+    UPDATE section s
+    SET "liveCount" = src.cnt
+    FROM (
+      SELECT section_id, COUNT(*)::int AS cnt
+      FROM stalls
+      WHERE live = true
+      GROUP BY section_id
+    ) src
+    WHERE s.id = src.section_id
+  `;
+  await prisma.$executeRaw`
+    UPDATE section s
+    SET "auctionCount" = src.cnt
+    FROM (
+      SELECT st.section_id, COUNT(*)::int AS cnt
+      FROM auctions a
+      JOIN stalls st ON st.id = a.stall_id
+      WHERE a.state = 'LIVE' AND a.ends_at > NOW()
+      GROUP BY st.section_id
+    ) src
+    WHERE s.id = src.section_id
+  `;
+}
+
+setInterval(() => {
+  updateCounts().catch((e) => console.error("[sectionHeat]", e));
+}, 30_000);
+
+updateCounts().catch((e) => console.error("[sectionHeat]", e));


### PR DESCRIPTION
## Summary
- track live stalls and active auctions in section heat data
- expose live and auction counts in API and draw icons on SwapMeet minimap
- add worker to keep section heat table in sync

## Testing
- `npm run lint` *(fails: React hook rule violations in unrelated files)*
- `npx eslint services/swapmeet-api/src/heatmap.ts services/swapmeet-api/src/__tests__/heatmap.test.ts app/swapmeet/components/Minimap.tsx workers/sectionHeat.ts`
- `npm run vitest services/swapmeet-api/src/__tests__/heatmap.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68910597058883299326ad24afc37cd0