### PR TITLE
Add scaffolding for article annotations

### DIFF
--- a/app/article/(by-slug)/[slug]/page.tsx
+++ b/app/article/(by-slug)/[slug]/page.tsx
@@ -11,15 +11,8 @@ import TextStyle from "@tiptap/extension-text-style";
 import Underline from "@tiptap/extension-underline";
 import Highlight from "@tiptap/extension-highlight";
 import TextAlign from "@tiptap/extension-text-align";
-import ArticleReader from "@/components/article/ArticleReader"; // your wrapper
-import HeroRenderer from "@/components/article/HeroRenderer"; // optional
-import { EditorContent } from "@tiptap/react";
+import ArticleReaderWithPins from "@/components/article/ArticleReaderWithPins";
 import Link from "@tiptap/extension-link";
-import Placeholder from "@tiptap/extension-placeholder";
-import CodeBlockLowlight from "@tiptap/extension-code-block-lowlight";
-import Collaboration from "@tiptap/extension-collaboration";
-import CollaborationCursor from "@tiptap/extension-collaboration-cursor";
-import CharacterCount from "@tiptap/extension-character-count";
 import Color from "@tiptap/extension-color";
 import {
   PullQuote,
@@ -69,19 +62,11 @@ export default async function ArticlePage({
 ])
 
   return (
-    <ArticleReader template={article.template} heroSrc={article.heroImageKey}>
-    {article.heroImageKey && (
-      <HeroRenderer
-        src={article.heroImageKey}
-        template={article.template}
-      />
-    )}
-  
-    {/* TipTap HTML goes here */}
-    <div
-  className="ProseMirror  "
-  dangerouslySetInnerHTML={{ __html: html }}
-/>
-  </ArticleReader>
+    <ArticleReaderWithPins
+      template={article.template}
+      heroSrc={article.heroImageKey}
+      html={html}
+      threads={[]}
+    />
   );
 }

--- a/components/article/ArticleReaderWithPins.tsx
+++ b/components/article/ArticleReaderWithPins.tsx
@@ -1,0 +1,86 @@
+"use client"
+
+import { useRef, useState, useMemo } from "react"
+import ArticleReader from "@/components/article/ArticleReader"
+import CommentSidebar from "@/components/article/CommentSidebar"
+import { CommentThread, Anchor } from "@/types/comments"
+
+interface ArticleReaderWithPinsProps {
+  template: string
+  heroSrc?: string | null
+  html: string
+  threads: CommentThread[]
+  currentUser?: unknown
+  onSubmit?: (threadId: string, body: string) => void
+  onResolve?: (threadId: string) => void
+  onVote?: (commentId: string, delta: number) => void
+}
+
+function getAnchorRect(anchor: Anchor, root: HTMLElement): DOMRect | null {
+  let node: Node | null = root
+  for (const index of anchor.startPath) {
+    node = node?.childNodes[index] ?? null
+    if (!node) return null
+  }
+  const range = document.createRange()
+  range.setStart(node!, anchor.startOffset)
+  range.setEnd(node!, anchor.startOffset)
+  const rect = range.getClientRects()[0]
+  return rect ?? null
+}
+
+export default function ArticleReaderWithPins({
+  template,
+  heroSrc,
+  html,
+  threads,
+  currentUser,
+  onSubmit,
+  onResolve,
+  onVote,
+}: ArticleReaderWithPinsProps) {
+  const containerRef = useRef<HTMLDivElement>(null)
+  const [openId, setOpenId] = useState<string | null>(null)
+
+  const positions = useMemo(() => {
+    const root = containerRef.current
+    if (!root) return {}
+    return Object.fromEntries(
+      threads.map((t) => [t.id, getAnchorRect(t.anchor, root)])
+    )
+  }, [threads, html])
+
+  return (
+    <ArticleReader template={template} heroSrc={heroSrc}>
+      <div className="relative">
+        <div
+          ref={containerRef}
+          className="prose max-w-none"
+          dangerouslySetInnerHTML={{ __html: html }}
+        />
+        {threads.map((t) => (
+          <button
+            key={t.id}
+            style={{
+              position: "absolute",
+              top: positions[t.id]?.top ?? 0,
+              left: (positions[t.id]?.left ?? 0) - 24,
+            }}
+            className={t.resolved ? "opacity-30" : ""}
+            onClick={() => setOpenId(t.id)}
+          >
+            ●
+          </button>
+        ))}
+        <CommentSidebar
+          threads={threads}
+          activeThreadId={openId}
+          onSubmit={onSubmit}
+          onResolve={onResolve}
+          onVote={onVote}
+          currentUser={currentUser}
+        />
+      </div>
+    </ArticleReader>
+  )
+}

--- a/components/article/CommentSidebar.tsx
+++ b/components/article/CommentSidebar.tsx
@@ -1,0 +1,38 @@
+"use client"
+
+import clsx from "clsx"
+import { CommentThread } from "@/types/comments"
+
+interface CommentSidebarProps {
+  threads: CommentThread[]
+  activeThreadId: string | null
+  onSubmit?: (threadId: string, body: string) => void
+  onResolve?: (threadId: string) => void
+  onVote?: (commentId: string, delta: number) => void
+  currentUser?: unknown
+}
+
+export default function CommentSidebar({
+  threads,
+  activeThreadId,
+}: CommentSidebarProps) {
+  return (
+    <aside className="fixed right-0 top-0 h-full w-80 overflow-y-auto border-l bg-white">
+      {threads.map((thread) => (
+        <div
+          key={thread.id}
+          className={clsx(
+            "p-4",
+            activeThreadId === thread.id && "bg-gray-100"
+          )}
+        >
+          {thread.comments.map((comment) => (
+            <p key={comment.id} className="mb-2 text-sm">
+              {comment.body}
+            </p>
+          ))}
+        </div>
+      ))}
+    </aside>
+  )
+}

--- a/types/comments.ts
+++ b/types/comments.ts
@@ -1,0 +1,26 @@
+export interface Anchor {
+  startPath: number[]
+  startOffset: number
+  endPath: number[]
+  endOffset: number
+}
+
+export interface Comment {
+  id: string
+  threadId: string
+  body: string
+  createdBy: string
+  createdAt: string
+  upvotes: number
+  downvotes: number
+}
+
+export interface CommentThread {
+  id: string
+  articleId: string
+  anchor: Anchor
+  resolved: boolean
+  createdBy: string
+  createdAt: string
+  comments: Comment[]
+}


### PR DESCRIPTION
## Summary
- define comment thread types
- add CommentSidebar and ArticleReaderWithPins components
- render published articles with annotation scaffolding

## Testing
- `npm run lint` *(fails: React Hook "useMemo" is called conditionally...)*

------
https://chatgpt.com/codex/tasks/task_e_68995c1f9af48329bdb6faa3d49c26cb