### PR TITLE
Restore portfolio builder interactions

### DIFF
--- a/app/portfolio/builder/page.tsx
+++ b/app/portfolio/builder/page.tsx
@@ -162,9 +162,11 @@ function SortableCanvasItem({
 function EditableBox({
   box,
   onInput,
+  onSelect,
 }: {
   box: TextBox;
   onInput: (t: string) => void;
+  onSelect: () => void;
 }) {
   const ref = useRef<HTMLDivElement>(null);
 
@@ -190,7 +192,10 @@ function EditableBox({
         whiteSpace: "pre-wrap",
         cursor: "text",
       }}
-      onPointerDown={(e) => e.stopPropagation()}
+      onPointerDown={(e) => {
+        onSelect();
+        e.stopPropagation();
+      }}
       onInput={(e) => onInput((e.target as HTMLElement).innerText)}
     />
   );
@@ -323,6 +328,7 @@ const DroppableCanvas = forwardRef<DroppableCanvasHandle, DroppableCanvasProps>(
     const [draggingState, setDraggingState] = useState<DragState | null>(null);
     const resizeRef = useRef<ResizeState | null>(null);
     const dragRef = useRef<DragState | null>(null);
+    const { setNodeRef } = useDroppable({ id: "canvas" });
 
     //  const setResizing = (s: ResizeState | null) => {
     //   resizeRef.current = s;
@@ -358,12 +364,31 @@ const DroppableCanvas = forwardRef<DroppableCanvasHandle, DroppableCanvasProps>(
         resizeRef.current = payload;
         setResizingState(payload);
       },
-      [boxes, elements]
+      [boxes, elements, canvasRef]
     );
 
     useImperativeHandle(ref, () => ({ startResize: handleResizeStart }), [
       handleResizeStart,
     ]);
+
+    const handleBoxPointerDown = (
+      e: React.PointerEvent,
+      box: TextBox
+    ) => {
+      if ((e.target as HTMLElement).classList.contains("resize-handle")) return;
+      e.stopPropagation();
+      setSelectedId(box.id);
+      const rect = canvasRef.current!.getBoundingClientRect();
+      const payload: DragState = {
+        id: box.id,
+        startX: e.clientX - rect.left,
+        startY: e.clientY - rect.top,
+        startLeft: box.x,
+        startTop: box.y,
+      };
+      dragRef.current = payload;
+      setDraggingState(payload);
+    };
 
     /* --- pointer‑move / pointer‑up (global once) --- */
     useEffect(() => {
@@ -450,7 +475,7 @@ const DroppableCanvas = forwardRef<DroppableCanvasHandle, DroppableCanvasProps>(
         window.removeEventListener("pointermove", onMove);
         window.removeEventListener("pointerup", onUp);
       };
-    }, [setBoxes, setElements]);
+    }, [canvasRef, setBoxes, setElements]);
 
     /* ---------- draw new text‑box ---------- */
     // inside the forwardRef body
@@ -486,10 +511,11 @@ const DroppableCanvas = forwardRef<DroppableCanvasHandle, DroppableCanvasProps>(
         y += height;
         height = -height;
       }
+      const id = nanoid();
       setBoxes((bs) => [
         ...bs,
         {
-          id: nanoid(),
+          id,
           x,
           y,
           width,
@@ -499,6 +525,7 @@ const DroppableCanvas = forwardRef<DroppableCanvasHandle, DroppableCanvasProps>(
           lineHeight: 1.2,
         },
       ]);
+      setSelectedId(id);
       setDraft(null);
     };
 
@@ -513,11 +540,14 @@ const DroppableCanvas = forwardRef<DroppableCanvasHandle, DroppableCanvasProps>(
     return (
       <div
         ref={(node) => {
+          setNodeRef(node);
           canvasRef.current = node;
         }}
         className={`relative flex-1 min-h-screen border border-dashed p-4 ${color} ${layoutClass}`}
         style={{ cursor: drawText ? "crosshair" : "default" }}
-        /* mouse handlers for drawText omitted for brevity */
+        onMouseDown={startDraw}
+        onMouseMove={moveDraw}
+        onMouseUp={endDraw}
       >
         {children}
 
@@ -549,6 +579,7 @@ const DroppableCanvas = forwardRef<DroppableCanvasHandle, DroppableCanvasProps>(
                   bs.map((b) => (b.id === box.id ? { ...b, text } : b))
                 )
               }
+              onSelect={() => setSelectedId(box.id)}
             />
           </div>
         ))}
@@ -1375,10 +1406,10 @@ export default function PortfolioBuilder() {
                         if (!isSafeHttpLink(v)) return; // bail out on invalid link
 
                         setElements((prev) =>
-                          prev.map((el) =>
-                            el.id === el.id // ← whichever id var you’re in
-                              ? { ...el, href: v } // patch that one element
-                              : el
+                          prev.map((it) =>
+                            it.id === el.id
+                              ? { ...it, href: v }
+                              : it
                           )
                         );
                       }}


### PR DESCRIPTION
## Summary
- ensure canvas registers as dnd-kit drop target and expose pointer handlers
- restore text box dragging and fix link element updates
- show style panel when a text box is selected

## Testing
- `npm run lint` *(fails: React Hooks called conditionally in other files)*
- `npm run lint -- --file app/portfolio/builder/page.tsx`


------
https://chatgpt.com/codex/tasks/task_e_689124c27e2c83299b99f605ff91fcfb