### PR TITLE
Add library post models

### DIFF
--- a/lib/models/schema.prisma
+++ b/lib/models/schema.prisma
@@ -45,6 +45,9 @@ model User {
   realtimeLikes             RealtimeLike[]
   realtimeposts             RealtimePost[]
   feedPosts                 FeedPost[]
+  libraryPosts              LibraryPost[]
+  stacks                    Stack[]
+  annotations               Annotation[]
   realtimeRoomInviteTokens  RealtimeRoomInviteToken[]
   recommendationClicks      RecommendationClick[]
   attributeEdits            UserAttributeEdit[]
@@ -128,6 +131,8 @@ model FeedPost {
   author           User              @relation(fields: [author_id], references: [id])
   predictionMarket PredictionMarket? @relation("FeedPostPrediction")
   productReview    ProductReview?
+  libraryPost      LibraryPost?     @relation(fields: [library_post_id], references: [id])
+  stack            Stack?           @relation(fields: [stack_id], references: [id])
   articleId        String?           @unique
   thumbnailKey     String? // 4:3 hero variant stored in CDN
   tldr             String? // 280-char summary
@@ -137,6 +142,9 @@ model FeedPost {
   feedPost         FeedPost?         @relation("FeedPostChildren", fields: [parent_id], references: [id], onDelete: Restrict)
   children         FeedPost[]        @relation("FeedPostChildren")
   Like             Like[]
+
+  library_post_id String?
+  stack_id        String?
 
   @@index([author_id])
   @@map("feed_posts")
@@ -166,6 +174,7 @@ enum feed_post_type {
   MUSIC
   ROOM_CANVAS
   ARTICLE
+  LIBRARY
 }
 
 model RealtimeLike {
@@ -1212,6 +1221,61 @@ enum auction_state {
 enum ArticleStatus {
   DRAFT
   PUBLISHED
+}
+
+model LibraryPost {
+  id          String       @id @default(cuid())
+  uploader_id BigInt
+  stack_id    String?
+  title       String?
+  page_count  Int
+  file_url    String
+  thumb_urls  String[]
+  created_at  DateTime     @default(now())
+
+  annotations Annotation[]
+  stack       Stack?       @relation(fields: [stack_id], references: [id])
+  uploader    User         @relation(fields: [uploader_id], references: [id])
+  feedPosts   FeedPost[]
+
+  @@index([uploader_id])
+  @@index([stack_id])
+  @@map("library_posts")
+}
+
+model Stack {
+  id          String       @id @default(cuid())
+  owner_id    BigInt
+  name        String
+  description String?
+  is_public   Boolean      @default(false)
+  order       String[]
+  created_at  DateTime     @default(now())
+  parent_id   String?
+
+  owner      User          @relation(fields: [owner_id], references: [id])
+  posts      LibraryPost[]
+  parent     Stack?        @relation("StackHierarchy", fields: [parent_id], references: [id])
+  children   Stack[]       @relation("StackHierarchy")
+  feedPosts  FeedPost[]
+
+  @@map("stacks")
+}
+
+model Annotation {
+  id         String   @id @default(cuid())
+  post_id    String
+  page       Int
+  rect       Json
+  text       String
+  author_id  BigInt
+  created_at DateTime @default(now())
+
+  post   LibraryPost @relation(fields: [post_id], references: [id], onDelete: Cascade)
+  author User        @relation(fields: [author_id], references: [id])
+
+  @@index([post_id])
+  @@map("annotations")
 }
 
 model Article {

--- a/prisma/migrations/20240807000000_add_library_post.sql
+++ b/prisma/migrations/20240807000000_add_library_post.sql
@@ -1,0 +1,51 @@
+ALTER TYPE "feed_post_type" ADD VALUE IF NOT EXISTS 'LIBRARY';
+
+CREATE TABLE "stacks" (
+  "id" TEXT PRIMARY KEY,
+  "owner_id" BIGINT NOT NULL,
+  "name" TEXT NOT NULL,
+  "description" TEXT,
+  "is_public" BOOLEAN DEFAULT false,
+  "order" TEXT[] NOT NULL DEFAULT '{}'::TEXT[],
+  "created_at" TIMESTAMPTZ NOT NULL DEFAULT now(),
+  "parent_id" TEXT,
+  CONSTRAINT "stacks_owner_id_fkey" FOREIGN KEY ("owner_id") REFERENCES "users"("id") ON DELETE CASCADE,
+  CONSTRAINT "stacks_parent_id_fkey" FOREIGN KEY ("parent_id") REFERENCES "stacks"("id") ON DELETE SET NULL
+);
+
+CREATE TABLE "library_posts" (
+  "id" TEXT PRIMARY KEY,
+  "uploader_id" BIGINT NOT NULL,
+  "stack_id" TEXT,
+  "title" TEXT,
+  "page_count" INTEGER NOT NULL,
+  "file_url" TEXT NOT NULL,
+  "thumb_urls" TEXT[] NOT NULL DEFAULT '{}'::TEXT[],
+  "created_at" TIMESTAMPTZ NOT NULL DEFAULT now(),
+  CONSTRAINT "library_posts_uploader_id_fkey" FOREIGN KEY ("uploader_id") REFERENCES "users"("id") ON DELETE CASCADE,
+  CONSTRAINT "library_posts_stack_id_fkey" FOREIGN KEY ("stack_id") REFERENCES "stacks"("id") ON DELETE SET NULL
+);
+
+CREATE INDEX "library_posts_uploader_id_idx" ON "library_posts" ("uploader_id");
+CREATE INDEX "library_posts_stack_id_idx" ON "library_posts" ("stack_id");
+
+CREATE TABLE "annotations" (
+  "id" TEXT PRIMARY KEY,
+  "post_id" TEXT NOT NULL,
+  "page" INTEGER NOT NULL,
+  "rect" JSONB NOT NULL,
+  "text" TEXT NOT NULL,
+  "author_id" BIGINT NOT NULL,
+  "created_at" TIMESTAMPTZ NOT NULL DEFAULT now(),
+  CONSTRAINT "annotations_post_id_fkey" FOREIGN KEY ("post_id") REFERENCES "library_posts"("id") ON DELETE CASCADE,
+  CONSTRAINT "annotations_author_id_fkey" FOREIGN KEY ("author_id") REFERENCES "users"("id") ON DELETE CASCADE
+);
+
+CREATE INDEX "annotations_post_id_idx" ON "annotations" ("post_id");
+
+ALTER TABLE "feed_posts" ADD COLUMN "library_post_id" TEXT;
+ALTER TABLE "feed_posts" ADD COLUMN "stack_id" TEXT;
+ALTER TABLE "feed_posts" ADD CONSTRAINT "feed_posts_library_post_id_fkey" FOREIGN KEY ("library_post_id") REFERENCES "library_posts"("id") ON DELETE SET NULL;
+ALTER TABLE "feed_posts" ADD CONSTRAINT "feed_posts_stack_id_fkey" FOREIGN KEY ("stack_id") REFERENCES "stacks"("id") ON DELETE SET NULL;
+CREATE INDEX "feed_posts_library_post_id_idx" ON "feed_posts" ("library_post_id");
+CREATE INDEX "feed_posts_stack_id_idx" ON "feed_posts" ("stack_id");


### PR DESCRIPTION
## Summary
- extend FeedPost with optional library and stack references
- add LibraryPost, Stack, and Annotation models and LIBRARY feed post type
- provide SQL migration for new tables and enum value

## Testing
- `npx prisma generate`
- `npm run lint` *(fails: React Hook "useMemo" is called conditionally, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68956c2a9d6483298cd7490e8cabd277