### PR TITLE
Fix image dragging and selection refresh in site builder

### DIFF
--- a/app/portfolio/builder/page.tsx
+++ b/app/portfolio/builder/page.tsx
@@ -115,21 +115,27 @@ function CanvasItem({
   id,
   x,
   y,
+  w,
+  h,
   children,
 }: {
   id: string;
   x: number;
   y: number;
+  w: number;
+  h: number;
   children: React.ReactNode;
 }) {
   const { attributes, listeners, setNodeRef } = useDraggable({ id });
   const dispatch = useCanvasDispatch();
-  const style = {
+  const style: React.CSSProperties = {
     position: "absolute",
     left: x,
     top: y,
+    width: w,
+    height: h,
     zIndex: 1,
-  } as React.CSSProperties;
+  };
   const handlePointerDown = (e: React.PointerEvent) => {
     const isMeta = e.metaKey || e.ctrlKey;
     if (isMeta) dispatch({ type: "toggleSelect", id });
@@ -1225,7 +1231,14 @@ DroppableCanvas.displayName = "DroppableCanvas";
           >
             {elements.map((el) =>
               template === "" ? (
-                <CanvasItem key={el.id} id={el.id} x={el.x} y={el.y}>
+                <CanvasItem
+                  key={el.id}
+                  id={el.id}
+                  x={el.x}
+                  y={el.y}
+                  w={el.width}
+                  h={el.height}
+                >
                   <div className="py-8 px-8 border-[1px] rounded-xl border-black savebutton bg-white/20 space-y-2">
                     {el.type === "text" && (
                       
@@ -1282,6 +1295,7 @@ DroppableCanvas.displayName = "DroppableCanvas";
                               alt="uploaded"
                               width={400}
                               height={400}
+                              draggable={false}
                               className="object-contain items-center justify-center w-full h-full"
                               crossOrigin="anonymous"
                               onLoad={(e) =>
@@ -1462,6 +1476,7 @@ DroppableCanvas.displayName = "DroppableCanvas";
                               alt="uploaded"
                               width={el.width}
                               height={el.height}
+                              draggable={false}
                               className="object-cover "
                               crossOrigin="anonymous"
                               onLoad={(e) =>
@@ -1692,6 +1707,7 @@ function PreviewOfItem({ id, elements }: PreviewProps) {
           }}
           width={el.width || 0}
           height={el.height || 0}
+          draggable={false}
         />
       );
 

--- a/lib/portfolio/canvasStore.ts
+++ b/lib/portfolio/canvasStore.ts
@@ -90,12 +90,14 @@ export const canvasReducer = produce(
         break;
       }
       case "toggleSelect": {
-        if (draft.selected.has(action.id)) draft.selected.delete(action.id);
-        else draft.selected.add(action.id);
+        const next = new Set(draft.selected);
+        if (next.has(action.id)) next.delete(action.id);
+        else next.add(action.id);
+        draft.selected = next;
         break;
       }
       case "clearSelect": {
-        draft.selected.clear();
+        draft.selected = new Set();
         break;
       }
       case "groupDragStart": {


### PR DESCRIPTION
## Summary
- ensure CanvasItem has width/height and pass element size so images are draggable
- clone selection Set in canvas reducer to trigger multi-select updates
- disable default image drag behavior with `draggable={false}`

## Testing
- `npm run lint` *(fails: React Hook "useMemo" is called conditionally, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68938eecfc8883298277967fac4afc5b