### PR TITLE
Add group conversation and attachment actions

### DIFF
--- a/lib/actions/conversation.actions.ts
+++ b/lib/actions/conversation.actions.ts
@@ -1,0 +1,78 @@
+"use server";
+
+import { prisma } from "@/lib/prismaclient";
+
+export async function getOrCreateDM({
+  userAId,
+  userBId,
+}: {
+  userAId: bigint;
+  userBId: bigint;
+}) {
+  const existing = await prisma.conversation.findFirst({
+    where: {
+      OR: [
+        { user1_id: userAId, user2_id: userBId },
+        { user1_id: userBId, user2_id: userAId },
+      ],
+    },
+  });
+  if (existing) return existing;
+  return prisma.$transaction(async (tx) => {
+    const convo = await tx.conversation.create({
+      data: { user1_id: userAId, user2_id: userBId },
+    });
+    await tx.conversationParticipant.createMany({
+      data: [
+        { conversation_id: convo.id, user_id: userAId },
+        { conversation_id: convo.id, user_id: userBId },
+      ],
+    });
+    return convo;
+  });
+}
+
+export async function createGroupConversation(
+  creatorId: bigint,
+  participantIds: bigint[],
+  title?: string
+) {
+  const ids = Array.from(new Set([creatorId, ...participantIds]));
+  if (ids.length < 3) throw new Error("Minimum 3 participants required");
+
+  return prisma.$transaction(async (tx) => {
+    const convo = await tx.conversation.create({
+      data: { title, is_group: true },
+    });
+    await tx.conversationParticipant.createMany({
+      data: ids.map((id) => ({ conversation_id: convo.id, user_id: id })),
+    });
+    return convo;
+  });
+}
+
+export async function fetchConversations(userId: bigint) {
+  return prisma.conversation.findMany({
+    where: { participants: { some: { user_id: userId } } },
+    include: {
+      participants: { include: { user: true } },
+      messages: { orderBy: { created_at: "desc" }, take: 1 },
+    },
+    orderBy: { updated_at: "desc" },
+  });
+}
+
+export async function fetchConversation(
+  conversationId: bigint,
+  userId: bigint
+) {
+  const convo = await prisma.conversation.findFirst({
+    where: {
+      id: conversationId,
+      participants: { some: { user_id: userId } },
+    },
+    include: { participants: { include: { user: true } } },
+  });
+  if (!convo) throw new Error("Conversation not found");
+  return convo;
+}

--- a/lib/storage/uploadAttachment.ts
+++ b/lib/storage/uploadAttachment.ts
@@ -1,0 +1,15 @@
+import { v4 as uuid } from "uuid";
+import { supabase } from "../supabaseclient";
+
+export async function uploadAttachment(file: File) {
+  const ext = file.name.split(".").pop();
+  const path = `${uuid()}.${ext}`;
+  const { error } = await supabase.storage
+    .from("message-attachments")
+    .upload(path, file, { contentType: file.type });
+  if (error) throw error;
+  const { data } = await supabase.storage
+    .from("message-attachments")
+    .createSignedUrl(path, 60 * 60 * 24 * 7);
+  return { url: data.signedUrl, size: file.size, type: file.type };
+}

--- a/tests/conversation.actions.test.ts
+++ b/tests/conversation.actions.test.ts
@@ -1,0 +1,103 @@
+const mockPrisma: any = {
+  conversation: {
+    findFirst: jest.fn(),
+    create: jest.fn(),
+    findMany: jest.fn(),
+  },
+  conversationParticipant: {
+    createMany: jest.fn(),
+  },
+  $transaction: jest.fn(async (fn: any) => fn(mockPrisma)),
+};
+
+jest.mock("@/lib/prismaclient", () => ({ prisma: mockPrisma }));
+
+const {
+  createGroupConversation,
+  fetchConversation,
+  fetchConversations,
+  getOrCreateDM,
+} = require("@/lib/actions/conversation.actions");
+
+describe("conversation actions", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test("getOrCreateDM returns existing conversation", async () => {
+    const existing = { id: 1n };
+    mockPrisma.conversation.findFirst.mockResolvedValue(existing);
+    const convo = await getOrCreateDM({ userAId: 1n, userBId: 2n });
+    expect(convo).toBe(existing);
+    expect(mockPrisma.conversation.create).not.toHaveBeenCalled();
+  });
+
+  test("getOrCreateDM creates conversation when none exists", async () => {
+    mockPrisma.conversation.findFirst.mockResolvedValue(null);
+    const created = { id: 3n };
+    mockPrisma.conversation.create.mockResolvedValue(created);
+    const convo = await getOrCreateDM({ userAId: 1n, userBId: 2n });
+    expect(mockPrisma.conversation.create).toHaveBeenCalledWith({
+      data: { user1_id: 1n, user2_id: 2n },
+    });
+    expect(mockPrisma.conversationParticipant.createMany).toHaveBeenCalledWith({
+      data: [
+        { conversation_id: created.id, user_id: 1n },
+        { conversation_id: created.id, user_id: 2n },
+      ],
+    });
+    expect(convo).toBe(created);
+  });
+
+  test("createGroupConversation requires minimum participants", async () => {
+    await expect(createGroupConversation(1n, [2n])).rejects.toThrow(
+      "Minimum 3 participants required"
+    );
+  });
+
+  test("createGroupConversation creates conversation and participants", async () => {
+    const created = { id: 5n };
+    mockPrisma.conversation.create.mockResolvedValue(created);
+    const convo = await createGroupConversation(1n, [2n, 3n], "Group");
+    expect(mockPrisma.conversation.create).toHaveBeenCalledWith({
+      data: { title: "Group", is_group: true },
+    });
+    expect(mockPrisma.conversationParticipant.createMany).toHaveBeenCalledWith({
+      data: [
+        { conversation_id: created.id, user_id: 1n },
+        { conversation_id: created.id, user_id: 2n },
+        { conversation_id: created.id, user_id: 3n },
+      ],
+    });
+    expect(convo).toBe(created);
+  });
+
+  test("fetchConversations returns list", async () => {
+    const list = [{ id: 1n }];
+    mockPrisma.conversation.findMany.mockResolvedValue(list);
+    const result = await fetchConversations(1n);
+    expect(mockPrisma.conversation.findMany).toHaveBeenCalledWith({
+      where: { participants: { some: { user_id: 1n } } },
+      include: {
+        participants: { include: { user: true } },
+        messages: { orderBy: { created_at: "desc" }, take: 1 },
+      },
+      orderBy: { updated_at: "desc" },
+    });
+    expect(result).toBe(list);
+  });
+
+  test("fetchConversation throws when missing", async () => {
+    mockPrisma.conversation.findFirst.mockResolvedValue(null);
+    await expect(fetchConversation(1n, 2n)).rejects.toThrow(
+      "Conversation not found"
+    );
+  });
+
+  test("fetchConversation returns conversation", async () => {
+    const convo = { id: 1n };
+    mockPrisma.conversation.findFirst.mockResolvedValue(convo);
+    const result = await fetchConversation(1n, 2n);
+    expect(result).toBe(convo);
+  });
+});


### PR DESCRIPTION
## Summary
- add Supabase upload helper for message attachments
- implement group conversation helpers and DM refactor
- support attachments and realtime broadcasts in sendMessage
- add unit tests for conversation actions

## Testing
- `npm run lint` *(fails: React Hook "useMemo" is called conditionally...)*
- `npm test tests/conversation.actions.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_689541d178748329b828cfcd5b13ade4