### PR TITLE
Add multi-select and group drag to builder

### DIFF
--- a/lib/portfolio/CanvasStoreProvider.tsx
+++ b/lib/portfolio/CanvasStoreProvider.tsx
@@ -60,3 +60,21 @@ export function useElement(id: string): ElementRecord {
 export function useCanvasDispatch() {
   return useStore().dispatch;
 }
+
+export function useCanvasSelection(): string[] {
+  const store = useStore();
+  return React.useSyncExternalStore(
+    store.subscribe,
+    () => Array.from(store.getSnapshot().selected),
+    () => Array.from(store.getSnapshot().selected),
+  );
+}
+
+export function useCanvasElements(): Map<string, ElementRecord> {
+  const store = useStore();
+  return React.useSyncExternalStore(
+    store.subscribe,
+    () => store.getSnapshot().elements,
+    () => store.getSnapshot().elements,
+  );
+}

--- a/lib/portfolio/selection.ts
+++ b/lib/portfolio/selection.ts
@@ -1,0 +1,14 @@
+export function getBoundingRect(
+  ids: string[],
+  elements: Map<string, { x: number; y: number; width: number; height: number }>,
+) {
+  const rects = ids
+    .map((id) => elements.get(id))
+    .filter((el): el is { x: number; y: number; width: number; height: number } => !!el);
+  if (!rects.length) return null;
+  const left = Math.min(...rects.map((r) => r.x));
+  const top = Math.min(...rects.map((r) => r.y));
+  const right = Math.max(...rects.map((r) => r.x + r.width));
+  const bottom = Math.max(...rects.map((r) => r.y + r.height));
+  return { left, top, width: right - left, height: bottom - top };
+}


### PR DESCRIPTION
## Summary
- support tracking selected elements and group dragging in canvas store
- expose selection hooks and bounding box util
- add multi-select, group move, and selection box rendering to portfolio builder

## Testing
- `npx next lint --file app/portfolio/builder/page.tsx --file lib/portfolio/canvasStore.ts --file lib/portfolio/CanvasStoreProvider.tsx --file lib/portfolio/selection.ts`

------
https://chatgpt.com/codex/tasks/task_e_6892d7db860c8329907ce66988047586