### PR TITLE
Add library post type scaffolding

### DIFF
--- a/app/api/library/import/route.ts
+++ b/app/api/library/import/route.ts
@@ -1,0 +1,10 @@
+import { NextRequest, NextResponse } from "next/server";
+
+// TODO: inject prisma & supabase server client once your pipeline is ready
+
+export async function POST(req: NextRequest) {
+  const payload = await req.json().catch(() => ({}));
+  // TEMP stub so UI can land: replace with real import (create LibraryPost/Stack rows, queue thumbs, create feed post)
+  return NextResponse.json({ ok: true, received: payload });
+}
+

--- a/components/cards/LibraryCard.tsx
+++ b/components/cards/LibraryCard.tsx
@@ -1,0 +1,58 @@
+"use client";
+import React from "react";
+import GalleryCarousel from "./GalleryCarousel";
+
+export type LibraryCardProps = {
+  kind: "single" | "stack";
+  coverUrl?: string;              // single
+  libraryPostId?: string;         // single
+  stackId?: string;               // stack
+  coverUrls?: string[];           // stack
+  size?: number;                  // stack size
+  caption?: string | null;
+  onOpenPdf?: (libraryPostId: string) => void;
+  onOpenStack?: (stackId: string) => void;
+};
+
+export default function LibraryCard(props: LibraryCardProps) {
+  const { kind, coverUrl, coverUrls = [], size = 0, caption, libraryPostId, stackId, onOpenPdf, onOpenStack } = props;
+  if (kind === "single" && coverUrl) {
+    return (
+      <img
+        src={coverUrl}
+        alt="PDF cover"
+        className="rounded-md cursor-pointer w-full h-auto"
+        onClick={() => libraryPostId && onOpenPdf?.(libraryPostId)}
+      />
+    );
+  }
+
+  if (kind === "stack") {
+    if (size <= 10) {
+      return (
+        <div className="grid justify-center items-center w-full">
+          <GalleryCarousel urls={coverUrls} caption={caption || undefined} />
+        </div>
+      );
+    }
+    // >10: simple 2x2 collage
+    const tiles = (coverUrls || []).slice(0, 4);
+    return (
+      <div className="w-full">
+        <div className="grid grid-cols-2 gap-1 rounded-md overflow-hidden">
+          {tiles.map((u, i) => (
+            <img key={i} src={u} alt={`PDF ${i}`} className="w-full aspect-[4/3] object-cover" />
+          ))}
+        </div>
+        <button
+          className="mt-2 text-sm underline"
+          onClick={() => stackId && onOpenStack?.(stackId)}
+        >
+          View Stack ({size})
+        </button>
+      </div>
+    );
+  }
+  return null;
+}
+

--- a/components/cards/PostCard.tsx
+++ b/components/cards/PostCard.tsx
@@ -18,6 +18,7 @@ import SoundCloudPlayer from "../players/SoundCloudPlayer";
 import Spline from "@splinetool/react-spline";
 import dynamic from "next/dynamic";
 import PredictionMarketCard from "./PredictionMarketCard";
+import LibraryCard from "./LibraryCard";
 import type { Like, RealtimeLike } from "@prisma/client";
 import React from "react";
 import localFont from "next/font/local";
@@ -40,7 +41,7 @@ interface ExtraUIProps {
   embedPost?: React.ReactNode;
 }
 
-type PostCardProps = BasePost & ExtraUIProps;
+type PostCardProps = BasePost & ExtraUIProps & { library?: any | null };
 
 const PostCard = ({
   id,
@@ -66,6 +67,7 @@ const PostCard = ({
   pluginData = null,
   claimIds,
   predictionMarket = null,
+  library = null,
 }: PostCardProps) => {
   if (content && content.startsWith("REPLICATE:")) {
     const dataStr = content.slice("REPLICATE:".length);
@@ -188,6 +190,19 @@ const PostCard = ({
                   caption={caption || undefined}
                 />
               </div>
+            )}
+            {type === "LIBRARY" && library && (
+              <LibraryCard
+                kind={library.kind}
+                coverUrl={library.coverUrl}
+                libraryPostId={library.libraryPostId}
+                stackId={library.stackId}
+                coverUrls={library.coverUrls}
+                size={library.size}
+                caption={caption}
+                onOpenPdf={(id) => console.debug("openPdfModal", id)}
+                onOpenStack={(id) => console.debug("openStack", id)}
+              />
             )}
             {type === "LIVECHAT" &&
               content &&

--- a/components/forms/CreateFeedPost.tsx
+++ b/components/forms/CreateFeedPost.tsx
@@ -32,6 +32,7 @@ import MusicNodeModal from "../modals/MusicNodeModal";
 import SplineViewerNodeModal from "../modals/SplineViewerNodeModal";
 import RoomCanvasModal from "../modals/RoomCanvasModal";
 import PredictionMarketModal from "../modals/PredictionMarketModal";
+import LibraryPostModal from "@/components/modals/LibraryPostModal";
 import { exportRoomCanvas } from "@/lib/actions/realtimeroom.actions";
 import {
   uploadFileToSupabase,
@@ -77,6 +78,7 @@ const nodeOptions: { label: string; nodeType: string }[] = [
   { label: "PRODUCT_REVIEW", nodeType: "PRODUCT_REVIEW" },
   { label: "PREDICTION", nodeType: "PREDICTION" },
   { label: "ROOM_CANVAS", nodeType: "ROOM_CANVAS" },
+  { label: "LIBRARY", nodeType: "LIBRARY" },
 ];
 
 interface Props {
@@ -552,6 +554,8 @@ const CreateFeedPost = ({ roomId = "global" }: Props) => {
             }}
           />
         );
+      case "LIBRARY":
+        return <LibraryPostModal onOpenChange={(v) => { if (!v) reset(); }} />;
 
       // onSubmit={async (vals) => {
       //   await createRealtimePost({

--- a/components/modals/LibraryPostModal.tsx
+++ b/components/modals/LibraryPostModal.tsx
@@ -1,0 +1,65 @@
+"use client";
+import React, { useState } from "react";
+import { DialogContent, DialogHeader, DialogTitle, DialogClose } from "@/components/ui/dialog";
+import { useCreateLibraryPost } from "@/lib/hooks/useCreateLibraryPost";
+
+type Props = {
+  onOpenChange: (v: boolean) => void;
+};
+
+export default function LibraryPostModal({ onOpenChange }: Props) {
+  const createLibraryPost = useCreateLibraryPost();
+  const [tab, setTab] = useState<"upload" | "url">("upload");
+  const [urls, setUrls] = useState<string>("");
+  const [files, setFiles] = useState<FileList | null>(null);
+
+  async function onSubmit() {
+    if (tab === "url") {
+      const list = urls.split("\n").map(s => s.trim()).filter(Boolean);
+      await createLibraryPost({ urls: list });
+      onOpenChange(false);
+      return;
+    }
+    if (files && files.length) {
+      await createLibraryPost({ files: Array.from(files) });
+      onOpenChange(false);
+    }
+  }
+
+  return (
+    <DialogContent className="max-w-[600px]">
+      <DialogHeader>
+        <DialogTitle>New Library</DialogTitle>
+      </DialogHeader>
+      <div className="flex gap-3 text-sm">
+        <button className={tab === "upload" ? "underline" : ""} onClick={() => setTab("upload")}>Upload</button>
+        <button className={tab === "url" ? "underline" : ""} onClick={() => setTab("url")}>Paste URL(s)</button>
+      </div>
+      {tab === "upload" ? (
+        <div className="mt-3 space-y-3">
+          <input
+            type="file"
+            accept="application/pdf"
+            multiple
+            onChange={(e) => setFiles(e.target.files)}
+          />
+          <div className="text-xs text-muted-foreground">You can select multiple PDFs.</div>
+        </div>
+      ) : (
+        <textarea
+          className="mt-3 w-full h-40 rounded border p-2"
+          placeholder="One PDF URL per line"
+          value={urls}
+          onChange={(e) => setUrls(e.target.value)}
+        />
+      )}
+      <div className="mt-4 flex justify-end gap-2">
+        <DialogClose asChild>
+          <button className="px-3 py-2 rounded border">Cancel</button>
+        </DialogClose>
+        <button className="px-3 py-2 rounded bg-black text-white" onClick={onSubmit}>Create</button>
+      </div>
+    </DialogContent>
+  );
+}
+

--- a/lib/hooks/useCreateLibraryPost.ts
+++ b/lib/hooks/useCreateLibraryPost.ts
@@ -1,0 +1,17 @@
+"use client";
+
+// NOTE: This is a thin client stub. Wire it to your upload/import pipeline next.
+export function useCreateLibraryPost() {
+  return async function createLibraryPost(input: { files?: File[]; urls?: string[] }) {
+    // TODO: Option A (now): call /api/library/import with { externalUrls: urls }
+    // TODO: Option B: upload files to Supabase; pass storage keys to /api/library/import
+    const res = await fetch("/api/library/import", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ externalUrls: input.urls || [], filesCount: input.files?.length || 0 })
+    });
+    if (!res.ok) throw new Error("Library import failed");
+    return res.json();
+  };
+}
+


### PR DESCRIPTION
## Summary
- add `LibraryCard` component and `LibraryPostModal`
- wire up stub hook and API route for library posts
- expose `LIBRARY` post type in post creation and card rendering

## Testing
- `npm run lint` *(fails: React Hook "useMemo" is called conditionally, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_689582a006048329a02f1cf35ab394db