### PR TITLE
Add stack pages and actions

### DIFF
--- a/app/stacks/[id]/page.tsx
+++ b/app/stacks/[id]/page.tsx
@@ -1,0 +1,85 @@
+import { notFound } from "next/navigation";
+import { getStackPageData, toggleStackSubscription, reorderStack, removeFromStack } from "@/lib/actions/stack.actions";
+import StackAddModal from "@/components/modals/StackAddModal";
+import PdfLightbox from "@/components/modals/PdfLightbox";
+
+export default async function StackPage({ params }: { params: { id: string } }) {
+  const data = await getStackPageData(params.id);
+  if ((data as any).notFound) return notFound();
+  const { stack, posts, viewer } = data as any;
+
+  return (
+    <div className="mx-auto max-w-4xl px-4 py-8">
+      <div className="flex items-start justify-between gap-4">
+        <div>
+          <h1 className="text-2xl font-semibold">{stack.name}</h1>
+          {stack.description && (
+            <p className="mt-2 text-sm text-muted-foreground">{stack.description}</p>
+          )}
+          <div className="mt-2 text-xs text-slate-500">
+            Visibility: {stack.is_public ? "Public" : "Private"}
+          </div>
+        </div>
+        <div className="flex items-center gap-2">
+          <form action={toggleStackSubscription}>
+            <input type="hidden" name="stackId" value={stack.id} />
+            <input type="hidden" name="op" value={viewer.subscribed ? "unsubscribe" : "subscribe"} />
+            <button className="px-3 py-2 rounded border">
+              {viewer.subscribed ? "Unsubscribe" : "Subscribe"}
+            </button>
+          </form>
+          {viewer.editable && <StackAddModal stackId={stack.id} />}
+        </div>
+      </div>
+
+      <div className="mt-8 grid grid-cols-2 sm:grid-cols-3 gap-3">
+        {posts.map((p: any) => {
+          const cover = p.thumb_urls?.[0] || "/assets/pdf-placeholder.png";
+          return (
+            <div key={p.id} className="group relative rounded border overflow-hidden bg-white">
+              <PdfLightbox
+                trigger={
+                  <img
+                    src={cover}
+                    alt={p.title || "PDF"}
+                    className="w-full aspect-[4/3] object-cover cursor-pointer"
+                  />
+                }
+                fileUrl={p.file_url}
+                title={p.title ?? "PDF"}
+              />
+              {viewer.editable && (
+                <div className="absolute top-2 right-2 flex gap-1 opacity-0 group-hover:opacity-100 transition">
+                  <form action={reorderStack}>
+                    <input type="hidden" name="stackId" value={stack.id} />
+                    <input type="hidden" name="postId" value={p.id} />
+                    <input type="hidden" name="direction" value="up" />
+                    <button className="px-2 py-1 text-xs rounded bg-white/90 border">↑</button>
+                  </form>
+                  <form action={reorderStack}>
+                    <input type="hidden" name="stackId" value={stack.id} />
+                    <input type="hidden" name="postId" value={p.id} />
+                    <input type="hidden" name="direction" value="down" />
+                    <button className="px-2 py-1 text-xs rounded bg-white/90 border">↓</button>
+                  </form>
+                  <form action={removeFromStack}>
+                    <input type="hidden" name="stackId" value={stack.id} />
+                    <input type="hidden" name="postId" value={p.id} />
+                    <button className="px-2 py-1 text-xs rounded bg-white/90 border">Remove</button>
+                  </form>
+                </div>
+              )}
+            </div>
+          );
+        })}
+      </div>
+
+      <div className="mt-10">
+        <h2 className="text-lg font-semibold">Discussion</h2>
+        <p className="text-sm text-muted-foreground">
+          (Optional) Reuse your existing Feed post comments by creating a top-level <code>FeedPost</code> with <code>stack_id</code> and rendering the thread here.
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/components/cards/LibraryCard.tsx
+++ b/components/cards/LibraryCard.tsx
@@ -1,6 +1,7 @@
 "use client";
 import React from "react";
 import GalleryCarousel from "./GalleryCarousel";
+import Link from "next/link";
 
 export type LibraryCardProps = {
   kind: "single" | "stack";
@@ -88,12 +89,18 @@ export default function LibraryCard(props: LibraryCardProps) {
                <img key={i} src={u} alt={`PDF ${i}`} className="w-full aspect-[4/3] object-cover" />
              ))}
            </div>
-           <button
-             className="mt-2 text-sm underline"
-             onClick={() => stackId && onOpenStack?.(stackId)}
-           >
-             View Stack ({size})
-           </button>
+           {stackId ? (
+             <Link href={`/stacks/${stackId}`} className="mt-2 inline-block text-sm underline">
+               View Stack ({size})
+             </Link>
+           ) : (
+             <button
+               className="mt-2 text-sm underline"
+               onClick={() => stackId && onOpenStack?.(stackId)}
+             >
+               View Stack ({size})
+             </button>
+           )}
          </div>
        );
   }

--- a/components/modals/PdfLightbox.tsx
+++ b/components/modals/PdfLightbox.tsx
@@ -1,104 +1,29 @@
 "use client";
+import React from "react";
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger } from "@/components/ui/dialog";
 
-import * as React from "react";
-import {
-  Dialog,
-  DialogContent,
-  DialogHeader,
-  DialogTitle,
-  DialogClose,
-} from "@/components/ui/dialog";
-
-type PdfLightboxProps = {
-  postId: string | null;
-  open: boolean;
-  onOpenChange: (v: boolean) => void;
-};
-
-type PostInfo = {
-  id: string;
-  title: string;
+export default function PdfLightbox({
+  trigger,
+  fileUrl,
+  title = "PDF",
+}: {
+  trigger: React.ReactNode;
   fileUrl: string;
-  pageCount: number;
-  thumbUrls: string[];
-};
-
-export default function PdfLightbox({ postId, open, onOpenChange }: PdfLightboxProps) {
-  const [loading, setLoading] = React.useState(false);
-  const [error, setError] = React.useState<string | null>(null);
-  const [info, setInfo] = React.useState<PostInfo | null>(null);
-
-  React.useEffect(() => {
-    let cancelled = false;
-    async function load() {
-      if (!open || !postId) return;
-      setLoading(true);
-      setError(null);
-      try {
-        const res = await fetch(`/api/library/post?id=${encodeURIComponent(postId)}`, {
-          cache: "no-store",
-        });
-        if (!res.ok) throw new Error(await res.text());
-        const json = (await res.json()) as PostInfo;
-        if (!cancelled) setInfo(json);
-      } catch (e: any) {
-        if (!cancelled) setError(String(e?.message || e));
-      } finally {
-        if (!cancelled) setLoading(false);
-      }
-    }
-    load();
-    return () => {
-      cancelled = true;
-    };
-  }, [open, postId]);
-
+  title?: string;
+}) {
+  const [open, setOpen] = React.useState(false);
   return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="max-w-[50rem] w-[92vw] h-[92vh] p-2 overflow-hidden bg-slate-500 border-2 border-slate-500">
-        <DialogHeader  className="px-3 py-0 h-min flex flex-1 mt-1 items-end text-black">
-          <a
-            href={info?.fileUrl || "#"}
-            target="_blank"
-            rel="noreferrer"
-            className="text-sm text-white "
-          >
-            Open
-          </a>
-       
-          <DialogTitle hidden className="truncate">
-            {info?.title || "Document"}
-          </DialogTitle>
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger asChild>
+        <div onClick={() => setOpen(true)}>{trigger}</div>
+      </DialogTrigger>
+      <DialogContent className="max-w-[90vw] w-[900px] h-[80vh]">
+        <DialogHeader>
+          <DialogTitle>{title}</DialogTitle>
         </DialogHeader>
-
-        {/* Body */}
-        <div className="w-full h-[calc(92vh-56px)] bg-white relative">
-          {loading && (
-            <div className="absolute inset-0 grid place-items-center text-sm text-gray-500">
-              Loading PDF…
-            </div>
-          )}
-
-          {error && (
-            <div className="p-4 text-sm text-red-600">
-              Failed to load: {error}
-            </div>
-          )}
-
-          {!loading && !error && info?.fileUrl && (
-            // Use native PDF viewer; widest compatibility and zero worker setup.
-            // On Safari/iOS, <iframe> generally works better than <object>.
-            <iframe
-              title={info.title}
-              src={`${info.fileUrl}#view=FitH`}
-              className="w-full h-full"
-              style={{ border: "none" }}
-            />
-          )}
+        <div className="w-full h-[calc(80vh-4rem)]">
+          <iframe src={fileUrl} className="w-full h-full rounded border" title={title} />
         </div>
-
-        {/* Footer actions */}
-        
       </DialogContent>
     </Dialog>
   );

--- a/components/modals/StackAddModal.tsx
+++ b/components/modals/StackAddModal.tsx
@@ -1,0 +1,16 @@
+"use client";
+import React from "react";
+import { Dialog, DialogTrigger } from "@/components/ui/dialog";
+import LibraryPostModal from "@/components/modals/LibraryPostModal";
+
+export default function StackAddModal({ stackId }: { stackId: string }) {
+  const [open, setOpen] = React.useState(false);
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger asChild>
+        <button className="px-3 py-2 rounded bg-black text-white">Add PDFs</button>
+      </DialogTrigger>
+      <LibraryPostModal onOpenChange={setOpen} stackId={stackId} />
+    </Dialog>
+  );
+}

--- a/lib/actions/stack.actions.ts
+++ b/lib/actions/stack.actions.ts
@@ -1,0 +1,170 @@
+"use server";
+import { prisma } from "@/lib/prismaclient";
+import { getUserFromCookies } from "@/lib/serverutils";
+import { revalidatePath } from "next/cache";
+
+type Viewer = { id: bigint | null };
+
+function canEdit(stack: any, viewer: Viewer) {
+  if (!viewer.id) return false;
+  if (stack.owner_id === viewer.id) return true;
+  if (!stack.collaborators) return false;
+  return stack.collaborators.some(
+    (c: any) =>
+      c.user_id === viewer.id &&
+      (c.role === "EDITOR" || c.role === "OWNER")
+  );
+}
+
+export async function getStackPageData(stackId: string) {
+  const u = await getUserFromCookies();
+  const viewerId = u?.userId ? BigInt(u.userId) : null;
+
+  const stack = await prisma.stack.findUnique({
+    where: { id: stackId },
+    include: {
+      owner: { select: { id: true, name: true, image: true } },
+      collaborators: true,
+      subscribers: viewerId
+        ? { where: { user_id: viewerId }, select: { user_id: true } }
+        : false,
+      posts: {
+        orderBy: { created_at: "asc" },
+        select: {
+          id: true,
+          title: true,
+          file_url: true,
+          thumb_urls: true,
+          page_count: true,
+          uploader_id: true,
+          created_at: true,
+        },
+      },
+    },
+  });
+  if (!stack) return { notFound: true } as const;
+
+  const editable = canEdit(stack, { id: viewerId });
+  const subscribed = !!(stack as any).subscribers?.length;
+
+  const order = stack.order ?? [];
+  const postsById = new Map(stack.posts.map((p) => [p.id, p]));
+  const posts =
+    order.length > 0
+      ? order.map((id) => postsById.get(id)).filter(Boolean)
+      : stack.posts;
+
+  return {
+    stack: {
+      id: stack.id,
+      name: stack.name,
+      description: stack.description,
+      is_public: stack.is_public,
+      owner_id: stack.owner_id,
+      slug: stack.slug ?? null,
+    },
+    posts,
+    viewer: { id: viewerId, editable, subscribed },
+  };
+}
+
+export async function toggleStackSubscription(formData: FormData) {
+  const u = await getUserFromCookies();
+  if (!u) throw new Error("Unauthenticated");
+  const userId = BigInt(u.userId);
+
+  const stackId = String(formData.get("stackId") || "");
+  const op = String(formData.get("op") || "toggle");
+
+  const existing = await prisma.stackSubscription.findUnique({
+    where: { stack_id_user_id: { stack_id: stackId, user_id: userId } },
+  });
+
+  if (existing) {
+    if (op !== "subscribe") {
+      await prisma.stackSubscription.delete({
+        where: { stack_id_user_id: { stack_id: stackId, user_id: userId } },
+      });
+    }
+  } else {
+    if (op !== "unsubscribe") {
+      await prisma.stackSubscription.create({
+        data: { stack_id: stackId, user_id: userId },
+      });
+    }
+  }
+
+  revalidatePath(`/stacks/${stackId}`);
+}
+
+export async function reorderStack(formData: FormData) {
+  const u = await getUserFromCookies();
+  if (!u) throw new Error("Unauthenticated");
+  const userId = BigInt(u.userId);
+
+  const stackId = String(formData.get("stackId") || "");
+  const direction = String(formData.get("direction") || "up");
+  const postId = String(formData.get("postId") || "");
+
+  const stack = await prisma.stack.findUnique({
+    where: { id: stackId },
+    include: { collaborators: true },
+  });
+  if (!stack) throw new Error("Stack not found");
+  if (!canEdit(stack, { id: userId })) throw new Error("Forbidden");
+
+  const order = [...(stack.order ?? [])];
+  const idx = order.indexOf(postId);
+  if (idx === -1) {
+    const posts = await prisma.libraryPost.findMany({
+      where: { stack_id: stackId },
+      orderBy: { created_at: "asc" },
+      select: { id: true },
+    });
+    order.splice(0, order.length, ...posts.map((p) => p.id));
+  }
+
+  const i = order.indexOf(postId);
+  if (i < 0) return;
+  if (direction === "up" && i > 0) {
+    [order[i - 1], order[i]] = [order[i], order[i - 1]];
+  } else if (direction === "down" && i < order.length - 1) {
+    [order[i], order[i + 1]] = [order[i + 1], order[i]];
+  }
+
+  await prisma.stack.update({
+    where: { id: stackId },
+    data: { order },
+  });
+
+  revalidatePath(`/stacks/${stackId}`);
+}
+
+export async function removeFromStack(formData: FormData) {
+  const u = await getUserFromCookies();
+  if (!u) throw new Error("Unauthenticated");
+  const userId = BigInt(u.userId);
+
+  const stackId = String(formData.get("stackId") || "");
+  const postId = String(formData.get("postId") || "");
+
+  const stack = await prisma.stack.findUnique({
+    where: { id: stackId },
+    include: { collaborators: true },
+  });
+  if (!stack) throw new Error("Stack not found");
+  if (!canEdit(stack, { id: userId })) throw new Error("Forbidden");
+
+  await prisma.$transaction([
+    prisma.libraryPost.update({
+      where: { id: postId },
+      data: { stack_id: null },
+    }),
+    prisma.stack.update({
+      where: { id: stackId },
+      data: { order: (stack.order ?? []).filter((id) => id !== postId) },
+    }),
+  ]);
+
+  revalidatePath(`/stacks/${stackId}`);
+}

--- a/lib/models/schema.prisma
+++ b/lib/models/schema.prisma
@@ -1292,14 +1292,48 @@ model Stack {
   order       String[]
   created_at  DateTime      @default(now()) @db.Timestamptz(6)
   parent_id   String?
+  slug        String?       @unique
   owner       User          @relation(fields: [owner_id], references: [id], onDelete: Cascade)
   posts       LibraryPost[]
   parent      Stack?        @relation("StackHierarchy", fields: [parent_id], references: [id])
   children    Stack[]       @relation("StackHierarchy")
   feedPosts   FeedPost[]
+  collaborators StackCollaborator[]
+  subscribers   StackSubscription[]
 
   @@unique([owner_id, name])
   @@map("stacks")
+}
+
+enum StackRole {
+  OWNER
+  EDITOR
+  VIEWER
+}
+
+model StackCollaborator {
+  stack_id   String
+  user_id    BigInt
+  role       StackRole @default(EDITOR)
+  created_at DateTime  @default(now()) @db.Timestamptz(6)
+
+  stack Stack @relation(fields: [stack_id], references: [id], onDelete: Cascade)
+  user  User  @relation(fields: [user_id], references: [id], onDelete: Cascade)
+
+  @@id([stack_id, user_id])
+  @@map("stack_collaborators")
+}
+
+model StackSubscription {
+  stack_id   String
+  user_id    BigInt
+  created_at DateTime @default(now()) @db.Timestamptz(6)
+
+  stack Stack @relation(fields: [stack_id], references: [id], onDelete: Cascade)
+  user  User  @relation(fields: [user_id], references: [id], onDelete: Cascade)
+
+  @@id([stack_id, user_id])
+  @@map("stack_subscriptions")
 }
 
 model Annotation {


### PR DESCRIPTION
## Summary
- extend Prisma Stack model with slug, collaborators and subscriptions
- add server actions for stack pages and subscription, ordering, removal
- create stack page with PDF lightbox, subscribe, and editor controls
- allow uploading PDFs directly into stacks and link stack cards to new page

## Testing
- `npm run lint` *(fails: React hooks used conditionally in existing files)*

------
https://chatgpt.com/codex/tasks/task_e_689d08d6ba40832991148acb5fd7c1ca