### PR TITLE
Refactor builder canvas state

### DIFF
--- a/lib/portfolio/CanvasStoreProvider.tsx
+++ b/lib/portfolio/CanvasStoreProvider.tsx
@@ -53,8 +53,7 @@ export function CanvasProvider({
   /* ---------- NEW stable store ---------- */
   const listeners = useRef(new Set<() => void>());
 
-  const stateRef = useRef(initialCanvasState); // holds latest state
-  stateRef.current = state;                    // update ref each render
+  const stateRef = useRef(state); // holds latest state
 
   const subscribe = useCallback((fn: () => void) => {
     listeners.current.add(fn);
@@ -62,13 +61,17 @@ export function CanvasProvider({
   }, []);
 
   const store = useMemo<Store>(() => {
-    const getSnapshot = () => stateRef.current;  // ⚡️ SAME fn for life
+    const getSnapshot = () => stateRef.current; // ⚡️ SAME fn for life
     return { getSnapshot, dispatch, subscribe };
   }, [dispatch, subscribe]); // deps are stable
+
   useLayoutEffect(() => {
+    stateRef.current = state;
     listeners.current.forEach((fn) => fn());
     onChange?.(state);
   }, [state, onChange]);
+
+  React.useEffect(() => () => listeners.current.clear(), []);
 
   return <CanvasCtx.Provider value={store}>{children}</CanvasCtx.Provider>;
 }

--- a/lib/portfolio/export.ts
+++ b/lib/portfolio/export.ts
@@ -37,11 +37,12 @@ export interface AbsoluteElement {
 }
 
 export function serialize(state: CanvasState): string {
+  const { elements, selected, past, future, _dragStart, ...rest } = state as any;
   return JSON.stringify({
     schemaVersion: 1,
-    ...state,
-    elements: [...state.elements.values()],
-    selected: [...state.selected],
+    ...rest,
+    elements: [...elements.values()],
+    selected: [...selected],
   });
 }
 
@@ -60,7 +61,15 @@ export function jsonToCanvasState(
     obj.elements.forEach((el: ElementRecord) => elements.set(el.id, el));
   }
   const selected = new Set<string>(Array.isArray(obj.selected) ? obj.selected : []);
-  return { elements, selected, past: [], future: [] };
+  return {
+    elements,
+    selected,
+    past: [],
+    future: [],
+    layout: obj.layout,
+    color: obj.color,
+    schemaVersion: obj.schemaVersion,
+  };
 }
 export function generatePortfolioTemplates(
   data: PortfolioExportData,


### PR DESCRIPTION
## Summary
- centralize portfolio builder canvas state in reducer for undo/redo and autosave
- persist layout/color metadata and clean up canvas store provider
- improve serialization and keyboard shortcuts

## Testing
- `npm run lint` *(fails: React hooks mis-use and no-img-element warnings in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68945c3831688329a9845ce63c1962b2