### PR TITLE
Implement undo/redo history and autosave for portfolio builder

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,12 @@ See services/embedding/README.md for setup.
 taste. Authentication via Supabase session is required. Results are cached in
 Redis for `CANDIDATE_CACHE_TTL` seconds.
 
+## Portfolio Builder shortcuts
+
+- Cmd/Ctrl+Z = Undo
+- Cmd/Ctrl+Shift+Z or Ctrl+Y = Redo
+- Draft autosaves locally every 0.8 s; clear via "New / Clear" in menu
+
 ## Roadmap Highlights
 
 The documents in this repo outline the path toward a public launch. Key themes include:

--- a/lib/portfolio/CanvasStoreProvider.tsx
+++ b/lib/portfolio/CanvasStoreProvider.tsx
@@ -1,4 +1,10 @@
-import React, { useReducer, useCallback, useLayoutEffect,useMemo,useRef } from "react";
+import React, {
+  useReducer,
+  useCallback,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+} from "react";
 import {
   canvasReducer,
   initialCanvasState,
@@ -15,8 +21,19 @@ interface Store {
 
 const CanvasCtx = React.createContext<Store | null>(null);
 
-export function CanvasProvider({ children }: { children: React.ReactNode }) {
-  const [state, dispatch] = useReducer(canvasReducer, initialCanvasState);
+export function CanvasProvider({
+  children,
+  initial,
+  onChange,
+}: {
+  children: React.ReactNode;
+  initial?: CanvasState | null;
+  onChange?: (s: CanvasState) => void;
+}) {
+  const [state, dispatch] = useReducer(
+    canvasReducer,
+    initial ?? initialCanvasState,
+  );
   // const listeners = React.useRef(new Set<() => void>());
 
   // const subscribe = useCallback((fn: () => void) => {
@@ -50,7 +67,8 @@ export function CanvasProvider({ children }: { children: React.ReactNode }) {
   }, [dispatch, subscribe]); // deps are stable
   useLayoutEffect(() => {
     listeners.current.forEach((fn) => fn());
-  }, [state]);
+    onChange?.(state);
+  }, [state, onChange]);
 
   return <CanvasCtx.Provider value={store}>{children}</CanvasCtx.Provider>;
 }
@@ -101,4 +119,14 @@ export function useCanvasElements(): Map<string, ElementRecord> {
     () => store.getSnapshot().elements,
     () => store.getSnapshot().elements,
   );
+}
+
+export function useCanvasUndo() {
+  const store = useStore();
+  return () => store.dispatch({ type: "undo" });
+}
+
+export function useCanvasRedo() {
+  const store = useStore();
+  return () => store.dispatch({ type: "redo" });
 }

--- a/lib/portfolio/export.ts
+++ b/lib/portfolio/export.ts
@@ -1,4 +1,6 @@
 import { escapeHtml, escapeJSX, camelToKebab } from "@/lib/utils/escape";
+import { CanvasState } from "./canvasStore";
+import { ElementRecord } from "./types";
 
 
 export interface PortfolioExportData {
@@ -32,6 +34,33 @@ export interface AbsoluteElement {
   fontFamily?: string;
   fontWeight?: 400 | 500 | 600 | 700;
   italic?: boolean;
+}
+
+export function serialize(state: CanvasState): string {
+  return JSON.stringify({
+    schemaVersion: 1,
+    ...state,
+    elements: [...state.elements.values()],
+    selected: [...state.selected],
+  });
+}
+
+export function jsonToCanvasState(
+  obj: any,
+  projectKey?: string,
+): CanvasState | null {
+  if (!obj || obj.schemaVersion !== 1) {
+    if (projectKey && typeof window !== "undefined") {
+      localStorage.removeItem(projectKey);
+    }
+    return null;
+  }
+  const elements = new Map<string, ElementRecord>();
+  if (Array.isArray(obj.elements)) {
+    obj.elements.forEach((el: ElementRecord) => elements.set(el.id, el));
+  }
+  const selected = new Set<string>(Array.isArray(obj.selected) ? obj.selected : []);
+  return { elements, selected, past: [], future: [] };
 }
 export function generatePortfolioTemplates(
   data: PortfolioExportData,

--- a/public/assets/redo.svg
+++ b/public/assets/redo.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 7v6h-6"/><path d="M21 13a9 9 0 1 1-3-7"/></svg>

--- a/public/assets/undo.svg
+++ b/public/assets/undo.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 7v6h6"/><path d="M3 13a9 9 0 1 0 3-7"/></svg>


### PR DESCRIPTION
## Summary
- add undo/redo hooks and history-aware CanvasProvider
- autosave and restore canvas state with schema version guard
- toolbar buttons and keyboard shortcuts for undo/redo
- document portfolio builder shortcuts

## Testing
- `npm run lint` *(fails: React Hook errors in unrelated files)*
- `npx eslint app/portfolio/builder/page.tsx lib/portfolio/CanvasStoreProvider.tsx lib/portfolio/export.ts`

------
https://chatgpt.com/codex/tasks/task_e_68943ee6e5bc832987539eed3ce1fb72