### PR TITLE
Add lightweight polls for chat

### DIFF
--- a/app/api/polls/[id]/vote/route.ts
+++ b/app/api/polls/[id]/vote/route.ts
@@ -1,0 +1,20 @@
+import { NextResponse } from "next/server";
+import { upsertVote } from "@/lib/actions/poll.actions";
+
+export async function POST(
+  req: Request,
+  { params }: { params: { id: string } }
+) {
+  try {
+    const body = await req.json();
+    const { state } = await upsertVote({
+      pollId: BigInt(params.id),
+      kind: body.kind,
+      optionIdx: body.optionIdx,
+      value: body.value,
+    });
+    return NextResponse.json({ ok: true, state });
+  } catch (e: any) {
+    return NextResponse.json({ ok: false, error: e.message }, { status: 400 });
+  }
+}

--- a/app/api/polls/route.ts
+++ b/app/api/polls/route.ts
@@ -1,0 +1,32 @@
+import { NextResponse } from "next/server";
+import { createPoll } from "@/lib/actions/poll.actions";
+
+export async function POST(req: Request) {
+  try {
+    const body = await req.json();
+    const poll = await createPoll({
+      conversationId: BigInt(body.conversationId),
+      messageId: BigInt(body.messageId),
+      kind: body.kind,
+      options: body.options,
+    });
+    return NextResponse.json({
+      ok: true,
+      poll: {
+        ...poll,
+        id: String(poll.id),
+        conversationId: String(poll.conversation_id),
+        messageId: String(poll.message_id),
+        createdById: String(poll.created_by_id),
+        kind: poll.kind,
+        options: poll.options ?? undefined,
+        maxOptions: poll.max_options,
+        closesAt: poll.closes_at ? poll.closes_at.toISOString() : null,
+        anonymous: poll.anonymous,
+        createdAt: poll.created_at.toISOString(),
+      },
+    });
+  } catch (e: any) {
+    return NextResponse.json({ ok: false, error: e.message }, { status: 400 });
+  }
+}

--- a/components/chat/PollChip.tsx
+++ b/components/chat/PollChip.tsx
@@ -1,0 +1,61 @@
+import { PollUI } from "@/contexts/useChatStore";
+
+export default function PollChip({ poll, onVote }: {
+  poll: PollUI;
+  onVote: (params: { optionIdx?: number; value?: number }) => void;
+}) {
+  if (poll.kind === "OPTIONS") {
+    const { poll: p, totals, count, myVote } = poll;
+    if (myVote == null) {
+      return (
+        <div className="inline-flex gap-2 flex-wrap">
+          {p.options!.map((opt, idx) => (
+            <button
+              key={idx}
+              onClick={() => onVote({ optionIdx: idx })}
+              className="px-2 py-1 rounded bg-white/70 border hover:bg-white text-xs"
+            >
+              {opt}
+            </button>
+          ))}
+        </div>
+      );
+    }
+    const total = Math.max(1, count);
+    return (
+      <div className="flex flex-col gap-1">
+        {p.options!.map((opt, idx) => {
+          const pct = Math.round(((totals[idx] ?? 0) * 100) / total);
+          const mine = myVote === idx;
+          return (
+            <div key={idx} className="text-[11px]">
+              <div className="flex justify-between">
+                <span className={mine ? "font-medium" : ""}>{opt}</span>
+                <span>{pct}%</span>
+              </div>
+              <div className="h-1.5 bg-slate-200 rounded">
+                <div className="h-1.5 rounded" style={{ width: `${pct}%` }} />
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    );
+  } else {
+    const { avg, count, myValue } = poll;
+    return (
+      <div className="flex items-center gap-2 text-xs">
+        <input
+          type="range"
+          min={0}
+          max={100}
+          defaultValue={myValue ?? 50}
+          onMouseUp={(e) => onVote({ value: Number((e.target as HTMLInputElement).value) })}
+        />
+        <span>
+          Avg: {avg} ({count})
+        </span>
+      </div>
+    );
+  }
+}

--- a/contexts/useChatStore.ts
+++ b/contexts/useChatStore.ts
@@ -1,6 +1,6 @@
 "use client";
 import { create } from "zustand";
-
+import type { PollDTO, PollStateDTO, MyVoteDTO } from "@/types/poll";
 
 export interface Attachment {
   id: string;
@@ -9,7 +9,6 @@ export interface Attachment {
   size: number;
 }
 
-// NEW: sender is optional; attachments optional
 export interface Message {
   id: string;
   text: string | null;
@@ -23,30 +22,34 @@ interface Conversation {
   title?: string | null;
 }
 
+export type PollUI =
+  | { kind: "OPTIONS"; poll: PollDTO; totals: number[]; count: number; myVote: number | null }
+  | { kind: "TEMP"; poll: PollDTO; avg: number; count: number; myValue: number | null };
 
 interface ChatState {
   conversations: Record<string, Conversation>;
   currentConversation?: string;
   messages: Record<string, Message[]>;
+  pollsByMessageId: Record<string, PollUI>;
   setCurrentConversation: (id: string) => void;
   setConversations: (list: Conversation[]) => void;
   setMessages: (id: string, msgs: Message[]) => void;
   appendMessage: (id: string, msg: Message) => void;
+  setPolls: (conversationId: string, polls: PollUI[]) => void;
+  upsertPoll: (poll: PollDTO, initState: PollStateDTO | null, myVote: MyVoteDTO | null) => void;
+  applyPollState: (state: PollStateDTO) => void;
+  setMyVote: (my: MyVoteDTO) => void;
   sendMessage: (id: string, data: FormData) => Promise<void>;
 }
-
-
 
 export const useChatStore = create<ChatState>((set, get) => ({
   conversations: {},
   messages: {},
+  pollsByMessageId: {},
   setCurrentConversation: (id) => set({ currentConversation: id }),
   setConversations: (list) =>
     set({ conversations: Object.fromEntries(list.map((c) => [c.id, c])) }),
 
-
-    
-  // normalize: attachments => []
   setMessages: (id, msgs) =>
     set((state) => ({
       messages: {
@@ -55,13 +58,87 @@ export const useChatStore = create<ChatState>((set, get) => ({
       },
     })),
 
-  // dedupe + normalize attachments
   appendMessage: (id, msg) =>
     set((state) => {
       const list = state.messages[id] || [];
       if (list.some((m) => m.id === msg.id)) return { messages: state.messages };
       const normalized = { ...msg, attachments: msg.attachments ?? [] };
       return { messages: { ...state.messages, [id]: [...list, normalized] } };
+    }),
+
+  setPolls: (_cid, polls) =>
+    set((state) => ({
+      pollsByMessageId: {
+        ...state.pollsByMessageId,
+        ...Object.fromEntries(polls.map((p) => [p.poll.messageId, p])),
+      },
+    })),
+
+  upsertPoll: (poll, initState, myVote) =>
+    set((state) => {
+      let ui: PollUI;
+      if (poll.kind === "OPTIONS") {
+        const totals =
+          initState && initState.kind === "OPTIONS"
+            ? initState.totals
+            : new Array(poll.options?.length ?? 0).fill(0);
+        const count =
+          initState && initState.kind === "OPTIONS" ? initState.count : 0;
+        const my =
+          myVote && myVote.kind === "OPTIONS" ? myVote.optionIdx : null;
+        ui = { kind: "OPTIONS", poll, totals, count, myVote: my };
+      } else {
+        const avg =
+          initState && initState.kind === "TEMP" ? initState.avg : 0;
+        const count =
+          initState && initState.kind === "TEMP" ? initState.count : 0;
+        const my = myVote && myVote.kind === "TEMP" ? myVote.value : null;
+        ui = { kind: "TEMP", poll, avg, count, myValue: my };
+      }
+      return {
+        pollsByMessageId: {
+          ...state.pollsByMessageId,
+          [poll.messageId]: ui,
+        },
+      };
+    }),
+
+  applyPollState: (incoming) =>
+    set((state) => {
+      const entryKey = Object.keys(state.pollsByMessageId).find(
+        (k) => state.pollsByMessageId[k].poll.id === incoming.pollId
+      );
+      if (!entryKey) return {};
+      const existing = state.pollsByMessageId[entryKey];
+      let updated: PollUI | undefined;
+      if (incoming.kind === "OPTIONS" && existing.kind === "OPTIONS") {
+        updated = { ...existing, totals: incoming.totals, count: incoming.count };
+      } else if (incoming.kind === "TEMP" && existing.kind === "TEMP") {
+        updated = { ...existing, avg: incoming.avg, count: incoming.count };
+      }
+      if (!updated) return {};
+      return {
+        pollsByMessageId: { ...state.pollsByMessageId, [entryKey]: updated },
+      };
+    }),
+
+  setMyVote: (my) =>
+    set((state) => {
+      const entryKey = Object.keys(state.pollsByMessageId).find(
+        (k) => state.pollsByMessageId[k].poll.id === my.pollId
+      );
+      if (!entryKey) return {};
+      const existing = state.pollsByMessageId[entryKey];
+      let updated: PollUI | undefined;
+      if (my.kind === "OPTIONS" && existing.kind === "OPTIONS") {
+        updated = { ...existing, myVote: my.optionIdx };
+      } else if (my.kind === "TEMP" && existing.kind === "TEMP") {
+        updated = { ...existing, myValue: my.value };
+      }
+      if (!updated) return {};
+      return {
+        pollsByMessageId: { ...state.pollsByMessageId, [entryKey]: updated },
+      };
     }),
 
   sendMessage: async (id, data) => {

--- a/lib/actions/poll.actions.ts
+++ b/lib/actions/poll.actions.ts
@@ -1,0 +1,106 @@
+"use server";
+
+import { prisma } from "@/lib/prismaclient";
+import { getUserFromCookies } from "@/lib/server/getUser";
+
+export async function createPoll(input: {
+  conversationId: bigint;
+  messageId: bigint;
+  kind: "OPTIONS" | "TEMP";
+  options?: string[];
+}) {
+  const user = await getUserFromCookies();
+  if (!user?.userId) throw new Error("unauthorized");
+
+  if (input.kind === "OPTIONS") {
+    const opts = input.options ?? [];
+    if (opts.length < 2 || opts.length > 4) throw new Error("bad options");
+  }
+
+  const poll = await prisma.poll.create({
+    data: {
+      conversation_id: input.conversationId,
+      message_id: input.messageId,
+      created_by_id: BigInt(user.userId),
+      kind: input.kind,
+      options: input.kind === "OPTIONS" ? input.options! : undefined,
+      max_options: 1,
+    },
+  });
+
+  return poll;
+}
+
+export async function upsertVote(input: {
+  pollId: bigint;
+  kind: "OPTIONS" | "TEMP";
+  optionIdx?: number;
+  value?: number;
+}) {
+  const user = await getUserFromCookies();
+  if (!user?.userId) throw new Error("unauthorized");
+
+  const poll = await prisma.poll.findUnique({ where: { id: input.pollId } });
+  if (!poll) throw new Error("not found");
+  if (poll.kind !== input.kind) throw new Error("bad kind");
+
+  if (poll.kind === "OPTIONS") {
+    if (typeof input.optionIdx !== "number") throw new Error("missing optionIdx");
+    if (!poll.options || input.optionIdx < 0 || input.optionIdx >= poll.options.length) {
+      throw new Error("bad optionIdx");
+    }
+  } else {
+    if (typeof input.value !== "number" || input.value < 0 || input.value > 100) {
+      throw new Error("bad value");
+    }
+  }
+
+  await prisma.pollVote.upsert({
+    where: { poll_id_user_id: { poll_id: poll.id, user_id: BigInt(user.userId) } },
+    update: { option_idx: input.optionIdx ?? null, value: input.value ?? null },
+    create: {
+      poll_id: poll.id,
+      user_id: BigInt(user.userId),
+      option_idx: input.optionIdx ?? null,
+      value: input.value ?? null,
+    },
+  });
+
+  if (poll.kind === "OPTIONS") {
+    const rows = await prisma.pollVote.groupBy({
+      by: ["option_idx"],
+      where: { poll_id: poll.id },
+      _count: { _all: true },
+    });
+    const totals = new Array(poll.options?.length ?? 0).fill(0);
+    for (const r of rows) {
+      const idx = r.option_idx ?? -1;
+      if (idx >= 0 && idx < totals.length) totals[idx] = r._count._all;
+    }
+    const count = rows.reduce((a, r) => a + r._count._all, 0);
+    return {
+      poll,
+      state: {
+        kind: "OPTIONS" as const,
+        pollId: String(poll.id),
+        totals,
+        count,
+      },
+    };
+  } else {
+    const agg = await prisma.pollVote.aggregate({
+      where: { poll_id: poll.id, value: { not: null } },
+      _avg: { value: true },
+      _count: { _all: true },
+    });
+    return {
+      poll,
+      state: {
+        kind: "TEMP" as const,
+        pollId: String(poll.id),
+        avg: Math.round(agg._avg.value ?? 0),
+        count: agg._count._all ?? 0,
+      },
+    };
+  }
+}

--- a/lib/models/schema.prisma
+++ b/lib/models/schema.prisma
@@ -609,6 +609,43 @@ model Message {
   @@map("messages")
 }
 
+enum PollKind {
+  OPTIONS
+  TEMP
+}
+
+model Poll {
+  id              BigInt    @id @default(autoincrement())
+  conversation_id BigInt
+  message_id      BigInt
+  created_by_id   BigInt
+  kind            PollKind
+  options         String[] @default([])
+  max_options     Int       @default(1)
+  closes_at       DateTime? @db.Timestamptz(6)
+  anonymous       Boolean   @default(false)
+  created_at      DateTime  @default(now()) @db.Timestamptz(6)
+
+  votes        PollVote[]
+
+  @@index([conversation_id])
+  @@map("polls")
+}
+
+model PollVote {
+  id         BigInt   @id @default(autoincrement())
+  poll_id    BigInt
+  user_id    BigInt
+  option_idx Int?
+  value      Int?
+  created_at DateTime @default(now()) @db.Timestamptz(6)
+
+  poll Poll @relation(fields: [poll_id], references: [id], onDelete: Cascade)
+
+  @@unique([poll_id, user_id])
+  @@map("poll_votes")
+}
+
 model CanonicalMedia {
   id            String         @id
   title         String

--- a/types/poll.ts
+++ b/types/poll.ts
@@ -1,0 +1,22 @@
+export type PollKind = "OPTIONS" | "TEMP";
+
+export type PollDTO = {
+  id: string;
+  conversationId: string;
+  messageId: string;
+  createdById: string;
+  kind: PollKind;
+  options?: string[];
+  maxOptions: number;
+  closesAt?: string | null;
+  anonymous: boolean;
+  createdAt: string;
+};
+
+export type PollStateDTO =
+  | { kind: "OPTIONS"; pollId: string; totals: number[]; count: number }
+  | { kind: "TEMP"; pollId: string; avg: number; count: number };
+
+export type MyVoteDTO =
+  | { kind: "OPTIONS"; pollId: string; optionIdx: number | null }
+  | { kind: "TEMP"; pollId: string; value: number | null };


### PR DESCRIPTION
## Summary
- add poll schema and types
- implement poll create/vote actions and API routes
- extend chat store and ChatRoom with poll rendering and voting

## Testing
- `npx prisma generate`
- `npx prisma migrate dev -n polls` *(fails: Can't reach database server)*
- `npm run lint` *(fails: React Hook "useMemo" is called conditionally, among other errors)*

------
https://chatgpt.com/codex/tasks/task_e_68999622dc788329a8cd60927afc1d77