### PR TITLE
Add private side-reply anchor for group chats

### DIFF
--- a/app/(root)/(standard)/messages/[id]/page.tsx
+++ b/app/(root)/(standard)/messages/[id]/page.tsx
@@ -2,7 +2,7 @@
 import { useUserInbox } from "@/hooks/useUserInbox";
 import { fetchMessages } from "@/lib/actions/message.actions";
 import { fetchConversation } from "@/lib/actions/conversation.actions";
-import { getUserFromCookies } from '@/lib/server/getUser';
+import { getUserFromCookies } from "@/lib/server/getUser";
 import { redirect, notFound } from "next/navigation";
 import ChatRoom from "@/components/chat/ChatRoom";
 import MessageComposer from "@/components/chat/MessageComposer";
@@ -12,7 +12,7 @@ import Image from "next/image";
 
 
 
-export default async function Page({ params }: { params: { id: string } }) {
+export default async function Page({ params, searchParams }: { params: { id: string }; searchParams: { mid?: string } }) {
   const user = await getUserFromCookies();
   if (!user?.userId) redirect("/login");
 
@@ -83,9 +83,11 @@ export default async function Page({ params }: { params: { id: string } }) {
   //   })),
   // }));
 
+  const highlightMessageId = searchParams?.mid || null;
+
   return (
     <main className="p-4 mt-[-4rem] items-center justify-center">
- <div className="flex w-full h-full items-center justify-center align-center gap-4">
+      <div className="flex w-full h-full items-center justify-center align-center gap-4">
         {isGroup ? (
           // Composite avatar (up to 4 faces)
           <div className="flex flex-wrap rounded-full gap-4 ">
@@ -124,6 +126,7 @@ export default async function Page({ params }: { params: { id: string } }) {
           conversationId={params.id}             // pass as string
           currentUserId={user.userId.toString()} // pass as string
           initialMessages={initialMessages}
+          highlightMessageId={highlightMessageId}
         />
         <hr />
         <MessageComposer conversationId={params.id} />

--- a/components/chat/ChatRoom.tsx
+++ b/components/chat/ChatRoom.tsx
@@ -15,7 +15,14 @@ type Props = {
   conversationId: string;
   currentUserId: string;
   initialMessages: Message[];
+  highlightMessageId?: string | null;
 };
+
+function excerpt(text?: string | null, len = 100) {
+  if (!text) return null;
+  const t = text.replace(/\s+/g, " ").trim();
+  return t.length > len ? t.slice(0, len - 1) + "…" : t;
+}
 
 function Attachment({ a }: { a: { id: string; path: string; type: string; size: number } }) {
   const [url, setUrl] = useState<string | null>(null);
@@ -46,15 +53,22 @@ const MessageRow = memo(function MessageRow({
   m,
   currentUserId,
   onOpen,
+  onPrivateReply,
 }: {
   m: Message;
   currentUserId: string;
   onOpen: (peerId: string, peerName: string, peerImage?: string | null) => void;
+  onPrivateReply?: (m: Message) => void;
 }) {
   const isMine = String(m.senderId) === String(currentUserId);
 
   return (
-    <ChatMessage type={isMine ? "outgoing" : "incoming"} id={m.id} variant="bubble">
+    <ChatMessage
+      type={isMine ? "outgoing" : "incoming"}
+      id={m.id}
+      variant="bubble"
+      data-msg-id={m.id}
+    >
       {!isMine && (
         <DropdownMenu>
           <DropdownMenuTrigger className="cursor-pointer">
@@ -65,6 +79,9 @@ const MessageRow = memo(function MessageRow({
               onClick={() => onOpen(String(m.senderId), m.sender?.name ?? "User", m.sender?.image ?? null)}
             >
               💬 Chat
+            </DropdownMenuItem>
+            <DropdownMenuItem onClick={() => onPrivateReply?.(m)}>
+              🔒 Reply privately with {m.sender?.name || "User"}
             </DropdownMenuItem>
           </DropdownMenuContent>
         </DropdownMenu>
@@ -83,8 +100,8 @@ const MessageRow = memo(function MessageRow({
   );
 });
 
-export default function ChatRoom({ conversationId, currentUserId, initialMessages }: Props) {
-  const { open } = usePrivateChatManager();
+export default function ChatRoom({ conversationId, currentUserId, initialMessages, highlightMessageId }: Props) {
+  const { open, state } = usePrivateChatManager();
 
   const handleOpen = useCallback(
     (peerId: string, peerName: string, peerImage?: string | null) => {
@@ -100,7 +117,7 @@ export default function ChatRoom({ conversationId, currentUserId, initialMessage
     () => allMessages[conversationId] ?? [],
     [allMessages, conversationId]
   );
-    const setMessages = useChatStore((s) => s.setMessages);
+  const setMessages = useChatStore((s) => s.setMessages);
   const appendMessage = useChatStore((s) => s.appendMessage);
 
   const appendRef = useRef(appendMessage);
@@ -121,16 +138,65 @@ export default function ChatRoom({ conversationId, currentUserId, initialMessage
     return () => { try { channel.unsubscribe?.(); } catch {} supabase.removeChannel(channel); };
   }, [conversationId]);
 
+  const onPrivateReply = useCallback((m: Message) => {
+    const authorId = String(m.senderId);
+    if (authorId === String(currentUserId)) return;
+    const rid = roomKey(conversationId, currentUserId, authorId);
+    open(authorId, m.sender?.name ?? "User", conversationId, {
+      roomId: rid,
+      peerImage: m.sender?.image ?? null,
+      anchor: {
+        messageId: m.id,
+        messageText: excerpt(m.text),
+        authorId,
+        authorName: m.sender?.name ?? "User",
+        conversationId,
+      },
+    });
+  }, [conversationId, currentUserId, open]);
+
+  useEffect(() => {
+    if (!highlightMessageId) return;
+    const el = document.querySelector(`[data-msg-id="${highlightMessageId}"]`) as HTMLElement | null;
+    if (el) {
+      el.scrollIntoView({ block: "center", behavior: "smooth" });
+      el.classList.add("ring-2", "ring-indigo-400", "ring-offset-2");
+      setTimeout(() => el.classList.remove("ring-2", "ring-indigo-400", "ring-offset-2"), 2000);
+    }
+  }, [highlightMessageId, messages.length]);
+
   return (
     <div className="space-y-3">
-    {messages.map((m) => (
-      <MessageRow
-        key={m.id}
-        m={m}
-        currentUserId={currentUserId}
-        onOpen={handleOpen}
-      />
-    ))}
-  </div>
+      {messages.map((m) => {
+        const panes = Object.values(state.panes);
+        const anchored = panes.find(
+          (p) => p.anchor?.messageId === m.id && p.peerId === String(m.senderId)
+        );
+        return (
+          <div key={m.id} className="space-y-1">
+            <MessageRow
+              m={m}
+              currentUserId={currentUserId}
+              onOpen={handleOpen}
+              onPrivateReply={onPrivateReply}
+            />
+            {anchored && (
+              <button
+                className="text-[11px] px-2 py-[2px] rounded bg-white/70 border hover:bg-white"
+                onClick={() =>
+                  open(anchored.peerId, anchored.peerName, conversationId, {
+                    roomId: anchored.id,
+                    peerImage: anchored.peerImage ?? null,
+                  })
+                }
+                title="Open private side chat"
+              >
+                Side chat
+              </button>
+            )}
+          </div>
+        );
+      })}
+    </div>
   );
 }

--- a/lib/chat/permalink.ts
+++ b/lib/chat/permalink.ts
@@ -1,0 +1,3 @@
+export function messagePermalink(conversationId: string, messageId: string) {
+  return `/messages/${conversationId}?mid=${encodeURIComponent(messageId)}`;
+}


### PR DESCRIPTION
## Summary
- track optional pane anchor in PrivateChatManager and persist it
- add "Reply privately" to group message menu and highlight anchored messages
- show anchor chip with jump link in DM pane header

## Testing
- `npm run lint` *(fails: React Hook "useMemo" is called conditionally etc.)*
- `npx eslint "app/(root)/(standard)/messages/[id]/page.tsx" components/PrivateChatPane.tsx components/chat/ChatRoom.tsx contexts/PrivateChatManager.tsx lib/chat/permalink.ts`

------
https://chatgpt.com/codex/tasks/task_e_6899664cf0c483299509d8c534029641