### PR TITLE
Add group chat API routes and chat store

### DIFF
--- a/app/(root)/(standard)/messages/[id]/page.tsx
+++ b/app/(root)/(standard)/messages/[id]/page.tsx
@@ -1,40 +1,32 @@
-import { fetchConversation, fetchMessages } from "@/lib/actions/message.actions";
+import { fetchMessages } from "@/lib/actions/message.actions";
+import { fetchConversation } from "@/lib/actions/conversation.actions";
 import { getUserFromCookies } from "@/lib/serverutils";
 import { redirect, notFound } from "next/navigation";
 import MessageForm from "./send-form";
 import ChatRoom from "@/components/chat/ChatRoom";
-import Link from "next/link";
-import { useContext } from "react";
 
 export default async function Page({ params }: { params: { id: string } }) {
   const user = await getUserFromCookies();
   if (!user?.userId) redirect("/login");
   const conversationId = BigInt(params.id);
-  const conversation = await fetchConversation({ conversationId });
-  if (!conversation) notFound();
-  if (conversation.user1_id !== user.userId && conversation.user2_id !== user.userId) notFound();
+  const conversation = await fetchConversation(conversationId, user.userId);
   const messages = await fetchMessages({ conversationId });
-  const other = conversation.user1_id === user.userId ? conversation.user2 : conversation.user1;
   return (
     <main className=" p-4 mt-[-3rem] items-center justify-center ">
-      <Link href={`/profile/${other.id}`} className="justify-center   text-[2.4rem]  ">{other.name}
-      {/* <h1 className="ml-[40%]  text-[2.4rem]  ">{other.name}</h1> */}
-      </Link>
-      <hr></hr>
-    <div className="mt-6 space-y-6">
-      <ChatRoom
-        conversationId={conversationId}
-        currentUserId={user.userId}
-        initialMessages={messages.map((m) => ({
-          id: m.id.toString(),
-          text: m.text,
-          created_at: m.created_at.toISOString(),
-          sender_id: m.sender_id.toString(),
-          sender: { name: m.sender.name, image: m.sender.image },
-        }))}
-      />
-      <hr></hr>
-      <MessageForm conversationId={conversationId} />
+      <div className="mt-6 space-y-6">
+        <ChatRoom
+          conversationId={conversationId}
+          currentUserId={user.userId}
+          initialMessages={messages.map((m) => ({
+            id: m.id.toString(),
+            text: m.text,
+            createdAt: m.created_at.toISOString(),
+            senderId: m.sender_id.toString(),
+            sender: { name: m.sender.name, image: m.sender.image },
+          }))}
+        />
+        <hr></hr>
+        <MessageForm conversationId={conversationId} />
       </div>
     </main>
   );

--- a/app/(root)/(standard)/messages/[id]/send-form.tsx
+++ b/app/(root)/(standard)/messages/[id]/send-form.tsx
@@ -1,5 +1,6 @@
 "use client";
 import { useState } from "react";
+import { useChatStore } from "@/contexts/useChatStore";
 
 interface Props {
   conversationId: bigint;
@@ -7,13 +8,12 @@ interface Props {
 
 export default function MessageForm({ conversationId }: Props) {
   const [text, setText] = useState("");
+  const sendMessage = useChatStore((s) => s.sendMessage);
   async function send() {
     if (!text.trim()) return;
-    await fetch(`/api/messages/${conversationId}`, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ text }),
-    });
+    const form = new FormData();
+    form.append("text", text);
+    await sendMessage(conversationId.toString(), form);
     setText("");
   }
   return (

--- a/app/(root)/(standard)/profile/messages/page.tsx
+++ b/app/(root)/(standard)/profile/messages/page.tsx
@@ -1,6 +1,6 @@
 import Link from "next/link";
 import Image from "next/image";
-import { fetchConversations } from "@/lib/actions/message.actions";
+import { fetchConversations } from "@/lib/actions/conversation.actions";
 import { getUserFromCookies } from "@/lib/serverutils";
 import { redirect } from "next/navigation";
 

--- a/app/api/conversations/group/route.ts
+++ b/app/api/conversations/group/route.ts
@@ -1,0 +1,17 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getUserFromCookies } from "@/lib/serverutils";
+import { createGroupConversation } from "@/lib/actions/conversation.actions";
+
+export async function POST(req: NextRequest) {
+  const user = await getUserFromCookies();
+  if (!user?.userId) {
+    return new NextResponse("Unauthorized", { status: 401 });
+  }
+  const { title, participantIds } = await req.json();
+  if (!Array.isArray(participantIds) || participantIds.length === 0) {
+    return new NextResponse("Invalid participants", { status: 400 });
+  }
+  const ids = participantIds.map((id: string) => BigInt(id));
+  const convo = await createGroupConversation(user.userId, ids, title);
+  return NextResponse.json({ id: convo.id.toString() }, { status: 201 });
+}

--- a/app/api/messages/[id]/route.ts
+++ b/app/api/messages/[id]/route.ts
@@ -1,32 +1,40 @@
 import { NextRequest, NextResponse } from "next/server";
-import { getUserFromCookies } from "@/lib/serverutils";
-import { fetchMessages, sendMessage, fetchConversation } from "@/lib/actions/message.actions";
+import { fetchMessages, sendMessage } from "@/lib/actions/message.actions";
+import { ensureParticipant } from "../ensureParticipant";
 
-export async function GET(req: NextRequest, { params }: { params: { id: string } }) {
-  const user = await getUserFromCookies();
-  if (!user?.userId) {
-    return new NextResponse("Unauthorized", { status: 401 });
-  }
+export async function GET(
+  req: NextRequest,
+  { params }: { params: { id: string } }
+) {
   const conversationId = BigInt(params.id);
-  const conv = await fetchConversation({ conversationId });
-  if (!conv || (conv.user1_id !== user.userId && conv.user2_id !== user.userId)) {
-    return new NextResponse("Not Found", { status: 404 });
-  }
-  const messages = await fetchMessages({ conversationId });
-  return NextResponse.json(messages);
+  const userCheck = await ensureParticipant(req, conversationId);
+  if (userCheck instanceof NextResponse) return userCheck;
+
+  const cursorParam = req.nextUrl.searchParams.get("cursor");
+  const limitParam = req.nextUrl.searchParams.get("limit");
+  const cursor = cursorParam ? BigInt(cursorParam) : undefined;
+  const limit = limitParam ? parseInt(limitParam, 10) : undefined;
+  const messages = await fetchMessages({ conversationId, cursor, limit });
+  return NextResponse.json(messages, { status: 200 });
 }
 
-export async function POST(req: NextRequest, { params }: { params: { id: string } }) {
-  const user = await getUserFromCookies();
-  if (!user?.userId) {
-    return new NextResponse("Unauthorized", { status: 401 });
-  }
+export async function POST(
+  req: NextRequest,
+  { params }: { params: { id: string } }
+) {
   const conversationId = BigInt(params.id);
-  const conv = await fetchConversation({ conversationId });
-  if (!conv || (conv.user1_id !== user.userId && conv.user2_id !== user.userId)) {
-    return new NextResponse("Not Found", { status: 404 });
-  }
-  const { text } = await req.json();
-  await sendMessage({ conversationId, senderId: user.userId, text, path: `/messages/${params.id}` });
-  return NextResponse.json({ status: "ok" });
+  const userCheck = await ensureParticipant(req, conversationId);
+  if (userCheck instanceof NextResponse) return userCheck;
+  const { userId } = userCheck;
+
+  const form = await req.formData();
+  const text = form.get("text") as string | null;
+  const files = form.getAll("files").filter(Boolean) as File[];
+  const message = await sendMessage({
+    conversationId,
+    senderId: userId,
+    text: text ?? undefined,
+    files: files.length ? files : undefined,
+  });
+  return NextResponse.json(message, { status: 201 });
 }

--- a/app/api/messages/ensureParticipant.ts
+++ b/app/api/messages/ensureParticipant.ts
@@ -1,0 +1,27 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getUserFromCookies } from "@/lib/serverutils";
+import { prisma } from "@/lib/prismaclient";
+
+export async function ensureParticipant(
+  req: NextRequest,
+  conversationId: bigint
+): Promise<{ userId: bigint } | NextResponse> {
+  const user = await getUserFromCookies();
+  if (!user?.userId)
+    return new NextResponse("Unauthorized", { status: 401 });
+
+  const conversation = await prisma.conversation.findFirst({
+    where: { id: conversationId },
+    select: {
+      id: true,
+      participants: { where: { user_id: user.userId }, select: { user_id: true } },
+    },
+  });
+  if (!conversation) {
+    return new NextResponse("Not Found", { status: 404 });
+  }
+  if (conversation.participants.length === 0) {
+    return new NextResponse("Forbidden", { status: 403 });
+  }
+  return { userId: user.userId };
+}

--- a/app/api/messages/start/route.ts
+++ b/app/api/messages/start/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getUserFromCookies } from "@/lib/serverutils";
-import { getOrCreateConversation } from "@/lib/actions/message.actions";
+import { getOrCreateDM } from "@/lib/actions/conversation.actions";
 
 export async function POST(req: NextRequest) {
   const user = await getUserFromCookies();
@@ -8,9 +8,9 @@ export async function POST(req: NextRequest) {
     return new NextResponse("Unauthorized", { status: 401 });
   }
   const { targetUserId } = await req.json();
-  const conversation = await getOrCreateConversation({
-    userId: user.userId,
-    targetUserId: BigInt(targetUserId),
+  const conversation = await getOrCreateDM({
+    userAId: user.userId,
+    userBId: BigInt(targetUserId),
   });
   return NextResponse.json({ id: conversation.id });
 }

--- a/contexts/useChatStore.ts
+++ b/contexts/useChatStore.ts
@@ -1,0 +1,56 @@
+"use client";
+import { create } from "zustand";
+
+interface Attachment {
+  id: string;
+  path: string;
+  type: string;
+  size: number;
+}
+
+interface Message {
+  id: string;
+  text: string | null;
+  createdAt: string;
+  senderId: string;
+  attachments: Attachment[];
+}
+
+interface Conversation {
+  id: string;
+  title?: string | null;
+}
+
+interface ChatState {
+  conversations: Record<string, Conversation>;
+  currentConversation?: string;
+  messages: Record<string, Message[]>;
+  setCurrentConversation: (id: string) => void;
+  setConversations: (list: Conversation[]) => void;
+  setMessages: (id: string, msgs: Message[]) => void;
+  appendMessage: (id: string, msg: Message) => void;
+  sendMessage: (id: string, data: FormData) => Promise<void>;
+}
+
+export const useChatStore = create<ChatState>((set, get) => ({
+  conversations: {},
+  messages: {},
+  setCurrentConversation: (id) => set({ currentConversation: id }),
+  setConversations: (list) =>
+    set({ conversations: Object.fromEntries(list.map((c) => [c.id, c])) }),
+  setMessages: (id, msgs) =>
+    set((state) => ({ messages: { ...state.messages, [id]: msgs } })),
+  appendMessage: (id, msg) =>
+    set((state) => ({
+      messages: {
+        ...state.messages,
+        [id]: [...(state.messages[id] || []), msg],
+      },
+    })),
+  sendMessage: async (id, data) => {
+    const res = await fetch(`/api/messages/${id}`, { method: "POST", body: data });
+    if (!res.ok) throw new Error("Failed to send message");
+    const msg = await res.json();
+    get().appendMessage(id, msg);
+  },
+}));


### PR DESCRIPTION
## Summary
- add API route to create group conversations and message attachments
- broadcast message events and group creation via Supabase
- introduce Zustand chat store and integrate ChatRoom & MessageForm

## Testing
- `npm run lint` *(fails: React Hook "useMemo" is called conditionally etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68955baf211c832994c933ae7a11d6d4