### PR TITLE
Fix article reader text styling

### DIFF
--- a/app/article/(by-key)/[key]/page.tsx
+++ b/app/article/(by-key)/[key]/page.tsx
@@ -1,24 +1,27 @@
 
 import { prisma } from "@/lib/prismaclient";
 import { notFound } from "next/navigation";
-import { generateHTML } from '@tiptap/html'
-import StarterKit from '@tiptap/starter-kit'
-import { TextStyleSSR } from '@/lib/tiptap/extensions/text-style-ssr'
-import TextAlign from '@tiptap/extension-text-align'
-import Underline from '@tiptap/extension-underline'
-import Highlight from '@tiptap/extension-highlight'
-import Link from '@tiptap/extension-link'
-import ArticleReaderWithPins from "@/components/article/ArticleReaderWithPins";
+import { generateHTML } from "@tiptap/html"
+import StarterKit from "@tiptap/starter-kit"
+import TextStyle from "@tiptap/extension-text-style"
+import { FontFamily } from "@/lib/tiptap/extensions/font-family"
+import { FontSize } from "@/lib/tiptap/extensions/font-size"
+import Color from "@tiptap/extension-color"
+import Highlight from "@tiptap/extension-highlight"
+import Underline from "@tiptap/extension-underline"
+import TextAlign from "@tiptap/extension-text-align"
+import Link from "@tiptap/extension-link"
+import ArticleReaderWithPins from "@/components/article/ArticleReaderWithPins"
 import {
   PullQuote,
   Callout,
   MathBlock,
   MathInline,
   CustomImage,
-} from '@/lib/tiptap/extensions'
+} from "@/lib/tiptap/extensions"
 
-import TaskList from "@tiptap/extension-task-list";
-import TaskItem from "@tiptap/extension-task-item";
+import TaskList from "@tiptap/extension-task-list"
+import TaskItem from "@tiptap/extension-task-item"
 
 export default async function ArticlePage({
   params,
@@ -54,55 +57,28 @@ export default async function ArticlePage({
       downvotes: c.downvotes,
     })),
   }));
-  console.log('AST on server:', JSON.stringify(article.astJson))
   /* 2️⃣ convert TipTap JSON → HTML (use SAME extensions as editor) */
-  // const html = generateHTML(article.astJson as any, [
-  //   // nodes & utilities first
-  //   StarterKit,
-  //   CustomImage,
-  //   PullQuote,
-  //   Callout,
-  //   MathBlock,
-  //   MathInline,
-  //   TaskList,
-  //   TaskItem,
-  //   Link,
-  //        TextAlign.configure({
-  //       types: ['heading', 'paragraph', 'blockquote', 'listItem'],
-  //       alignments: ['left', 'center', 'right', 'justify'],
-  //     }),
-  
-  //   TextStyleSSR,
-  // ])
   const html = generateHTML(article.astJson as any, [
-  StarterKit,
-  CustomImage, PullQuote, Callout, MathBlock, MathInline,
-  TaskList, TaskItem,
-  Link,
-  TextAlign.configure({ types: ['heading','paragraph','blockquote','listItem'] }),
-  TextStyleSSR, // LAST
-])
-  const testDoc = {
-    type: 'doc',
-    content: [{
-      type: 'paragraph',
-      content: [{
-        type: 'text',
-        text: 'HELLO WORLD',
-        marks: [{
-          type: 'textStyle',
-          attrs: { fontFamily: "'New Edge Test', serif", fontSize: '48px' }
-        }],
-      }],
-    }],
-  }
-  
-  console.log(generateHTML(testDoc, [StarterKit, TextStyleSSR]));
-  // expect: <p><span style="font-family:'New Edge Test', serif; font-size:48px">HELLO WORLD</span></p>
-
-  // => <p style="text-align:center"><span style="font-family:'Kolonia', serif; font-size:48px; color:#333">WORLD</span></p>
-  // expect: <p style="text-align:center"><span style="font-family:'Kolonia', serif; font-size:48px; color:#333333">WORLD</span></p>
-  // last
+    StarterKit,
+    TextStyle,
+    FontSize,
+    FontFamily,
+    Color,
+    Highlight,
+    Underline,
+    TextAlign.configure({
+      types: ["heading", "paragraph", "blockquote", "listItem"],
+      alignments: ["left", "center", "right", "justify"],
+    }),
+    TaskList,
+    TaskItem,
+    CustomImage,
+    PullQuote,
+    Callout,
+    MathBlock,
+    MathInline,
+    Link,
+  ])
   
   return (
     <ArticleReaderWithPins

--- a/lib/tiptap/extensions/text-style-ssr.ts
+++ b/lib/tiptap/extensions/text-style-ssr.ts
@@ -15,34 +15,35 @@ function quoteFontList(val?: string | null): string | null {
 }
 
 export const TextStyleSSR = Mark.create({
-  name: 'textStyle',
+  name: "textStyle",
 
-  // keep this lean; SSR only needs to *render*
+  // lean: only render attributes we care about for SSR
   addAttributes() {
     return {
       fontFamily: { default: null },
-      fontSize:   { default: null },
-      color:      { default: null },
+      fontSize: { default: null },
+      color: { default: null },
     }
   },
 
-  // (parseHTML not needed for SSR → we aren’t parsing from HTML)
-
-  renderHTML({ mark, HTMLAttributes }) {
-    const a = { ...(mark?.attrs ?? {}), ...(HTMLAttributes ?? {}) }
-
+  // server rendering only
+  renderHTML({ HTMLAttributes }) {
     const css: string[] = []
-    if (a.fontFamily) css.push(`font-family:${quoteFontList(a.fontFamily)}`)
-    if (a.fontSize)   css.push(`font-size:${a.fontSize}`)
-    if (a.color)      css.push(`color:${a.color}`)
+    if (HTMLAttributes.fontFamily)
+      css.push(`font-family:${quoteFontList(HTMLAttributes.fontFamily)}`)
+    if (HTMLAttributes.fontSize)
+      css.push(`font-size:${HTMLAttributes.fontSize}`)
+    if (HTMLAttributes.color) css.push(`color:${HTMLAttributes.color}`)
 
-    const style = [HTMLAttributes?.style, css.join('; ')].filter(Boolean).join('; ')
+    const style = [css.join("; "), HTMLAttributes.style]
+      .filter(Boolean)
+      .join("; ")
+
     const out = mergeAttributes(HTMLAttributes, style ? { style } : {})
-
     delete (out as any).fontFamily
     delete (out as any).fontSize
     delete (out as any).color
 
-    return ['span', out, 0]
+    return ["span", out, 0]
   },
 })


### PR DESCRIPTION
## Summary
- render article HTML with TextStyle, FontFamily, FontSize, Color, and alignment extensions
- tidy up SSR textStyle mark to emit inline styles

## Testing
- `npm run lint` *(fails: React Hook "useMemo" is called conditionally ...)*
- `npx eslint app/article/(by-key)/[key]/page.tsx lib/tiptap/extensions/text-style-ssr.ts`


------
https://chatgpt.com/codex/tasks/task_e_689ad8de9b988329a15a7331070536e8