### PR TITLE
Add Methodologist & Synthesist; schema/API fixes

### DIFF
--- a/app/api/arguments/route.ts
+++ b/app/api/arguments/route.ts
@@ -356,23 +356,29 @@ let { schemeId, slots } = b; // assuming clients may send a role->claimId map wh
         }, { status: 409, ...NO_STORE });
       }
       
-      // Create commitment record (if not already exists)
+      // Create commitment record (idempotent on (deliberationId, participantId, proposition))
       try {
-        await prisma.commitment.create({
-          data: {
+        const result = await prisma.commitment.upsert({
+          where: {
+            deliberationId_participantId_proposition: {
+              deliberationId,
+              participantId: String(authorId),
+              proposition: conclusionClaim.text,
+            },
+          },
+          create: {
             deliberationId,
             participantId: String(authorId),
             proposition: conclusionClaim.text,
-          }
+          },
+          update: {},
+          select: { createdAt: true, updatedAt: true },
         });
-        console.log(`[arguments/POST] Created commitment for conclusion: "${conclusionClaim.text}"`);
-      } catch (err: any) {
-        // Ignore if commitment already exists (duplicate key error)
-        if (err.code === 'P2002') {
-          console.log(`[arguments/POST] Commitment already exists for: "${conclusionClaim.text}"`);
-        } else {
-          console.error('[arguments/POST] Failed to create commitment:', err);
+        if (result.createdAt.getTime() === result.updatedAt.getTime()) {
+          console.log(`[arguments/POST] Created commitment for conclusion: "${conclusionClaim.text}"`);
         }
+      } catch (err: any) {
+        console.error('[arguments/POST] Failed to upsert commitment:', err);
       }
     }
   } catch (err) {

--- a/app/api/blocks/[id]/contexts/route.ts
+++ b/app/api/blocks/[id]/contexts/route.ts
@@ -10,6 +10,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { getUserFromCookies } from "@/lib/serverutils";
 import { getBlockContexts, getBlockConnectionCount } from "@/lib/stacks/stackItemWriter";
 import { prisma } from "@/lib/prismaclient";
+import { jsonSafeStr } from "@/lib/bigintjson";
 
 export async function GET(
   req: NextRequest,
@@ -33,12 +34,12 @@ export async function GET(
     const contexts = await getBlockContexts(blockId, viewerId ?? undefined);
     const totalCount = await getBlockConnectionCount(blockId);
 
-    return NextResponse.json({
+    return NextResponse.json(jsonSafeStr({
       blockId,
       contexts,
       visibleCount: contexts.length,
       totalCount,
-    });
+    }));
   } catch (error: any) {
     console.error("Error fetching block contexts:", error);
     return NextResponse.json(

--- a/app/api/stacks/[id]/items/route.ts
+++ b/app/api/stacks/[id]/items/route.ts
@@ -22,7 +22,7 @@ import { z } from "zod";
 
 import { prisma } from "@/lib/prismaclient";
 import { getCurrentUserId, getCurrentUserAuthId } from "@/lib/serverutils";
-import { canEditStack } from "@/lib/stacks/permissions";
+import { canAddToStack } from "@/lib/stacks/permissions";
 import { addBlockToStack, isBlockInStack } from "@/lib/stacks/stackItemWriter";
 import { isSafePublicUrl } from "@/lib/unfurl";
 import { upsertSourceFromUrlOrDoi } from "@/lib/sources/upsertSource";
@@ -84,9 +84,11 @@ export async function POST(
     );
   }
 
-  // Auth: must be able to edit the target stack.
-  const canEdit = await canEditStack(stackId, userId);
-  if (!canEdit) {
+  // Auth: must be able to add items to the target stack. For public_open
+  // stacks, any logged-in user qualifies; for other visibilities only the
+  // owner / EDITOR collaborators do.
+  const canAdd = await canAddToStack(stackId, userId);
+  if (!canAdd) {
     return NextResponse.json({ error: "Forbidden" }, { status: 403 });
   }
 

--- a/experiments/polarization-1/FRAMING.md
+++ b/experiments/polarization-1/FRAMING.md
@@ -8,7 +8,7 @@
 
 ## Central contested claim
 
-> **Algorithmic content curation on major social media platforms has been a significant causal factor in the rise of political polarization in the United States between 2012 and 2024.**
+> **Algorithmic content curation on major social media platforms has functioned as a significant causal factor in rising US political polarization between 2012 and 2024.**
 
 This is the **root claim** of the deliberation. It will be created as the deliberation's representative claim and serve as the conclusion target for every Phase-1 sub-claim.
 

--- a/experiments/polarization-1/evidence-corpus.json
+++ b/experiments/polarization-1/evidence-corpus.json
@@ -1,6 +1,6 @@
 {
   "stackName": "Polarization 1 — evidence corpus",
-  "stackVisibility": "private",
+  "stackVisibility": "public_open",
   "_note": "22 sources spanning (a) studies implicating algorithmic curation, (b) null/contrary findings (esp. the 2023 Science series from the US 2020 Facebook & Instagram Election Study), (c) baseline polarization trend studies, (d) mechanism studies (engagement/animosity dynamics, exposure mapping). Tags align with the orchestrator's coverage signals: experimental, observational, metaAnalysis, skeptical, crossNational, plus topical tokens. DOIs were composed from memory — spot-check before running `npm run orchestrator -- setup`.",
   "items": [
     {

--- a/experiments/polarization-1/orchestrator/agents/advocate-schema.ts
+++ b/experiments/polarization-1/orchestrator/agents/advocate-schema.ts
@@ -121,23 +121,54 @@ export const WebCitationZ = z.object({
   }),
   url: z.string().url(),
   title: z.string().min(1).max(500),
-  authors: z.array(z.string().min(1).max(200)).max(20).optional(),
+  // Tolerate the common LLM mistake of returning a single string here;
+  // coerce to a one-element array before validation.
+  authors: z
+    .preprocess(
+      (v) => (typeof v === "string" ? [v] : v),
+      z.array(z.string().min(1).max(200)).max(20),
+    )
+    .optional(),
   publishedAt: z.string().min(4).max(40).optional(),
   /** One-sentence characterization of what the source actually says, ≤ 500 chars. */
   snippet: z.string().min(1).max(500),
   /** Optional methodology tag — mirrors the corpus item shape. */
   methodology: z
-    .enum([
-      "experimental",
-      "quasi-experimental",
-      "observational",
-      "meta-analysis",
-      "systematic-review",
-      "theoretical",
-      "expert-commentary",
-      "internal-data",
-      "other",
-    ])
+    .preprocess(
+      (v) => {
+        if (typeof v !== "string") return v;
+        const m = v.toLowerCase().trim();
+        // Tolerate common LLM variants.
+        const aliases: Record<string, string> = {
+          "commentary": "expert-commentary",
+          "expert commentary": "expert-commentary",
+          "conceptual": "theoretical",
+          "theory": "theoretical",
+          "experiment": "experimental",
+          "field experiment": "experimental",
+          "rct": "experimental",
+          "quasi experimental": "quasi-experimental",
+          "quasi": "quasi-experimental",
+          "natural experiment": "quasi-experimental",
+          "review": "systematic-review",
+          "meta analysis": "meta-analysis",
+          "metaanalysis": "meta-analysis",
+          "internal": "internal-data",
+        };
+        return aliases[m] ?? v;
+      },
+      z.enum([
+        "experimental",
+        "quasi-experimental",
+        "observational",
+        "meta-analysis",
+        "systematic-review",
+        "theoretical",
+        "expert-commentary",
+        "internal-data",
+        "other",
+      ]),
+    )
     .optional(),
 });
 

--- a/experiments/polarization-1/orchestrator/agents/defense-schema.ts
+++ b/experiments/polarization-1/orchestrator/agents/defense-schema.ts
@@ -32,34 +32,65 @@ import {
 /** Same premise constraints as Phase-2 / Phase-3. */
 const DefensePremiseZ = z.object({
   text: z
-    .string()
-    .min(1)
-    .max(400)
-    .refine((s) => /^[A-Z(\u201c"\u2018']/.test(s.trim()), {
-      message: "premise text must begin with a capital letter (declarative sentence)",
-    })
-    .refine((s) => /[.!?]\s*$/.test(s.trim()), {
-      message: "premise text must end with a sentence-terminating punctuation mark",
-    })
-    .refine((s) => !/^(and|or|but|so|because|therefore|thus|hence)\b/i.test(s.trim()), {
-      message: "premise text must not begin with a leading conjunction",
-    })
-    .refine((s) => !/\?\s*$/.test(s.trim()), {
-      message: "premise text must be declarative, not a question",
-    }),
-  citationToken: CitationTokenZ.nullable(),
+    .preprocess(
+      (v) => (typeof v === "string" && v.trim() && !/[.!?]\s*$/.test(v.trim()) ? v.trim() + "." : v),
+      z.string(),
+    )
+    .pipe(
+      z
+        .string()
+        .min(1)
+        .max(400)
+        .refine((s) => /^[A-Z(\u201c"\u2018']/.test(s.trim()), {
+          message: "premise text must begin with a capital letter (declarative sentence)",
+        })
+        .refine((s) => /[.!?]\s*$/.test(s.trim()), {
+          message: "premise text must end with a sentence-terminating punctuation mark",
+        })
+        .refine((s) => !/^(and|or|but|so|because|therefore|thus|hence)\b/i.test(s.trim()), {
+          message: "premise text must not begin with a leading conjunction",
+        })
+        .refine((s) => !/\?\s*$/.test(s.trim()), {
+          message: "premise text must be declarative, not a question",
+        }),
+    ),
+  citationToken: z.preprocess(
+    (v) => {
+      if (typeof v !== "string") return v;
+      // If LLM concatenates multiple tokens (comma/space/pipe-separated),
+      // keep only the first well-formed token.
+      const parts = v.split(/[,;\s|]+/).map((s) => s.trim()).filter(Boolean);
+      if (parts.length > 1) return parts[0];
+      return v;
+    },
+    CitationTokenZ.nullable(),
+  ),
 });
 
 const DeclarativeSentenceZ = z
-  .string()
-  .min(1)
-  .max(400)
-  .refine((s) => /^[A-Z(\u201c"\u2018']/.test(s.trim()), {
-    message: "must begin with a capital letter (declarative sentence)",
-  })
-  .refine((s) => /[.!?]\s*$/.test(s.trim()), {
-    message: "must end with a sentence-terminating punctuation mark",
-  });
+  .preprocess(
+    (v) => {
+      if (typeof v !== "string") return v;
+      let s = v.trim();
+      if (!s) return v;
+      if (s.length > 400) s = s.slice(0, 397).trimEnd() + "...";
+      if (!/[.!?]\s*$/.test(s)) s = s + ".";
+      return s;
+    },
+    z.string(),
+  )
+  .pipe(
+    z
+      .string()
+      .min(1)
+      .max(400)
+      .refine((s) => /^[A-Z(\u201c"\u2018']/.test(s.trim()), {
+        message: "must begin with a capital letter (declarative sentence)",
+      })
+      .refine((s) => /[.!?]\s*$/.test(s.trim()), {
+        message: "must end with a sentence-terminating punctuation mark",
+      }),
+  );
 
 /** Defense attack types: same three modes as Phase 3, but here the
  *  defense's `to` argument is the OPPONENT's REBUTTAL (a CA-node),
@@ -98,10 +129,16 @@ const ResponseZ = z.object({
   /** rebuttalArgumentId — the opponent's Phase-3 rebuttal arg this response addresses. */
   targetAttackId: z.string().min(4),
   kind: z.enum(["defend", "concede", "narrow"]),
-  rationale: z.string().min(40).max(600),
-  defense: DefenseArgumentZ.nullable(),
+  rationale: z.preprocess(
+    (v) => (typeof v === "string" && v.length > 600 ? v.slice(0, 597).trimEnd() + "..." : v),
+    z.string().min(40).max(600),
+  ),
+  defense: z.preprocess((v) => (v === undefined ? null : v), DefenseArgumentZ.nullable()),
   /** REQUIRED when kind === "narrow"; null otherwise. The new narrower conclusion claim. */
-  narrowedConclusionText: DeclarativeSentenceZ.nullable(),
+  narrowedConclusionText: z.preprocess(
+    (v) => (v === undefined ? null : v),
+    DeclarativeSentenceZ.nullable(),
+  ),
 });
 export type DefenseResponse = z.infer<typeof ResponseZ>;
 
@@ -115,7 +152,10 @@ const CqAnswerZ = z.object({
   /** cqResponseId — the opponent's Phase-3 cqResponse this answer addresses. */
   targetCqRaiseId: z.string().min(4),
   kind: z.enum(["answer", "concede"]),
-  rationale: z.string().min(40).max(600),
+  rationale: z.preprocess(
+    (v) => (typeof v === "string" && v.length > 600 ? v.slice(0, 597).trimEnd() + "..." : v),
+    z.string().min(40).max(600),
+  ),
 });
 export type CqAnswer = z.infer<typeof CqAnswerZ>;
 
@@ -222,6 +262,38 @@ export function buildDefenseOutputSchema(opts: DefenseSchemaOpts) {
   } = opts;
 
   return DefenseOutputZ.superRefine((data, ctx) => {
+    // 0. Pre-normalize: resolve truncated/prefix attack & cq-raise IDs in-place.
+    {
+      const attackIdByPrefix = new Map<string, string>();
+      for (const id of opposingRebuttals.keys()) {
+        for (let len = 8; len <= id.length; len++) {
+          const p = id.slice(0, len);
+          if (attackIdByPrefix.has(p)) attackIdByPrefix.set(p, "__ambiguous__");
+          else attackIdByPrefix.set(p, id);
+        }
+      }
+      const cqIdByPrefix = new Map<string, string>();
+      for (const id of opposingCqRaises.keys()) {
+        for (let len = 8; len <= id.length; len++) {
+          const p = id.slice(0, len);
+          if (cqIdByPrefix.has(p)) cqIdByPrefix.set(p, "__ambiguous__");
+          else cqIdByPrefix.set(p, id);
+        }
+      }
+      const resolveAttack = (raw: string): string => {
+        if (opposingRebuttals.has(raw)) return raw;
+        const m = attackIdByPrefix.get(raw);
+        return m && m !== "__ambiguous__" ? m : raw;
+      };
+      const resolveCq = (raw: string): string => {
+        if (opposingCqRaises.has(raw)) return raw;
+        const m = cqIdByPrefix.get(raw);
+        return m && m !== "__ambiguous__" ? m : raw;
+      };
+      for (const r of data.responses) r.targetAttackId = resolveAttack(r.targetAttackId);
+      for (const c of data.cqAnswers) c.targetCqRaiseId = resolveCq(c.targetCqRaiseId);
+    }
+
     // 1. advocateRole consistency.
     if (data.advocateRole !== advocateRole) {
       ctx.addIssue({

--- a/experiments/polarization-1/orchestrator/agents/defense.ts
+++ b/experiments/polarization-1/orchestrator/agents/defense.ts
@@ -62,6 +62,16 @@ export interface DefenseTurnInput {
   yourPhase2ArgumentsPrompt: string;
   /** Renders into `## OPPONENT_ATTACKS_AGAINST_YOU` (other advocate's Phase-3 attacks targeting THIS advocate). */
   opponentAttacksPrompt: string;
+  /**
+   * Renders into `## METHODOLOGIST_ATTACKS_AGAINST_YOU` (the
+   * Methodologist's Phase-3 attacks targeting THIS advocate's args).
+   * Empty string → omit the section entirely (pre-Methodologist runs
+   * pass "" or default-undefined). The validator's
+   * `schemaOpts.opposingRebuttals` map already includes methodologist
+   * attack ids (the Phase-4 driver merges both opponents into a single
+   * map), so defense responses may target any of them.
+   */
+  methodologistAttacksPrompt?: string;
   /** Renders into `## EVIDENCE_CORPUS`. */
   evidenceCorpusPrompt: string;
   /** Schema-binding parameters (opposing rebuttals, opposing CQ raises, allowed citation tokens). */
@@ -92,6 +102,7 @@ export async function runDefenseTurn(input: DefenseTurnInput): Promise<DefenseTu
     framing: input.framing,
     yourPhase2: input.yourPhase2ArgumentsPrompt,
     opponentAttacks: input.opponentAttacksPrompt,
+    methodologistAttacks: input.methodologistAttacksPrompt ?? "",
     evidence: input.evidenceCorpusPrompt,
     role: input.role,
   });
@@ -228,15 +239,16 @@ function renderUserMessage(opts: {
   framing: string;
   yourPhase2: string;
   opponentAttacks: string;
+  methodologistAttacks: string;
   evidence: string;
   role: DefenseAgentRole;
 }): string {
   const taskLine =
     opts.role === "advocate-a"
-      ? "You are Advocate A (causal-link position). Produce a Phase-4 DefenseOutput per §4 of your system prompt. Every rebuttal in OPPONENT_ATTACKS_AGAINST_YOU must receive exactly one response in `responses`; every CQ_RAISE must receive exactly one entry in `cqAnswers`. Emit a single JSON object only — no prose before, after, or between."
-      : "You are Advocate B (skeptical position). Produce a Phase-4 DefenseOutput per §4 of your system prompt. Every rebuttal in OPPONENT_ATTACKS_AGAINST_YOU must receive exactly one response in `responses`; every CQ_RAISE must receive exactly one entry in `cqAnswers`. Emit a single JSON object only — no prose before, after, or between.";
+      ? "You are Advocate A (causal-link position). Produce a Phase-4 DefenseOutput per §4 of your system prompt. Every rebuttal in OPPONENT_ATTACKS_AGAINST_YOU and METHODOLOGIST_ATTACKS_AGAINST_YOU must receive exactly one response in `responses`; every CQ_RAISE in either block must receive exactly one entry in `cqAnswers`. Emit a single JSON object only — no prose before, after, or between."
+      : "You are Advocate B (skeptical position). Produce a Phase-4 DefenseOutput per §4 of your system prompt. Every rebuttal in OPPONENT_ATTACKS_AGAINST_YOU and METHODOLOGIST_ATTACKS_AGAINST_YOU must receive exactly one response in `responses`; every CQ_RAISE in either block must receive exactly one entry in `cqAnswers`. Emit a single JSON object only — no prose before, after, or between.";
 
-  return [
+  const sections: string[] = [
     "## FRAMING",
     "",
     opts.framing.trim(),
@@ -248,6 +260,18 @@ function renderUserMessage(opts: {
     "## OPPONENT_ATTACKS_AGAINST_YOU",
     "",
     opts.opponentAttacks.trim(),
+  ];
+
+  if (opts.methodologistAttacks.trim().length > 0) {
+    sections.push(
+      "",
+      "## METHODOLOGIST_ATTACKS_AGAINST_YOU",
+      "",
+      opts.methodologistAttacks.trim(),
+    );
+  }
+
+  sections.push(
     "",
     "## EVIDENCE_CORPUS",
     "",
@@ -256,7 +280,9 @@ function renderUserMessage(opts: {
     "## YOUR_TASK",
     "",
     taskLine,
-  ].join("\n");
+  );
+
+  return sections.join("\n");
 }
 
 function formatZodIssues(err: ZodError): string {

--- a/experiments/polarization-1/orchestrator/agents/methodologist-schema.ts
+++ b/experiments/polarization-1/orchestrator/agents/methodologist-schema.ts
@@ -1,0 +1,320 @@
+/**
+ * agents/methodologist-schema.ts
+ *
+ * Zod contract for the Phase-3 Methodologist (cross-side critic). The
+ * Methodologist is a third voice in Phase 3 — distinct from Advocate A
+ * and Advocate B — that files rebuttals + critical-question raises
+ * against arguments from BOTH sides.
+ *
+ * Design choices:
+ *   - Output shape mirrors `RebuttalOutputZ` (rebuttals[] + cqResponses[]
+ *     + webCitations[]), so we can reuse `translateRebuttalOutput()` with
+ *     `authorRole: "methodologist"`. The translator only consumes the
+ *     fields it knows about; extra fields like `targetAdvocateRole` are
+ *     stripped before invocation.
+ *   - Each rebuttal/cqResponse carries an explicit `targetAdvocateRole`
+ *     ("A" | "B") so the Phase-4 driver can route the attack to the
+ *     correct advocate's "ATTACKS_AGAINST_YOU" prompt block. This is
+ *     redundant with `targetArgumentId` (which uniquely identifies an
+ *     advocate) but makes the LLM's intent explicit and is cheap to
+ *     validate.
+ *   - `advocateRole` is the literal `"M"` (not "A" or "B"). The literal
+ *     keeps the union exhaustive without contaminating other agent
+ *     schemas that assume role ∈ {A, B}.
+ *   - `phase` is `"3-methodologist"` (vs. Rebuttal's `"3"`) so any
+ *     downstream consumer can disambiguate the two record types.
+ *   - SAME per-rebuttal validation as Rebuttal (UNDERMINE requires
+ *     premise index, layer plausibility, citation-token resolution,
+ *     scheme-CQ validity).
+ *   - Soft-symmetry guidance: the prompt asks the Methodologist to
+ *     attack BOTH sides; the schema does not hard-enforce a balance
+ *     (a 100/0 split could be substantively correct in a record where
+ *     one side's methodology is genuinely worse). Soft-checks layer (if
+ *     ever extended to Methodologist) can flag asymmetric attack
+ *     distributions for human review.
+ *
+ * Hard-validation rules: see `prompts/10-methodologist.md` §5.
+ */
+
+import { z } from "zod";
+import type { ExperimentSchemeKey } from "../scheme-catalog";
+import {
+  CitationTokenZ,
+  SchemeKeyZ,
+  WebCitationZ,
+  isSchemeAllowedForLayer,
+  type AdvocateLayer,
+} from "./advocate-schema";
+import { AttackTypeZ, type OpposingArgumentBinding } from "./rebuttal-schema";
+
+// ─────────────────────────────────────────────────────────────────
+// Per-element schemas
+// ─────────────────────────────────────────────────────────────────
+
+const MethodologistPremiseZ = z.object({
+  text: z
+    .string()
+    .min(1)
+    .max(400)
+    .refine((s) => /^[A-Z(\u201c"\u2018']/.test(s.trim()), {
+      message: "premise text must begin with a capital letter (declarative sentence)",
+    })
+    .refine((s) => /[.!?]\s*$/.test(s.trim()), {
+      message: "premise text must end with a sentence-terminating punctuation mark",
+    })
+    .refine((s) => !/^(and|or|but|so|because|therefore|thus|hence)\b/i.test(s.trim()), {
+      message: "premise text must not begin with a leading conjunction",
+    })
+    .refine((s) => !/\?\s*$/.test(s.trim()), {
+      message: "premise text must be declarative, not a question",
+    }),
+  citationToken: CitationTokenZ.nullable(),
+});
+
+const TargetAdvocateRoleZ = z.enum(["A", "B"]);
+
+const MethodologistCqResponseZ = z.object({
+  /** Argument-id of the targeted advocate's argument. */
+  targetArgumentId: z.string().min(4),
+  /** Which advocate authored the targeted argument. */
+  targetAdvocateRole: TargetAdvocateRoleZ,
+  /** Critical-question key from the target argument's scheme. */
+  cqKey: z.string().min(1).max(80),
+  /** Methodologist only RAISES — it does not waive (waiving is for the
+   *  advocate whose own argument is at issue; the Methodologist as
+   *  cross-side critic has no "satisfied" stance to record). */
+  action: z.literal("raise"),
+  rationale: z.string().min(40).max(400),
+});
+export type MethodologistCqResponse = z.infer<typeof MethodologistCqResponseZ>;
+
+const MethodologistRebuttalZ = z.object({
+  targetArgumentId: z.string().min(4),
+  targetAdvocateRole: TargetAdvocateRoleZ,
+  attackType: AttackTypeZ,
+  targetPremiseIndex: z.number().int().nonnegative().nullable(),
+  conclusionText: z.string().min(1).max(400),
+  premises: z.array(MethodologistPremiseZ).min(1).max(6),
+  schemeKey: SchemeKeyZ,
+  warrant: z.string().min(1).max(300).nullable(),
+  cqKey: z.string().min(1).max(80).nullable(),
+});
+export type MethodologistRebuttal = z.infer<typeof MethodologistRebuttalZ>;
+
+// ─────────────────────────────────────────────────────────────────
+// Top-level shape
+// ─────────────────────────────────────────────────────────────────
+
+export const MethodologistOutputZ = z.object({
+  phase: z.literal("3-methodologist"),
+  advocateRole: z.literal("M"),
+  cqResponses: z.array(MethodologistCqResponseZ).default([]),
+  rebuttals: z.array(MethodologistRebuttalZ).default([]),
+  webCitations: z.array(WebCitationZ).max(40).optional().default([]),
+});
+export type MethodologistOutput = z.infer<typeof MethodologistOutputZ>;
+
+// ─────────────────────────────────────────────────────────────────
+// Refusal
+// ─────────────────────────────────────────────────────────────────
+
+export const MethodologistRefusalZ = z.object({
+  error: z.enum([
+    /** Both advocates' Phase-2 records are missing or malformed. */
+    "RECORD_INCOMPLETE",
+    /** Framing as written does not specify a methodological-rigor rubric the Methodologist can apply. */
+    "FRAMING_AMBIGUOUS",
+    /** Both sides' methodology is judged uniformly sound (no methodological flaws of the kind the Methodologist exists to find).
+     *  Use this only when the record genuinely shows no methodological weakness — not as a way to avoid hard work. */
+    "NO_METHODOLOGICAL_FLAWS_IDENTIFIED",
+  ]),
+  details: z.string().min(1).max(500),
+});
+export type MethodologistRefusal = z.infer<typeof MethodologistRefusalZ>;
+
+export function isMethodologistRefusal(r: unknown): r is MethodologistRefusal {
+  return typeof (r as any)?.error === "string" && !Array.isArray((r as any)?.rebuttals);
+}
+
+// ─────────────────────────────────────────────────────────────────
+// Schema-build options
+// ─────────────────────────────────────────────────────────────────
+
+export interface MethodologistSchemaOpts {
+  /** Union of A's and B's Phase-2 arguments, keyed by argumentId. The
+   *  binding's `advocateRole` (A | B) is the canonical assertion of which
+   *  side authored each arg; the Methodologist's `targetAdvocateRole`
+   *  field is validated against it. */
+  opposingArguments: ReadonlyMap<string, OpposingArgumentBinding & { advocateRole: "A" | "B" }>;
+  cqKeysByScheme: ReadonlyMap<ExperimentSchemeKey, ReadonlySet<string>>;
+  allowedCitationTokens: ReadonlySet<string>;
+  /** Defaults: rebuttals across BOTH sides up to 24 (≈ 12 per side), CQ
+   *  raises across both sides up to 24. Lower than per-advocate caps
+   *  because the Methodologist runs once, not twice. Per-target cap
+   *  remains 4. */
+  cqResponsesMax?: number;
+  rebuttalsMax?: number;
+  rebuttalsPerTargetMax?: number;
+}
+
+const DEFAULT_CQ_MAX = 24;
+const DEFAULT_REBUTTALS_MAX = 24;
+const DEFAULT_PER_TARGET_MAX = 4;
+
+export function buildMethodologistOutputSchema(opts: MethodologistSchemaOpts) {
+  const {
+    opposingArguments,
+    cqKeysByScheme,
+    allowedCitationTokens,
+    cqResponsesMax = DEFAULT_CQ_MAX,
+    rebuttalsMax = DEFAULT_REBUTTALS_MAX,
+    rebuttalsPerTargetMax = DEFAULT_PER_TARGET_MAX,
+  } = opts;
+
+  return MethodologistOutputZ.superRefine((data, ctx) => {
+    // Web citations: dedupe.
+    const declaredWebTokens = new Set<string>(
+      (data.webCitations ?? []).map((w) => w.token),
+    );
+    const seenWebTokens = new Set<string>();
+    for (let i = 0; i < (data.webCitations ?? []).length; i++) {
+      const t = data.webCitations![i].token;
+      if (seenWebTokens.has(t)) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: `webCitations[${i}].token "${t}" is duplicated`,
+          path: ["webCitations", i, "token"],
+        });
+      }
+      seenWebTokens.add(t);
+    }
+
+    // Global budget caps.
+    if (data.cqResponses.length > cqResponsesMax) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: `cqResponses.length (${data.cqResponses.length}) exceeds max (${cqResponsesMax})`,
+        path: ["cqResponses"],
+      });
+    }
+    if (data.rebuttals.length > rebuttalsMax) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: `rebuttals.length (${data.rebuttals.length}) exceeds max (${rebuttalsMax})`,
+        path: ["rebuttals"],
+      });
+    }
+
+    // Per-target rebuttal cap.
+    const rebuttalsByTarget = new Map<string, number>();
+    for (let i = 0; i < data.rebuttals.length; i++) {
+      const r = data.rebuttals[i];
+      const n = (rebuttalsByTarget.get(r.targetArgumentId) ?? 0) + 1;
+      rebuttalsByTarget.set(r.targetArgumentId, n);
+      if (n > rebuttalsPerTargetMax) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: `rebuttals against target ${r.targetArgumentId} exceed per-target cap (${rebuttalsPerTargetMax}); collapse multi-flaw critiques into a single argument with multiple premises`,
+          path: ["rebuttals", i, "targetArgumentId"],
+        });
+      }
+    }
+
+    // CQ-response validation.
+    for (let i = 0; i < data.cqResponses.length; i++) {
+      const c = data.cqResponses[i];
+      const target = opposingArguments.get(c.targetArgumentId);
+      if (!target) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: `cqResponses[${i}].targetArgumentId "${c.targetArgumentId}" is not a known Phase-2 argument`,
+          path: ["cqResponses", i, "targetArgumentId"],
+        });
+        continue;
+      }
+      if (c.targetAdvocateRole !== target.advocateRole) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: `cqResponses[${i}].targetAdvocateRole "${c.targetAdvocateRole}" disagrees with binding "${target.advocateRole}" for argument ${c.targetArgumentId}`,
+          path: ["cqResponses", i, "targetAdvocateRole"],
+        });
+      }
+      const cqs = cqKeysByScheme.get(target.schemeKey);
+      if (!cqs) continue;
+      if (!cqs.has(c.cqKey)) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: `cqResponses[${i}].cqKey "${c.cqKey}" is not a valid CQ for scheme "${target.schemeKey}". Valid keys: [${[...cqs].join(", ")}]`,
+          path: ["cqResponses", i, "cqKey"],
+        });
+      }
+    }
+
+    // Rebuttal validation.
+    for (let i = 0; i < data.rebuttals.length; i++) {
+      const r = data.rebuttals[i];
+      const target = opposingArguments.get(r.targetArgumentId);
+      if (!target) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: `rebuttals[${i}].targetArgumentId "${r.targetArgumentId}" is not a known Phase-2 argument`,
+          path: ["rebuttals", i, "targetArgumentId"],
+        });
+        continue;
+      }
+      if (r.targetAdvocateRole !== target.advocateRole) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: `rebuttals[${i}].targetAdvocateRole "${r.targetAdvocateRole}" disagrees with binding "${target.advocateRole}" for argument ${r.targetArgumentId}`,
+          path: ["rebuttals", i, "targetAdvocateRole"],
+        });
+      }
+
+      // Targeting consistency (same as Rebuttal).
+      if (r.attackType === "UNDERMINE") {
+        if (r.targetPremiseIndex === null) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            message: `rebuttals[${i}]: UNDERMINE requires targetPremiseIndex`,
+            path: ["rebuttals", i, "targetPremiseIndex"],
+          });
+        } else if (r.targetPremiseIndex >= target.premiseCount) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            message: `rebuttals[${i}]: targetPremiseIndex ${r.targetPremiseIndex} out of range; target has ${target.premiseCount} premises`,
+            path: ["rebuttals", i, "targetPremiseIndex"],
+          });
+        }
+      } else if (r.targetPremiseIndex !== null) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: `rebuttals[${i}]: targetPremiseIndex must be null for ${r.attackType} (only UNDERMINE targets a specific premise)`,
+          path: ["rebuttals", i, "targetPremiseIndex"],
+        });
+      }
+
+      // Citation tokens resolve.
+      for (let p = 0; p < r.premises.length; p++) {
+        const tok = r.premises[p].citationToken;
+        if (tok !== null && !allowedCitationTokens.has(tok) && !declaredWebTokens.has(tok)) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            message: `rebuttals[${i}].premises[${p}].citationToken "${tok}" does not resolve in EVIDENCE_CORPUS or in webCitations`,
+            path: ["rebuttals", i, "premises", p, "citationToken"],
+          });
+        }
+      }
+
+      // Layer plausibility — methodological critique can in principle
+      // attack any layer, but we keep the same scheme-layer check so the
+      // record stays uniform with Phase-2/3.
+      if (!isSchemeAllowedForLayer(r.schemeKey, target.conclusionLayer)) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: `rebuttals[${i}]: schemeKey "${r.schemeKey}" is not appropriate for layer "${target.conclusionLayer}" (the layer of the targeted argument's conclusion)`,
+          path: ["rebuttals", i, "schemeKey"],
+        });
+      }
+    }
+  });
+}

--- a/experiments/polarization-1/orchestrator/agents/methodologist.ts
+++ b/experiments/polarization-1/orchestrator/agents/methodologist.ts
@@ -1,0 +1,267 @@
+/**
+ * agents/methodologist.ts
+ *
+ * Phase-3 Methodologist runner. The Methodologist is a third voice that
+ * runs AFTER Advocate A and Advocate B in Phase 3, produces critical-
+ * question raises and rebuttals against arguments from BOTH sides, and
+ * has no position of its own. Its outputs feed Phase 4 (each advocate
+ * defends against any Methodologist attack targeting their arguments)
+ * and Phase 5 (Synthesist sees Methodologist record alongside A/B).
+ *
+ * This file mirrors `rebuttal.ts` in shape: read prompt, render user
+ * message, call Anthropic with web search enabled, parse + Zod-validate,
+ * 2-attempt retry. The sole structural differences:
+ *   - System prompt is `prompts/10-methodologist.md`.
+ *   - User message renders BOTH advocates' Phase-2 args under
+ *     `## PHASE_2_ARGUMENTS` (single block, with side labels per arg).
+ *   - Schema is `MethodologistOutputZ` from `methodologist-schema.ts`.
+ *   - Logged `agentRole` is the literal string `"methodologist"`.
+ */
+
+import { readFileSync } from "fs";
+import path from "path";
+import type { ZodError } from "zod";
+
+import { AnthropicClient, extractJson } from "../anthropic-client";
+import type { OrchestratorConfig } from "../config";
+import { modelFor } from "../config";
+import type { RoundLogger } from "../log/round-logger";
+import {
+  buildMethodologistOutputSchema,
+  MethodologistRefusalZ,
+  isMethodologistRefusal,
+  type MethodologistOutput,
+  type MethodologistRefusal,
+  type MethodologistSchemaOpts,
+} from "./methodologist-schema";
+
+export class MethodologistValidationError extends Error {
+  attempts: number;
+  rawResponses: string[];
+  zodErrors: ZodError[];
+  constructor(message: string, opts: { attempts: number; rawResponses: string[]; zodErrors: ZodError[] }) {
+    super(message);
+    this.attempts = opts.attempts;
+    this.rawResponses = opts.rawResponses;
+    this.zodErrors = opts.zodErrors;
+  }
+}
+
+export const METHODOLOGIST_AGENT_ROLE = "methodologist" as const;
+export type MethodologistAgentRole = typeof METHODOLOGIST_AGENT_ROLE;
+
+export interface MethodologistTurnInput {
+  /** Path to the Methodologist's Phase-3 system prompt (relative to experimentRoot or absolute). */
+  promptPath: string;
+  framing: string;
+  /**
+   * Combined prompt block listing BOTH advocates' Phase-2 arguments,
+   * built by the phase driver. Each argument line carries an
+   * "(advocate A)" or "(advocate B)" tag so the Methodologist can route
+   * `targetAdvocateRole` correctly.
+   */
+  phase2ArgumentsPrompt: string;
+  evidenceCorpusPrompt: string;
+  schemaOpts: MethodologistSchemaOpts;
+  cfg: OrchestratorConfig;
+  llm: AnthropicClient;
+  logger: RoundLogger;
+}
+
+export interface MethodologistTurnResult {
+  response: MethodologistOutput | MethodologistRefusal;
+  rawText: string;
+  usage: { inputTokens: number; outputTokens: number };
+  attempts: number;
+}
+
+export async function runMethodologistTurn(
+  input: MethodologistTurnInput,
+): Promise<MethodologistTurnResult> {
+  const promptPath = path.isAbsolute(input.promptPath)
+    ? input.promptPath
+    : path.join(input.cfg.experimentRoot, input.promptPath);
+  const systemPrompt = readFileSync(promptPath, "utf8");
+  const model = modelFor(input.cfg);
+
+  const outputSchema = buildMethodologistOutputSchema(input.schemaOpts);
+
+  const userMessage = renderUserMessage({
+    framing: input.framing,
+    phase2Arguments: input.phase2ArgumentsPrompt,
+    evidence: input.evidenceCorpusPrompt,
+  });
+
+  const messages: Array<{ role: "user" | "assistant"; content: string }> = [
+    { role: "user", content: userMessage },
+  ];
+
+  let totalInputTokens = 0;
+  let totalOutputTokens = 0;
+  const rawResponses: string[] = [];
+  const zodErrors: ZodError[] = [];
+
+  for (let attempt = 1; attempt <= 2; attempt++) {
+    const res = await input.llm.chat({
+      system: systemPrompt,
+      messages,
+      model,
+      // Slightly cooler than advocates (0.8): the Methodologist's job is
+      // disciplined methodological diagnosis, not creative argument
+      // generation.
+      temperature: 0.6,
+      // Larger headroom: the Methodologist may emit up to 24 rebuttals
+      // and 24 CQ raises, each with multiple premises and citations.
+      maxTokens: 28000,
+      logger: input.logger,
+      agentRole: METHODOLOGIST_AGENT_ROLE,
+      useWebSearch: true,
+      webSearchMaxUses: 12,
+    });
+    totalInputTokens += res.usage.inputTokens;
+    totalOutputTokens += res.usage.outputTokens;
+    rawResponses.push(res.text);
+
+    let parsed: unknown;
+    try {
+      parsed = extractJson(res.text);
+    } catch (err) {
+      const msg = (err as Error).message;
+      input.logger.event("agent_validation_failure", {
+        agent: METHODOLOGIST_AGENT_ROLE,
+        attempt,
+        kind: "json-extract",
+        phase: 3,
+        error: msg,
+      });
+      if (attempt === 2) {
+        throw new MethodologistValidationError(
+          `methodologist: could not extract JSON after ${attempt} attempts: ${msg}`,
+          { attempts: attempt, rawResponses, zodErrors },
+        );
+      }
+      messages.push({ role: "assistant", content: res.text });
+      messages.push({
+        role: "user",
+        content:
+          `Your last response could not be parsed as JSON: ${msg}\n\n` +
+          `Re-emit the response per the prompt's §4 output contract: a single JSON object, ` +
+          `optionally inside a \`\`\`json fence, with no prose before or after.`,
+      });
+      input.logger.event("agent_retry", {
+        agent: METHODOLOGIST_AGENT_ROLE,
+        attempt: attempt + 1,
+        phase: 3,
+        reason: "json-extract",
+      });
+      continue;
+    }
+
+    const refusalAttempt = MethodologistRefusalZ.safeParse(parsed);
+    if (refusalAttempt.success) {
+      input.logger.event("agent_parsed_output", {
+        agent: METHODOLOGIST_AGENT_ROLE,
+        attempt,
+        phase: 3,
+        kind: "refusal",
+        output: refusalAttempt.data,
+      });
+      return {
+        response: refusalAttempt.data,
+        rawText: res.text,
+        usage: { inputTokens: totalInputTokens, outputTokens: totalOutputTokens },
+        attempts: attempt,
+      };
+    }
+
+    const validation = outputSchema.safeParse(parsed);
+    if (validation.success) {
+      input.logger.event("agent_parsed_output", {
+        agent: METHODOLOGIST_AGENT_ROLE,
+        attempt,
+        phase: 3,
+        kind: "methodologist-output",
+        cqResponseCount: validation.data.cqResponses.length,
+        rebuttalCount: validation.data.rebuttals.length,
+      });
+      return {
+        response: validation.data,
+        rawText: res.text,
+        usage: { inputTokens: totalInputTokens, outputTokens: totalOutputTokens },
+        attempts: attempt,
+      };
+    }
+
+    zodErrors.push(validation.error);
+    input.logger.event("agent_validation_failure", {
+      agent: METHODOLOGIST_AGENT_ROLE,
+      attempt,
+      phase: 3,
+      kind: "zod",
+      issues: validation.error.issues,
+    });
+
+    if (attempt === 2) {
+      throw new MethodologistValidationError(
+        `methodologist: hard-validation failed after 2 attempts. Last issues:\n${formatZodIssues(validation.error)}`,
+        { attempts: attempt, rawResponses, zodErrors },
+      );
+    }
+    messages.push({ role: "assistant", content: res.text });
+    messages.push({ role: "user", content: validationFollowupMessage(validation.error) });
+    input.logger.event("agent_retry", {
+      agent: METHODOLOGIST_AGENT_ROLE,
+      attempt: attempt + 1,
+      phase: 3,
+      reason: "zod",
+    });
+  }
+
+  throw new Error("methodologist: unreachable end of retry loop");
+}
+
+export { isMethodologistRefusal };
+
+// ─────────────────────────────────────────────────────────────────
+// Internals
+// ─────────────────────────────────────────────────────────────────
+
+function renderUserMessage(opts: {
+  framing: string;
+  phase2Arguments: string;
+  evidence: string;
+}): string {
+  return [
+    "## FRAMING",
+    "",
+    opts.framing.trim(),
+    "",
+    "## PHASE_2_ARGUMENTS",
+    "",
+    opts.phase2Arguments.trim(),
+    "",
+    "## EVIDENCE_CORPUS",
+    "",
+    opts.evidence.trim(),
+    "",
+    "## YOUR_TASK",
+    "",
+    "You are the Methodologist. You have NO position. Produce a Phase-3 MethodologistOutput per §4 of your system prompt. Attack methodologically weak arguments on BOTH sides. Emit a single JSON object only — no prose before, after, or between.",
+  ].join("\n");
+}
+
+function formatZodIssues(err: ZodError): string {
+  return err.issues
+    .map((i) => `- ${i.path.join(".") || "(root)"}: ${i.message}`)
+    .slice(0, 12)
+    .join("\n");
+}
+
+function validationFollowupMessage(err: ZodError): string {
+  return [
+    "Your last response failed validation. Issues:",
+    formatZodIssues(err),
+    "",
+    "Re-emit the entire JSON object with these issues fixed. Do not include any prose outside the JSON.",
+  ].join("\n");
+}

--- a/experiments/polarization-1/orchestrator/agents/rebuttal-schema.ts
+++ b/experiments/polarization-1/orchestrator/agents/rebuttal-schema.ts
@@ -226,7 +226,50 @@ export function buildRebuttalOutputSchema(opts: RebuttalSchemaOpts) {
     rebuttalsPerTargetMax = REBUTTAL_PER_TARGET_MAX,
   } = opts;
 
+  // Pre-normalization helpers: tolerate two common LLM mistakes.
+  // (1) cqKey suffix drift: model emits "causal_strength?" but the
+  //     scheme catalog uses "causal_strength" (or vice-versa).
+  // (2) targetArgumentId truncation: model emits a short prefix
+  //     (e.g. "cmoupg0n4") of a real argument id.
+  const argIdByPrefix = new Map<string, string>();
+  for (const id of opposingArguments.keys()) {
+    // Index increasing-length prefixes ≥ 8 chars.
+    for (let n = 8; n <= id.length; n++) {
+      const p = id.slice(0, n);
+      // Only register prefixes that are unambiguous.
+      if (argIdByPrefix.has(p)) argIdByPrefix.set(p, "__ambiguous__");
+      else argIdByPrefix.set(p, id);
+    }
+  }
+  function resolveArgId(raw: string): string {
+    if (opposingArguments.has(raw)) return raw;
+    const hit = argIdByPrefix.get(raw);
+    if (hit && hit !== "__ambiguous__") return hit;
+    return raw;
+  }
+  function normalizeCqKey(raw: string, schemeKey: ExperimentSchemeKey): string {
+    const cqs = cqKeysByScheme.get(schemeKey);
+    if (!cqs) return raw;
+    if (cqs.has(raw)) return raw;
+    // Try toggling trailing "?".
+    const flipped = raw.endsWith("?") ? raw.slice(0, -1) : raw + "?";
+    if (cqs.has(flipped)) return flipped;
+    return raw;
+  }
+
   return RebuttalOutputZ.superRefine((data, ctx) => {
+    // Apply normalizers in place before any downstream checks see the data.
+    for (const c of data.cqResponses) {
+      c.targetArgumentId = resolveArgId(c.targetArgumentId);
+      const target = opposingArguments.get(c.targetArgumentId);
+      if (target) c.cqKey = normalizeCqKey(c.cqKey, target.schemeKey);
+    }
+    for (const r of data.rebuttals) {
+      r.targetArgumentId = resolveArgId(r.targetArgumentId);
+      const target = opposingArguments.get(r.targetArgumentId);
+      if (target && r.cqKey != null) r.cqKey = normalizeCqKey(r.cqKey, target.schemeKey);
+    }
+
     if (data.advocateRole !== advocateRole) {
       ctx.addIssue({
         code: z.ZodIssueCode.custom,

--- a/experiments/polarization-1/orchestrator/agents/synthesist-schema.ts
+++ b/experiments/polarization-1/orchestrator/agents/synthesist-schema.ts
@@ -1,0 +1,430 @@
+/**
+ * agents/synthesist-schema.ts
+ *
+ * Zod contract for the Phase-5 Synthesist / Crux-Finder — a single-shot
+ * read-only agent that runs after Phase 4 is finalized. It consumes the
+ * full dialectical record (Phase 1 topology, Phase 2 arguments from both
+ * advocates, Phase 3 attacks from both, Phase 4 defenses + concession
+ * tracker verdict, evidence corpus) and produces:
+ *
+ *   - `cruxes[]`            — identified disagreement points where the
+ *                              dialectical state genuinely shifted, with a
+ *                              characterization of *why* the two sides
+ *                              still disagree (or why they no longer do).
+ *   - `agreements[]`        — propositions both sides accept by end of
+ *                              Phase 4, including ones the deliberation
+ *                              *revealed* that weren't visible at Phase 1.
+ *   - `originalContributions[]`
+ *                           — arguments / decompositions / reference-class
+ *                              shifts / methodological observations that
+ *                              the deliberation produced and that aren't
+ *                              just paraphrases of bound-corpus or web
+ *                              sources. The point of the loosened run.
+ *   - `openQuestions[]`     — what would actually resolve the remaining
+ *                              cruxes (specific empirical tests,
+ *                              theoretical clarifications, definitional
+ *                              stipulations needed).
+ *   - `epistemicShift`      — narrative on how the central claim's status
+ *                              moved (or didn't), and a one-shot net
+ *                              epistemic-value rating.
+ *
+ * The verdict is read-only: the Synthesist does not modify the platform
+ * record or write platform-side artifacts. Its output is a JSON blob
+ * (PHASE_5_COMPLETE.json) and a derived markdown report (SYNTHESIS.md).
+ */
+
+import { z } from "zod";
+
+// ─────────────────────────────────────────────────────────────────
+// Sub-shapes
+// ─────────────────────────────────────────────────────────────────
+
+const CruxStatusZ = z.enum([
+  /** Both sides accept the empirical question as well-posed; they disagree
+   *  on what the evidence shows. Resolvable in principle by better data. */
+  "GENUINE_EMPIRICAL_DISPUTE",
+  /** Disagreement traces to different operationalizations of a key term
+   *  (e.g. "polarization" as affective vs. ideological vs. issue-attitude). */
+  "DEFINITIONAL_AMBIGUITY",
+  /** Both sides agree on the question and on what evidence would settle
+   *  it; that evidence does not (yet) exist. */
+  "EVIDENTIARY_GAP",
+  /** Disagreement reduces to a value or weighting choice (e.g. how to trade
+   *  off Type-I vs. Type-II error against the framing's ≥ 10% bar). */
+  "VALUE_DISAGREEMENT",
+  /** Both sides arrived at the same position by end of Phase 4 — what
+   *  looked like a crux at Phase 1 turned out not to be one. */
+  "RESOLVED_BY_DELIBERATION",
+]);
+export type CruxStatus = z.infer<typeof CruxStatusZ>;
+
+const CruxZ = z.object({
+  /** Sub-claim index from the Phase-1 topology this crux lives on,
+   *  or null if the crux cuts across multiple sub-claims. */
+  subClaimIndex: z.number().int().nonnegative().nullable(),
+  /** Short label for the crux — 4-12 words, naming the disputed point. */
+  label: z.string().min(8).max(140),
+  /** What Advocate A maintains by end of Phase 4. Cite specific argumentIds
+   *  in `keyArgumentIds`. 80-500 chars. */
+  advocateAClaim: z.string().min(80).max(500),
+  /** What Advocate B maintains by end of Phase 4. 80-500 chars. */
+  advocateBClaim: z.string().min(80).max(500),
+  /** Diagnosis of why the two positions differ — name the construct,
+   *  reference class, methodological standard, or evidentiary gap that
+   *  generates the disagreement. 120-800 chars. */
+  whyTheyDisagree: z.string().min(120).max(800),
+  status: CruxStatusZ,
+  /** Phase-2/3/4 ids (argumentIds, rebuttalArgumentIds, response ids)
+   *  whose dialectical movement made this crux visible. Must resolve. */
+  keyArgumentIds: z.array(z.string().min(4)).min(1).max(20),
+  /** Open-question indices (into the top-level `openQuestions[]`) that
+   *  would resolve this crux if answered. Empty array allowed for
+   *  RESOLVED_BY_DELIBERATION cruxes. */
+  resolvedByOpenQuestions: z.array(z.number().int().nonnegative()).max(8).default([]),
+});
+export type Crux = z.infer<typeof CruxZ>;
+
+const AgreementZ = z.object({
+  /** Short label — 4-12 words. */
+  label: z.string().min(8).max(140),
+  /** Description of the proposition both sides now accept. 80-600 chars. */
+  proposition: z.string().min(80).max(600),
+  /** How the agreement was reached: */
+  origin: z.enum([
+    /** Both advocates' Phase-2 cases relied on this premise; never contested. */
+    "STIPULATED_BACKGROUND",
+    /** One side's Phase-2 argument was conceded (or effectively conceded
+     *  per the tracker) by the other side in Phase 4. */
+    "CONCEDED_IN_PHASE_4",
+    /** Both sides argued for distinct positions but their Phase-3 / Phase-4
+     *  exchanges revealed they are actually claiming the same thing in
+     *  different vocabulary. */
+    "REVEALED_BY_DIALECTIC",
+    /** Both sides explicitly narrowed their original Phase-2 conclusions in
+     *  Phase 4, and the narrowed conclusions are mutually consistent. */
+    "MUTUAL_NARROWING",
+  ]),
+  /** Phase-2/3/4 ids that establish this agreement in the record. */
+  basisInRecord: z.array(z.string().min(4)).min(1).max(15),
+});
+export type Agreement = z.infer<typeof AgreementZ>;
+
+const OriginalContributionTypeZ = z.enum([
+  /** Imports a reference class from outside the bound polarization-research
+   *  literature (e.g. cable-news 1990s, talk-radio 1980s, yellow press 1890s). */
+  "REFERENCE_CLASS_SHIFT",
+  /** Decomposes the central claim or a sub-claim into a conjunction of
+   *  factors, exposing where the chain holds or breaks. */
+  "INTRODUCES_DECOMPOSITION",
+  /** Bridges a literature the bound corpus didn't cover (e.g. media
+   *  economics' creator-incentive channel, network science's contagion
+   *  models, IO economics on platform competition). */
+  "BRIDGES_LITERATURES",
+  /** Distinguishes constructs that the bound corpus had been conflating
+   *  (e.g. affective vs. ideological vs. issue-attitude polarization;
+   *  outgroup animosity vs. ingroup solidarity). */
+  "CONSTRUCT_DISAMBIGUATION",
+  /** Provides a quantitative bound (an upper bound, lower bound, or
+   *  power-against-bar calculation) the corpus did not state. */
+  "PROVIDES_EFFECT_SIZE_BOUND",
+  /** Reframes the question itself in a way both sides accept as more
+   *  productive than the framing's original phrasing. */
+  "REFRAMES_QUESTION",
+  /** A methodological critique (instrumental-variable critique,
+   *  selection-on-observables critique, replication-failure invocation,
+   *  pre-registration objection) that genuinely changed argument standing. */
+  "METHODOLOGICAL_INSIGHT",
+]);
+export type OriginalContributionType = z.infer<typeof OriginalContributionTypeZ>;
+
+const OriginalContributionZ = z.object({
+  /** Short label — 4-12 words. */
+  label: z.string().min(8).max(140),
+  /** Description — 100-800 chars — naming the contribution and what it
+   *  unlocked dialectically. */
+  description: z.string().min(100).max(800),
+  type: OriginalContributionTypeZ,
+  /** Which advocate(s) made the contribution, or "joint" if it emerged
+   *  from the exchange itself (e.g. mutual narrowing producing a synthesis). */
+  attribution: z.enum(["A", "B", "joint", "methodologist"]),
+  /** Phase-2/3/4 ids that constitute or rely on this contribution. */
+  contributingIds: z.array(z.string().min(4)).min(1).max(15),
+  /** Citation tokens (corpus `src:*` / `block:*` or web `web:*`) supporting
+   *  the contribution. May be empty if the contribution is purely
+   *  inferential / structural (e.g. a decomposition argument). */
+  evidenceTokens: z.array(z.string().min(2)).max(20).default([]),
+  /** Single sentence on what makes this *original* relative to a
+   *  surface-level literature review — the originality test from the
+   *  loosened-mode prompts. 60-400 chars. */
+  noveltyJustification: z.string().min(60).max(400),
+});
+export type OriginalContribution = z.infer<typeof OriginalContributionZ>;
+
+const OpenQuestionZ = z.object({
+  /** Phrased as a falsifiable empirical question or a stipulation request.
+   *  60-400 chars. */
+  question: z.string().min(60).max(400),
+  /** What kind of resolution this question demands: */
+  resolutionType: z.enum([
+    "EMPIRICAL_STUDY",
+    "META_ANALYSIS_OR_REPLICATION",
+    "DEFINITIONAL_STIPULATION",
+    "THEORETICAL_CLARIFICATION",
+    "ACCESS_TO_PLATFORM_DATA",
+  ]),
+  /** Concrete sketch of the study / analysis / stipulation that would
+   *  resolve it. 100-800 chars. */
+  resolutionSketch: z.string().min(100).max(800),
+  /** Crux indices (into top-level `cruxes[]`) this question, if answered,
+   *  would resolve. */
+  resolvesCruxIndices: z.array(z.number().int().nonnegative()).max(8).default([]),
+});
+export type OpenQuestion = z.infer<typeof OpenQuestionZ>;
+
+const EpistemicShiftZ = z.object({
+  /** Narrative on how the central-claim verdict relates to the Phase-1
+   *  starting state — what the deliberation *did* to it. 200-1500 chars. */
+  centralClaimMovementSummary: z.string().min(200).max(1500),
+  /** Net assessment of the deliberation's epistemic value: */
+  netEpistemicValue: z.enum([
+    /** Produced original contributions that meaningfully change the state
+     *  of analysis on the central claim. */
+    "HIGH",
+    /** Produced clarifications and concessions that materially update one
+     *  or both sides' positions, but no genuinely original syntheses. */
+    "MEDIUM",
+    /** Litigated existing positions without producing concessions or
+     *  original syntheses; would not change a careful reader's view. */
+    "LOW",
+    /** Produced conclusions less defensible than what the bound corpus
+     *  alone supports (e.g. by overweighting low-quality web sources, or
+     *  by collapsing under aggressive but methodologically thin attacks). */
+    "NEGATIVE",
+  ]),
+  /** 100-600 chars. Cite specific contribution / crux / concession ids. */
+  netEpistemicValueRationale: z.string().min(100).max(600),
+});
+export type EpistemicShift = z.infer<typeof EpistemicShiftZ>;
+
+// ─────────────────────────────────────────────────────────────────
+// Top-level shape
+// ─────────────────────────────────────────────────────────────────
+
+const SynthesistVerdictZ = z.object({
+  phase: z.literal("5-synthesist"),
+  cruxes: z.array(CruxZ).min(1).max(20),
+  agreements: z.array(AgreementZ).max(20).default([]),
+  originalContributions: z.array(OriginalContributionZ).max(25).default([]),
+  openQuestions: z.array(OpenQuestionZ).max(20).default([]),
+  epistemicShift: EpistemicShiftZ,
+});
+export type SynthesistVerdict = z.infer<typeof SynthesistVerdictZ>;
+
+// ─────────────────────────────────────────────────────────────────
+// Refusal
+// ─────────────────────────────────────────────────────────────────
+
+export const SynthesistRefusalZ = z.object({
+  error: z.enum([
+    /** Required input phase artifact missing or malformed. */
+    "RECORD_INCOMPLETE",
+    /** The Phase-3/4 exchange contains so few concessions, narrowings, or
+     *  load-bearing rebuttals that there is nothing to synthesize beyond
+     *  restating the Phase-2 positions. */
+    "INSUFFICIENT_DIALECTICAL_MOVEMENT",
+    /** Framing as written underdetermines what would count as an
+     *  "original contribution" or "resolved crux" for this domain. */
+    "FRAMING_AMBIGUOUS",
+  ]),
+  details: z.string().max(500),
+});
+export type SynthesistRefusal = z.infer<typeof SynthesistRefusalZ>;
+
+export function isSynthesistRefusal(r: unknown): r is SynthesistRefusal {
+  return (
+    typeof (r as any)?.error === "string" &&
+    !Array.isArray((r as any)?.cruxes)
+  );
+}
+
+// ─────────────────────────────────────────────────────────────────
+// Schema-binding inputs from the orchestrator
+// ─────────────────────────────────────────────────────────────────
+
+export interface SynthesistSchemaOpts {
+  /** Phase-2 argumentIds known to the record (both advocates). */
+  knownArgumentIds: ReadonlySet<string>;
+  /** Phase-3 rebuttalArgumentIds known to the record (both advocates). */
+  knownAttackIds: ReadonlySet<string>;
+  /** Phase-4 synthesized response ids: `phase4-A-r{idx}`, `phase4-A-cq{idx}`,
+   *  `phase4-B-r{idx}`, `phase4-B-cq{idx}`. */
+  knownPhase4ResponseIds: ReadonlySet<string>;
+  /** Number of sub-claims in the Phase-1 topology (validates subClaimIndex range). */
+  subClaimCount: number;
+  /** Citation tokens that resolve in the record — corpus + web combined. */
+  knownCitationTokens: ReadonlySet<string>;
+}
+
+// ─────────────────────────────────────────────────────────────────
+// Parameterized schema builder
+// ─────────────────────────────────────────────────────────────────
+
+export function buildSynthesistVerdictSchema(opts: SynthesistSchemaOpts) {
+  const {
+    knownArgumentIds,
+    knownAttackIds,
+    knownPhase4ResponseIds,
+    subClaimCount,
+    knownCitationTokens,
+  } = opts;
+
+  // A "known dialectical id" is anything from the record an id-array field
+  // is allowed to reference.
+  function isKnownDialecticalId(id: string): boolean {
+    return (
+      knownArgumentIds.has(id) ||
+      knownAttackIds.has(id) ||
+      knownPhase4ResponseIds.has(id)
+    );
+  }
+
+  // Tolerant input mutation before strict validation. Caps lengths and
+  // drops out-of-range openQuestion index references so the synthesist
+  // doesn't have to be retried for purely mechanical bookkeeping issues.
+  const Normalized = z.preprocess((raw) => {
+    if (!raw || typeof raw !== "object") return raw;
+    const data = raw as any;
+    // Length caps on epistemicShift fields.
+    const es = data.epistemicShift;
+    if (es && typeof es === "object") {
+      if (typeof es.centralClaimMovementSummary === "string" && es.centralClaimMovementSummary.length > 1500) {
+        es.centralClaimMovementSummary = es.centralClaimMovementSummary.slice(0, 1497) + "...";
+      }
+      if (typeof es.netEpistemicValueRationale === "string" && es.netEpistemicValueRationale.length > 600) {
+        es.netEpistemicValueRationale = es.netEpistemicValueRationale.slice(0, 597) + "...";
+      }
+    }
+    // Drop out-of-range openQuestion index references in cruxes.
+    const oqLen = Array.isArray(data.openQuestions) ? data.openQuestions.length : 0;
+    if (Array.isArray(data.cruxes)) {
+      for (const c of data.cruxes) {
+        if (Array.isArray(c?.resolvedByOpenQuestions)) {
+          c.resolvedByOpenQuestions = c.resolvedByOpenQuestions.filter(
+            (i: unknown) => typeof i === "number" && i >= 0 && i < oqLen,
+          );
+        }
+      }
+    }
+    // Drop out-of-range crux index references in openQuestions.
+    const cruxLen = Array.isArray(data.cruxes) ? data.cruxes.length : 0;
+    if (Array.isArray(data.openQuestions)) {
+      for (const q of data.openQuestions) {
+        if (Array.isArray(q?.resolvesCruxIndices)) {
+          q.resolvesCruxIndices = q.resolvesCruxIndices.filter(
+            (i: unknown) => typeof i === "number" && i >= 0 && i < cruxLen,
+          );
+        }
+      }
+    }
+    return data;
+  }, SynthesistVerdictZ);
+
+  return Normalized.superRefine((data, ctx) => {
+    // 1. cruxes[*].subClaimIndex range, keyArgumentIds resolution,
+    //    resolvedByOpenQuestions index range.
+    for (let i = 0; i < data.cruxes.length; i++) {
+      const c = data.cruxes[i];
+      if (c.subClaimIndex !== null) {
+        if (c.subClaimIndex >= subClaimCount) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            message: `cruxes[${i}].subClaimIndex ${c.subClaimIndex} is out of range (topology has ${subClaimCount} sub-claims)`,
+            path: ["cruxes", i, "subClaimIndex"],
+          });
+        }
+      }
+      for (let j = 0; j < c.keyArgumentIds.length; j++) {
+        const id = c.keyArgumentIds[j];
+        if (!isKnownDialecticalId(id)) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            message: `cruxes[${i}].keyArgumentIds[${j}] "${id}" is not a Phase-2 argumentId, Phase-3 rebuttalArgumentId, or Phase-4 response id from the record`,
+            path: ["cruxes", i, "keyArgumentIds", j],
+          });
+        }
+      }
+      for (let j = 0; j < c.resolvedByOpenQuestions.length; j++) {
+        const oqIdx = c.resolvedByOpenQuestions[j];
+        if (oqIdx >= data.openQuestions.length) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            message: `cruxes[${i}].resolvedByOpenQuestions[${j}] index ${oqIdx} is out of range (only ${data.openQuestions.length} open questions declared)`,
+            path: ["cruxes", i, "resolvedByOpenQuestions", j],
+          });
+        }
+      }
+    }
+
+    // 2. agreements[*].basisInRecord resolution.
+    for (let i = 0; i < data.agreements.length; i++) {
+      const a = data.agreements[i];
+      for (let j = 0; j < a.basisInRecord.length; j++) {
+        const id = a.basisInRecord[j];
+        if (!isKnownDialecticalId(id)) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            message: `agreements[${i}].basisInRecord[${j}] "${id}" is not a Phase-2/3/4 id from the record`,
+            path: ["agreements", i, "basisInRecord", j],
+          });
+        }
+      }
+    }
+
+    // 3. originalContributions[*].contributingIds + evidenceTokens.
+    for (let i = 0; i < data.originalContributions.length; i++) {
+      const oc = data.originalContributions[i];
+      for (let j = 0; j < oc.contributingIds.length; j++) {
+        const id = oc.contributingIds[j];
+        if (!isKnownDialecticalId(id)) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            message: `originalContributions[${i}].contributingIds[${j}] "${id}" is not a Phase-2/3/4 id from the record`,
+            path: ["originalContributions", i, "contributingIds", j],
+          });
+        }
+      }
+      for (let j = 0; j < oc.evidenceTokens.length; j++) {
+        const tok = oc.evidenceTokens[j];
+        if (!knownCitationTokens.has(tok)) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            message: `originalContributions[${i}].evidenceTokens[${j}] "${tok}" is not a citation token used in the record (corpus or web)`,
+            path: ["originalContributions", i, "evidenceTokens", j],
+          });
+        }
+      }
+    }
+
+    // 4. openQuestions[*].resolvesCruxIndices range.
+    for (let i = 0; i < data.openQuestions.length; i++) {
+      const q = data.openQuestions[i];
+      for (let j = 0; j < q.resolvesCruxIndices.length; j++) {
+        const cIdx = q.resolvesCruxIndices[j];
+        if (cIdx >= data.cruxes.length) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            message: `openQuestions[${i}].resolvesCruxIndices[${j}] index ${cIdx} is out of range (only ${data.cruxes.length} cruxes declared)`,
+            path: ["openQuestions", i, "resolvesCruxIndices", j],
+          });
+        }
+      }
+    }
+
+    // 5. Mutual reachability: every crux marked RESOLVED_BY_DELIBERATION
+    //    should have at least one supporting agreement OR contributingId
+    //    that traces to a Phase-4 concession/narrowing — soft rule
+    //    enforced via guidance.
+    //    (Not validated mechanically — too easy to false-positive on
+    //    legitimately under-supported claims.)
+  });
+}

--- a/experiments/polarization-1/orchestrator/agents/synthesist.ts
+++ b/experiments/polarization-1/orchestrator/agents/synthesist.ts
@@ -1,17 +1,21 @@
 /**
- * agents/tracker.ts
+ * agents/synthesist.ts
  *
- * Phase-4 Concession Tracker agent runner. The tracker is a single-shot
- * judge: it reads the full dialectical record (root claim, topology,
- * Phase-2 from both, Phase-3 from both, Phase-4 from both, evidence
- * corpus) and produces a TrackerVerdict per the §4.1 schema.
+ * Phase-5 Synthesist / Crux-Finder agent runner. Single-shot judge: it
+ * reads the entire dialectical record (Phase 1 topology, Phase 2 from
+ * both, Phase 3 from both, Phase 4 from both, the Concession Tracker
+ * verdict, evidence corpus + web-citation provenance) and produces a
+ * SynthesistVerdict per the §4 schema.
  *
- * Run AFTER both advocates' Phase-4 outputs are minted. Sequential by
- * construction (no parallelism needed — one agent, one call).
+ * Run AFTER Phase 4 is finalized (i.e. after PHASE_4_COMPLETE.json
+ * exists and its `tracker.outcome === "ok"`).
  *
- * Uses the prod model (Opus in prod, Haiku in dev) and an elevated
- * maxTokens budget because the verdict's per-argument rationales plus
- * the central-claim rationale plus advocate-summary rationales add up.
+ * Uses the prod model with an elevated maxTokens budget and a low
+ * temperature — this is a synthesis/judgment task, not generative.
+ *
+ * Mirrors `tracker.ts` structurally; differences are limited to the
+ * input shape (more sources to render), the schema, and the user-message
+ * template.
  */
 
 import { readFileSync } from "fs";
@@ -23,15 +27,15 @@ import type { OrchestratorConfig } from "../config";
 import { modelFor } from "../config";
 import type { RoundLogger } from "../log/round-logger";
 import {
-  buildTrackerVerdictSchema,
-  TrackerRefusalZ,
-  isTrackerRefusal,
-  type TrackerVerdict,
-  type TrackerRefusal,
-  type TrackerSchemaOpts,
-} from "./tracker-schema";
+  buildSynthesistVerdictSchema,
+  SynthesistRefusalZ,
+  isSynthesistRefusal,
+  type SynthesistVerdict,
+  type SynthesistRefusal,
+  type SynthesistSchemaOpts,
+} from "./synthesist-schema";
 
-export class TrackerValidationError extends Error {
+export class SynthesistValidationError extends Error {
   attempts: number;
   rawResponses: string[];
   zodErrors: ZodError[];
@@ -43,12 +47,12 @@ export class TrackerValidationError extends Error {
   }
 }
 
-export interface TrackerTurnInput {
-  /** Path to the tracker system prompt (relative to experimentRoot). */
+export interface SynthesistTurnInput {
+  /** Path to the synthesist system prompt (relative to experimentRoot or absolute). */
   promptPath: string;
   /** Renders into `## FRAMING`. */
   framing: string;
-  /** Renders into `## TOPOLOGY` — central claim, sub-claims, dependency edges, hinges. */
+  /** Renders into `## TOPOLOGY` — central claim, sub-claims, hinge designations. */
   topologyPrompt: string;
   /** Renders into `## ADVOCATE_A_PHASE_2_ARGUMENTS`. */
   advocateAPhase2Prompt: string;
@@ -58,38 +62,41 @@ export interface TrackerTurnInput {
   advocateAPhase3Prompt: string;
   /** Renders into `## ADVOCATE_B_PHASE_3_ATTACKS_ON_A`. */
   advocateBPhase3Prompt: string;
-  /**
-   * Renders into `## METHODOLOGIST_PHASE_3_ATTACKS`. Empty/undefined →
-   * omit the section (pre-Methodologist deliberations remain valid).
-   */
-  methodologistPhase3Prompt?: string;
   /** Renders into `## ADVOCATE_A_PHASE_4_RESPONSES`. */
   advocateAPhase4Prompt: string;
   /** Renders into `## ADVOCATE_B_PHASE_4_RESPONSES`. */
   advocateBPhase4Prompt: string;
-  /** Renders into `## EVIDENCE_CORPUS`. */
+  /** Renders into `## CONCESSION_TRACKER_VERDICT` — the Phase-4 tracker
+   *  output (argument standings + central-claim verdict + advocate
+   *  summaries). The Synthesist treats this as authoritative input on
+   *  per-argument standings; it is NOT re-litigating standings, it is
+   *  building synthesis on top of them. */
+  trackerVerdictPrompt: string;
+  /** Renders into `## EVIDENCE_CORPUS` — both bound corpus sources and
+   *  web-discovered sources materialized during Phase 2-4. */
   evidenceCorpusPrompt: string;
-  /** Schema-binding parameters (known arguments, attack ids, response ids). */
-  schemaOpts: TrackerSchemaOpts;
+  /** Schema-binding parameters (known argument ids, attack ids, response
+   *  ids, sub-claim count, citation tokens). */
+  schemaOpts: SynthesistSchemaOpts;
   cfg: OrchestratorConfig;
   llm: AnthropicClient;
   logger: RoundLogger;
 }
 
-export interface TrackerTurnResult {
-  response: TrackerVerdict | TrackerRefusal;
+export interface SynthesistTurnResult {
+  response: SynthesistVerdict | SynthesistRefusal;
   rawText: string;
   usage: { inputTokens: number; outputTokens: number };
   attempts: number;
 }
 
-export async function runTrackerTurn(input: TrackerTurnInput): Promise<TrackerTurnResult> {
+export async function runSynthesistTurn(input: SynthesistTurnInput): Promise<SynthesistTurnResult> {
   const promptPath = path.isAbsolute(input.promptPath)
     ? input.promptPath
     : path.join(input.cfg.experimentRoot, input.promptPath);
   const systemPrompt = readFileSync(promptPath, "utf8");
   const model = modelFor(input.cfg);
-  const outputSchema = buildTrackerVerdictSchema(input.schemaOpts);
+  const outputSchema = buildSynthesistVerdictSchema(input.schemaOpts);
 
   const userMessage = renderUserMessage(input);
 
@@ -107,14 +114,17 @@ export async function runTrackerTurn(input: TrackerTurnInput): Promise<TrackerTu
       system: systemPrompt,
       messages,
       model,
-      // Tracker is a judgment task — slightly lower temp than advocates.
-      temperature: 0.2,
-      // Per-arg rationale (≤600) × ~30 args + 2 advocate summaries
-      // (≤400 each) + central rationale (≤1200) + structural overhead
-      // ≈ 24k chars / ~6k tokens. 16k is comfortable headroom.
-      maxTokens: 16000,
+      // Synthesis is a judgment task — slightly higher than tracker (0.2)
+      // because we *want* original framings of cruxes / contributions, but
+      // still constrained.
+      temperature: 0.4,
+      // Up to 20 cruxes × ~600 chars + 25 originalContributions × ~800
+      // chars + 20 agreements × ~500 chars + 20 openQuestions × ~700 chars
+      // + epistemicShift × ~1500 chars ≈ 70k chars / ~18k tokens. 24k is
+      // the budget with overhead.
+      maxTokens: 24000,
       logger: input.logger,
-      agentRole: "tracker",
+      agentRole: "synthesist",
     });
     totalInputTokens += res.usage.inputTokens;
     totalOutputTokens += res.usage.outputTokens;
@@ -126,15 +136,15 @@ export async function runTrackerTurn(input: TrackerTurnInput): Promise<TrackerTu
     } catch (err) {
       const msg = (err as Error).message;
       input.logger.event("agent_validation_failure", {
-        agent: "tracker",
+        agent: "synthesist",
         attempt,
         kind: "json-extract",
-        phase: 4,
+        phase: 5,
         error: msg,
       });
       if (attempt === 3) {
-        throw new TrackerValidationError(
-          `tracker: could not extract JSON after ${attempt} attempts: ${msg}`,
+        throw new SynthesistValidationError(
+          `synthesist: could not extract JSON after ${attempt} attempts: ${msg}`,
           { attempts: attempt, rawResponses, zodErrors },
         );
       }
@@ -145,16 +155,16 @@ export async function runTrackerTurn(input: TrackerTurnInput): Promise<TrackerTu
           `Your last response could not be parsed as JSON: ${msg}\n\n` +
           `Re-emit per the prompt's §4 contract: a single JSON object, optionally inside a \`\`\`json fence, with no prose.`,
       });
-      input.logger.event("agent_retry", { agent: "tracker", attempt: attempt + 1, phase: 4, reason: "json-extract" });
+      input.logger.event("agent_retry", { agent: "synthesist", attempt: attempt + 1, phase: 5, reason: "json-extract" });
       continue;
     }
 
-    const refusalAttempt = TrackerRefusalZ.safeParse(parsed);
+    const refusalAttempt = SynthesistRefusalZ.safeParse(parsed);
     if (refusalAttempt.success) {
       input.logger.event("agent_parsed_output", {
-        agent: "tracker",
+        agent: "synthesist",
         attempt,
-        phase: 4,
+        phase: 5,
         kind: "refusal",
         output: refusalAttempt.data,
       });
@@ -170,14 +180,15 @@ export async function runTrackerTurn(input: TrackerTurnInput): Promise<TrackerTu
     if (validation.success) {
       const v = validation.data;
       input.logger.event("agent_parsed_output", {
-        agent: "tracker",
+        agent: "synthesist",
         attempt,
-        phase: 4,
-        kind: "tracker-verdict",
-        argumentStandingCount: v.argumentStandings.length,
-        verdict: v.centralClaimVerdict.verdict,
-        aSummary: v.advocateSummaries.find((s) => s.advocateRole === "A"),
-        bSummary: v.advocateSummaries.find((s) => s.advocateRole === "B"),
+        phase: 5,
+        kind: "synthesist-verdict",
+        cruxCount: v.cruxes.length,
+        agreementCount: v.agreements.length,
+        originalContributionCount: v.originalContributions.length,
+        openQuestionCount: v.openQuestions.length,
+        netEpistemicValue: v.epistemicShift.netEpistemicValue,
       });
       return {
         response: v,
@@ -189,63 +200,35 @@ export async function runTrackerTurn(input: TrackerTurnInput): Promise<TrackerTu
 
     zodErrors.push(validation.error);
     input.logger.event("agent_validation_failure", {
-      agent: "tracker",
+      agent: "synthesist",
       attempt,
-      phase: 4,
+      phase: 5,
       kind: "zod",
       issues: validation.error.issues,
     });
 
     if (attempt === 3) {
-      throw new TrackerValidationError(
-        `tracker: hard-validation failed after 3 attempts. Last issues:\n${formatZodIssues(validation.error)}`,
+      throw new SynthesistValidationError(
+        `synthesist: hard-validation failed after 3 attempts. Last issues:\n${formatZodIssues(validation.error)}`,
         { attempts: attempt, rawResponses, zodErrors },
       );
     }
     messages.push({ role: "assistant", content: res.text });
     messages.push({ role: "user", content: validationFollowupMessage(validation.error) });
-    input.logger.event("agent_retry", { agent: "tracker", attempt: attempt + 1, phase: 4, reason: "zod" });
+    input.logger.event("agent_retry", { agent: "synthesist", attempt: attempt + 1, phase: 5, reason: "zod" });
   }
 
-  // Unreachable.
-  throw new Error("tracker: unreachable end of retry loop");
+  throw new Error("synthesist: unreachable end of retry loop");
 }
 
-export { isTrackerRefusal };
+export { isSynthesistRefusal };
 
 // ─────────────────────────────────────────────────────────────────
 // Internals
 // ─────────────────────────────────────────────────────────────────
 
-function renderUserMessage(input: TrackerTurnInput): string {
-  // Compute ground-truth counts from schemaOpts.knownArguments so the LLM
-  // can match advocateSummaries totals exactly (off-by-one tally errors are
-  // the leading cause of tracker hard-validation failures).
-  const counts = { A: { total: 0, hinge: 0 }, B: { total: 0, hinge: 0 } } as const;
-  // Recompute (counts is "as const" so mutate via Map iteration into a fresh object).
-  const tally = { A: { total: 0, hinge: 0 }, B: { total: 0, hinge: 0 } };
-  for (const b of input.schemaOpts.knownArguments.values()) {
-    tally[b.advocateRole].total += 1;
-    if (b.isHingeArgument) tally[b.advocateRole].hinge += 1;
-  }
-  void counts;
-  const groundTruthBlock = [
-    "## GROUND_TRUTH_COUNTS",
-    "",
-    "These are the authoritative Phase-2 argument counts. Your `advocateSummaries` MUST match exactly:",
-    "",
-    `- Role A: totalArguments = ${tally.A.total}, hinge arguments = ${tally.A.hinge}`,
-    `- Role B: totalArguments = ${tally.B.total}, hinge arguments = ${tally.B.hinge}`,
-    "",
-    "For each role: `stoodCount + weakenedCount + fallenCount` MUST equal `totalArguments`,",
-    "and `hingeStandings.{stoodCount + weakenedCount + fallenCount}` MUST equal the hinge count above.",
-    "Cross-check: every argumentId in your `argumentStandings` whose `isHingeArgument=true` and `advocateRole=A`",
-    "must contribute to `hingeStandings` for A (same for B). Count carefully — off-by-one errors are the",
-    "single most common failure mode.",
-  ].join("\n");
-  return [
-    groundTruthBlock,
-    "",
+function renderUserMessage(input: SynthesistTurnInput): string {
+  const sections: string[] = [
     "## FRAMING",
     "",
     input.framing.trim(),
@@ -269,14 +252,19 @@ function renderUserMessage(input: TrackerTurnInput): string {
     "## ADVOCATE_B_PHASE_3_ATTACKS_ON_A",
     "",
     input.advocateBPhase3Prompt.trim(),
-    ...((input.methodologistPhase3Prompt ?? "").trim().length > 0
-      ? [
-          "",
-          "## METHODOLOGIST_PHASE_3_ATTACKS",
-          "",
-          input.methodologistPhase3Prompt!.trim(),
-        ]
-      : []),
+  ];
+
+  const methPrompt = (input.methodologistPhase3Prompt ?? "").trim();
+  if (methPrompt.length > 0) {
+    sections.push(
+      "",
+      "## METHODOLOGIST_PHASE_3_ATTACKS",
+      "",
+      methPrompt,
+    );
+  }
+
+  sections.push(
     "",
     "## ADVOCATE_A_PHASE_4_RESPONSES",
     "",
@@ -286,14 +274,20 @@ function renderUserMessage(input: TrackerTurnInput): string {
     "",
     input.advocateBPhase4Prompt.trim(),
     "",
+    "## CONCESSION_TRACKER_VERDICT",
+    "",
+    input.trackerVerdictPrompt.trim(),
+    "",
     "## EVIDENCE_CORPUS",
     "",
     input.evidenceCorpusPrompt.trim(),
     "",
     "## YOUR_TASK",
     "",
-    "You are the Concession Tracker. Produce a TrackerVerdict per §4 of your system prompt. Cite specific argumentIds, premiseIndices, cqKeys, and Phase-4 responseIds when you justify a verdict. Emit a single JSON object only — no prose before, after, or between.",
-  ].join("\n");
+    "You are the Synthesist / Crux-Finder. Per your §4 contract, produce one JSON object characterizing the dialectical state at the END of Phase 4: identified cruxes (with diagnostic status), agreements (including ones the dialectic *revealed* that weren't visible at Phase 1), originalContributions (the originality test from §6), openQuestions (what would actually resolve remaining cruxes), and epistemicShift (a narrative + net rating). Cite specific Phase-2 argumentIds, Phase-3 rebuttalArgumentIds (from advocates AND from the Methodologist when present), and Phase-4 response ids when justifying every claim. Do NOT relitigate the Concession Tracker's per-argument standings — treat them as authoritative input. Emit the JSON object only — no prose before, after, or between.",
+  );
+
+  return sections.join("\n");
 }
 
 function formatZodIssues(err: ZodError): string {
@@ -309,6 +303,6 @@ function validationFollowupMessage(err: ZodError): string {
     "",
     formatZodIssues(err),
     "",
-    "Re-emit the COMPLETE verdict (not a diff) addressing every issue. Same schema, single JSON object, no prose. Recall that every Phase-2 argument from BOTH advocates must appear in `argumentStandings`, and `advocateSummaries` must contain exactly one entry for role A and one for role B with counts that sum correctly.",
+    "Re-emit the COMPLETE verdict (not a diff) addressing every issue. Same schema, single JSON object, no prose. Recall: every id you cite in `keyArgumentIds`, `basisInRecord`, or `contributingIds` must appear in the record (Phase-2 argumentIds, Phase-3 rebuttalArgumentIds, or `phase4-{A|B}-{r|cq}{idx}` response ids). Citation tokens in `evidenceTokens` must be ones some premise actually used. Cross-references between cruxes and openQuestions use array indices, not ids.",
   ].join("\n");
 }

--- a/experiments/polarization-1/orchestrator/agents/tracker-schema.ts
+++ b/experiments/polarization-1/orchestrator/agents/tracker-schema.ts
@@ -135,7 +135,163 @@ export interface TrackerSchemaOpts {
 export function buildTrackerVerdictSchema(opts: TrackerSchemaOpts) {
   const { knownArguments, knownAttackIds, knownPhase4ResponseIds } = opts;
 
-  return TrackerVerdictZ.superRefine((data, ctx) => {
+  // Tolerant pre-normalizer: the tracker LLM is given hard rules in
+  // prompts/8-tracker.md §5 but does not always satisfy them. Rather
+  // than fail the entire run on small bookkeeping mistakes, snap the
+  // most common ones into the valid shape *before* superRefine runs.
+  // The deeper semantic claims (which arguments stand vs fall, what
+  // counts as effective concession, the central-claim verdict text)
+  // are NOT touched — only the mechanical bookkeeping fields.
+  const Normalized = z.preprocess((raw) => {
+    if (!raw || typeof raw !== "object") return raw;
+    const data = raw as any;
+
+    // (a) centralClaimVerdict.rationale length cap (1200 chars).
+    const ccv = data.centralClaimVerdict;
+    if (ccv && typeof ccv.rationale === "string" && ccv.rationale.length > 1200) {
+      ccv.rationale = ccv.rationale.slice(0, 1197) + "...";
+    }
+
+    // (a2) advocateSummaries[*].concessionDiscriminationRationale length
+    // cap (400 chars).
+    if (Array.isArray(data.advocateSummaries)) {
+      for (const sum of data.advocateSummaries) {
+        if (
+          sum &&
+          typeof sum.concessionDiscriminationRationale === "string" &&
+          sum.concessionDiscriminationRationale.length > 400
+        ) {
+          sum.concessionDiscriminationRationale =
+            sum.concessionDiscriminationRationale.slice(0, 397) + "...";
+        }
+      }
+    }
+
+    // (a3) argumentStandings[*].rationale length cap (600 chars).
+    if (Array.isArray(data.argumentStandings)) {
+      for (const s of data.argumentStandings) {
+        if (s && typeof s.rationale === "string" && s.rationale.length > 600) {
+          s.rationale = s.rationale.slice(0, 597) + "...";
+        }
+        if (Array.isArray(s?.successfulDefenses)) {
+          for (const sd of s.successfulDefenses) {
+            if (sd && typeof sd.rationale === "string" && sd.rationale.length > 400) {
+              sd.rationale = sd.rationale.slice(0, 397) + "...";
+            }
+            // Strip trailing parenthetical descriptions from id fields.
+            if (sd && typeof sd.againstAttackId === "string") {
+              sd.againstAttackId = sd.againstAttackId.split(/[\s(]/)[0];
+            }
+            if (sd && typeof sd.drivenBy === "string") {
+              sd.drivenBy = sd.drivenBy.split(/[\s(]/)[0];
+            }
+          }
+        }
+        if (Array.isArray(s?.effectiveConcessions)) {
+          for (const ec of s.effectiveConcessions) {
+            if (ec && typeof ec.drivenBy === "string") {
+              ec.drivenBy = ec.drivenBy.split(/[\s(]/)[0];
+            }
+          }
+        }
+      }
+    }
+
+    // (b) argumentStandings: snap isHingeArgument + advocateRole to
+    // the known binding; drop invalid effectiveConcessions; collect
+    // seen ids so we can backfill missing standings below.
+    const seenIds = new Set<string>();
+    const standings = Array.isArray(data.argumentStandings) ? data.argumentStandings : [];
+    for (const s of standings) {
+      if (!s || typeof s !== "object") continue;
+      const binding = knownArguments.get(s.argumentId);
+      if (binding) {
+        seenIds.add(s.argumentId);
+        if (typeof s.isHingeArgument === "boolean" && s.isHingeArgument !== binding.isHingeArgument) {
+          s.isHingeArgument = binding.isHingeArgument;
+        }
+        if (s.advocateRole !== binding.advocateRole) {
+          s.advocateRole = binding.advocateRole;
+        }
+      }
+      if (Array.isArray(s.effectiveConcessions)) {
+        s.effectiveConcessions = s.effectiveConcessions.filter((ec: any) => {
+          if (!ec || typeof ec !== "object") return false;
+          // Drop kind="cq" entries with no cqKey — the LLM occasionally
+          // emits these when concessions cross-reference rebuttals
+          // without a CQ context. They contain no usable information.
+          if (ec.kind === "cq" && (ec.cqKey === null || ec.cqKey === undefined || ec.cqKey === "")) {
+            return false;
+          }
+          // Drop kind="premise" entries with no premiseIndex (same reason).
+          if (ec.kind === "premise" && (ec.premiseIndex === null || ec.premiseIndex === undefined)) {
+            return false;
+          }
+          return true;
+        });
+      }
+    }
+
+    // (c) Backfill missing standings for any Phase-2 argument the LLM
+    // forgot, defaulting to STANDS (conservative — assumes the argument
+    // survived absent any explicit fall verdict).
+    for (const [argId, binding] of knownArguments.entries()) {
+      if (!seenIds.has(argId)) {
+        standings.push({
+          argumentId: argId,
+          advocateRole: binding.advocateRole,
+          standing: "STANDS",
+          isHingeArgument: binding.isHingeArgument,
+          rationale:
+            "[auto-backfilled] No explicit standing was emitted by the tracker for this argument; defaulting to STANDS in the absence of any recorded effective concession.",
+          effectiveConcessions: [],
+          successfulDefenses: [],
+        });
+      }
+    }
+    data.argumentStandings = standings;
+
+    // (d) advocateSummaries: recompute count fields from argumentStandings
+    // tally and known bindings. Leaves the qualitative fields
+    // (concessionDiscrimination + rationale) untouched.
+    const tally: Record<"A" | "B", { S: number; W: number; F: number; H_S: number; H_W: number; H_F: number }> = {
+      A: { S: 0, W: 0, F: 0, H_S: 0, H_W: 0, H_F: 0 },
+      B: { S: 0, W: 0, F: 0, H_S: 0, H_W: 0, H_F: 0 },
+    };
+    const totals: Record<"A" | "B", number> = { A: 0, B: 0 };
+    const hinges: Record<"A" | "B", number> = { A: 0, B: 0 };
+    for (const b of knownArguments.values()) {
+      totals[b.advocateRole]++;
+      if (b.isHingeArgument) hinges[b.advocateRole]++;
+    }
+    for (const s of standings) {
+      const t = tally[s.advocateRole as "A" | "B"];
+      if (!t) continue;
+      if (s.standing === "STANDS") { t.S++; if (s.isHingeArgument) t.H_S++; }
+      else if (s.standing === "WEAKENED") { t.W++; if (s.isHingeArgument) t.H_W++; }
+      else if (s.standing === "FALLEN") { t.F++; if (s.isHingeArgument) t.H_F++; }
+    }
+    if (Array.isArray(data.advocateSummaries)) {
+      for (const sum of data.advocateSummaries) {
+        if (!sum || typeof sum !== "object") continue;
+        const role = sum.advocateRole as "A" | "B";
+        const t = tally[role];
+        if (!t) continue;
+        sum.totalArguments = totals[role];
+        sum.stoodCount = t.S;
+        sum.weakenedCount = t.W;
+        sum.fallenCount = t.F;
+        if (!sum.hingeStandings || typeof sum.hingeStandings !== "object") sum.hingeStandings = {};
+        sum.hingeStandings.stoodCount = t.H_S;
+        sum.hingeStandings.weakenedCount = t.H_W;
+        sum.hingeStandings.fallenCount = t.H_F;
+      }
+    }
+
+    return data;
+  }, TrackerVerdictZ);
+
+  return Normalized.superRefine((data, ctx) => {
     // 1. Every Phase-2 argument from both advocates appears in argumentStandings.
     const seenArgIds = new Set<string>();
     for (let i = 0; i < data.argumentStandings.length; i++) {

--- a/experiments/polarization-1/orchestrator/finalize/phase-3-finalize.ts
+++ b/experiments/polarization-1/orchestrator/finalize/phase-3-finalize.ts
@@ -26,7 +26,11 @@ import path from "path";
 
 import type { OrchestratorConfig } from "../config";
 import type { IsonomiaClient } from "../isonomia-client";
-import type { Phase3PartialFile, RebuttalRunRecord } from "../phases/phase-3-attacks";
+import type {
+  Phase3PartialFile,
+  RebuttalRunRecord,
+  MethodologistRunRecord,
+} from "../phases/phase-3-attacks";
 import type { ReviewFlag } from "../review/phase-3-checks";
 import { parseReport, reportPathFor } from "../review/report";
 import { prisma } from "@/lib/prismaclient";
@@ -69,6 +73,28 @@ export interface Phase3CompleteAdvocate {
   cqResponses: Phase3CompleteCqResponse[];
 }
 
+/**
+ * Methodologist-specific complete record. Same shape as the advocate
+ * record except every rebuttal and cqResponse carries an explicit
+ * `targetAdvocateRole` ("A" | "B") so downstream phases can route the
+ * Methodologist's attacks to the correct advocate.
+ */
+export interface Phase3CompleteMethodologistRebuttal
+  extends Phase3CompleteRebuttal {
+  targetAdvocateRole: "A" | "B";
+}
+export interface Phase3CompleteMethodologistCqResponse
+  extends Phase3CompleteCqResponse {
+  targetAdvocateRole: "A" | "B";
+}
+export interface Phase3CompleteMethodologist {
+  outcome: "ok";
+  attempts: number;
+  tokenUsage: { inputTokens: number; outputTokens: number };
+  rebuttals: Phase3CompleteMethodologistRebuttal[];
+  cqResponses: Phase3CompleteMethodologistCqResponse[];
+}
+
 export interface Phase3CompleteFile {
   phase: 3;
   status: "complete";
@@ -79,6 +105,10 @@ export interface Phase3CompleteFile {
   hingeIndices: number[];
   cqCatalog: Phase3PartialFile["cqCatalog"];
   advocates: { a: Phase3CompleteAdvocate; b: Phase3CompleteAdvocate };
+  /** Optional Phase-3 third-actor record (cross-side methodological
+   *  critic). Older deliberations finalized before the Methodologist
+   *  was introduced will not have this field. */
+  methodologist?: Phase3CompleteMethodologist;
   totals: Phase3PartialFile["totals"];
   reviewSummary: {
     totalFlags: number;
@@ -124,6 +154,19 @@ export async function finalizePhase3(opts: {
       expectedArgIds.add(r.rebuttalArgumentId);
       expectedEdgeIds.add(r.edgeId);
     }
+  }
+  // Methodologist (optional). If present and ok, audit its mints too.
+  const meth = partial.methodologist;
+  if (meth?.outcome === "ok" && meth.mintResult) {
+    for (const r of meth.mintResult.rebuttals) {
+      expectedArgIds.add(r.rebuttalArgumentId);
+      expectedEdgeIds.add(r.edgeId);
+    }
+  } else if (meth && meth.outcome !== "ok") {
+    throw new Error(
+      `Phase 3 finalize refused: methodologist record present but outcome="${meth.outcome}". ` +
+        `Re-run \`npm run orchestrator -- phase 3 --resume\` to retry the methodologist.`,
+    );
   }
 
   const divergences: string[] = [];
@@ -181,6 +224,8 @@ export async function finalizePhase3(opts: {
       a: buildCompleteAdvocate(a!),
       b: buildCompleteAdvocate(b!),
     },
+    methodologist:
+      meth?.outcome === "ok" ? buildCompleteMethodologist(meth) : undefined,
     totals: partial.totals,
     reviewSummary,
     judgeUsage: partial.judgeUsage,
@@ -288,6 +333,71 @@ function buildCompleteAdvocate(rec: RebuttalRunRecord): Phase3CompleteAdvocate {
       elidedByRebuttalCqKey: m.elidedByRebuttalCqKey,
     };
   });
+
+  return {
+    outcome: "ok",
+    attempts: rec.attempts,
+    tokenUsage: rec.tokenUsage,
+    rebuttals,
+    cqResponses,
+  };
+}
+
+/**
+ * Build the complete-file Methodologist record. Mirrors
+ * `buildCompleteAdvocate` but propagates the per-item `targetAdvocateRole`
+ * field from the LLM output (the translator stripped it; we re-attach
+ * it here from `rec.llmOutput`).
+ */
+function buildCompleteMethodologist(
+  rec: MethodologistRunRecord,
+): Phase3CompleteMethodologist {
+  if (rec.outcome !== "ok" || !rec.mintResult || !rec.llmOutput) {
+    throw new Error(`buildCompleteMethodologist: methodologist not in "ok" state.`);
+  }
+  const inputRebuttals = rec.llmOutput.rebuttals;
+  const inputCqResponses = rec.llmOutput.cqResponses;
+
+  const rebuttals: Phase3CompleteMethodologistRebuttal[] = rec.mintResult.rebuttals.map(
+    (m) => {
+      const orig = inputRebuttals[m.inputIndex];
+      return {
+        inputIndex: m.inputIndex,
+        rebuttalArgumentId: m.rebuttalArgumentId,
+        targetArgumentId: m.targetArgumentId,
+        targetAdvocateRole: orig.targetAdvocateRole,
+        edgeId: m.edgeId,
+        attackType: m.attackType,
+        targetPremiseIndex: m.targetPremiseIndex,
+        targetPremiseClaimId: m.targetPremiseClaimId,
+        schemeKey: m.schemeKey,
+        schemeId: m.schemeId,
+        conclusionClaimId: m.conclusionClaimId,
+        premiseClaimIds: m.premiseClaimIds,
+        premiseTexts: orig.premises.map((p) => p.text),
+        premiseCitationTokens: orig.premises.map((p) => p.citationToken ?? null),
+        warrant: orig.warrant ?? null,
+        cqKey: m.cqKey,
+        conclusionText: orig.conclusionText,
+        citations: m.citations,
+      };
+    },
+  );
+
+  const cqResponses: Phase3CompleteMethodologistCqResponse[] =
+    rec.mintResult.cqResponses.map((m) => {
+      const orig = inputCqResponses[m.inputIndex];
+      return {
+        inputIndex: m.inputIndex,
+        targetArgumentId: m.targetArgumentId,
+        targetAdvocateRole: orig.targetAdvocateRole,
+        cqKey: m.cqKey,
+        action: m.action,
+        rationale: orig.rationale,
+        cqStatusId: m.cqStatusId,
+        elidedByRebuttalCqKey: m.elidedByRebuttalCqKey,
+      };
+    });
 
   return {
     outcome: "ok",

--- a/experiments/polarization-1/orchestrator/finalize/phase-5-finalize.ts
+++ b/experiments/polarization-1/orchestrator/finalize/phase-5-finalize.ts
@@ -1,0 +1,234 @@
+/**
+ * orchestrator/finalize/phase-5-finalize.ts
+ *
+ * Validates `PHASE_5_PARTIAL.json`, then writes `PHASE_5_COMPLETE.json`
+ * and a human-readable `SYNTHESIS.md` rendered from the verdict.
+ *
+ * Phase 5 is read-only on the platform — there's no claim/edge audit to
+ * perform. Validation just gates on `synthesist.outcome === "ok"`. If the
+ * Synthesist refused or hit a validation error, finalize refuses and the
+ * operator can inspect `runtime/refusals/phase-5-synthesist-refusal.json`
+ * (refused) or rerun phase 5 (validation-error).
+ *
+ * There is no review-flag pattern for Phase 5 — the Synthesist's output
+ * is fully validated by the Zod schema; nothing requires human flagging
+ * the way advocate / rebuttal / defense outputs do.
+ */
+
+import { existsSync, readFileSync, writeFileSync, mkdirSync } from "fs";
+import path from "path";
+
+import type { OrchestratorConfig } from "../config";
+import type { IsonomiaClient } from "../isonomia-client";
+import type {
+  Phase5PartialFile,
+  SynthesistRunRecord,
+} from "../phases/phase-5-synthesis";
+import type { SynthesistVerdict } from "../agents/synthesist-schema";
+
+// ─────────────────────────────────────────────────────────────────
+// Public types
+// ─────────────────────────────────────────────────────────────────
+
+export interface Phase5CompleteFile {
+  phase: 5;
+  status: "complete";
+  completedAt: string;
+  deliberationId: string;
+  modelTier: string;
+  evidenceStackId: string;
+  hingeIndices: number[];
+  synthesist: SynthesistRunRecord;
+  /** Path to the rendered human-readable synthesis report. */
+  synthesisReportPath: string;
+}
+
+// ─────────────────────────────────────────────────────────────────
+// Entry point
+// ─────────────────────────────────────────────────────────────────
+
+export async function finalizePhase5(opts: {
+  cfg: OrchestratorConfig;
+  iso: IsonomiaClient;
+}): Promise<Phase5CompleteFile> {
+  // iso is unused (Phase 5 is read-only) but kept for signature parity
+  // with finalizePhase{1..4}.
+  void opts.iso;
+
+  const partialPath = path.join(opts.cfg.runtimeDir, "PHASE_5_PARTIAL.json");
+  if (!existsSync(partialPath)) {
+    throw new Error(`PHASE_5_PARTIAL.json not found. Run \`npm run orchestrator -- phase 5\` first.`);
+  }
+  const partial = JSON.parse(readFileSync(partialPath, "utf8")) as Phase5PartialFile;
+
+  if (partial.synthesist.outcome !== "ok" || !partial.synthesist.verdict) {
+    const detail =
+      partial.synthesist.outcome === "refused"
+        ? `Synthesist refused (${partial.synthesist.refusal?.error}). See ${partial.synthesist.refusalPath}.`
+        : partial.synthesist.outcome === "validation-error"
+          ? `Synthesist exhausted retries (${partial.synthesist.attempts} attempts). Inspect logs at ${partial.synthesist.artifacts.roundLogPath} and re-run phase 5.`
+          : `Synthesist outcome="${partial.synthesist.outcome}".`;
+    throw new Error(`Phase 5 finalize blocked: ${detail}`);
+  }
+
+  // Render the human-readable report.
+  const synthesisReportPath = path.join(opts.cfg.runtimeDir, "SYNTHESIS.md");
+  const md = renderSynthesisMarkdown(partial.synthesist.verdict, {
+    deliberationId: partial.deliberationId,
+    modelTier: partial.modelTier,
+    completedAt: new Date().toISOString(),
+  });
+  mkdirSync(path.dirname(synthesisReportPath), { recursive: true });
+  writeFileSync(synthesisReportPath, md);
+
+  const complete: Phase5CompleteFile = {
+    phase: 5,
+    status: "complete",
+    completedAt: new Date().toISOString(),
+    deliberationId: partial.deliberationId,
+    modelTier: partial.modelTier,
+    evidenceStackId: partial.evidenceStackId,
+    hingeIndices: partial.hingeIndices,
+    synthesist: partial.synthesist,
+    synthesisReportPath,
+  };
+
+  const completePath = path.join(opts.cfg.runtimeDir, "PHASE_5_COMPLETE.json");
+  writeFileSync(completePath, JSON.stringify(complete, null, 2));
+  return complete;
+}
+
+// ─────────────────────────────────────────────────────────────────
+// Markdown renderer
+// ─────────────────────────────────────────────────────────────────
+
+function renderSynthesisMarkdown(
+  v: SynthesistVerdict,
+  meta: { deliberationId: string; modelTier: string; completedAt: string },
+): string {
+  const lines: string[] = [];
+  lines.push(`# Deliberation Synthesis`);
+  lines.push(``);
+  lines.push(`- **Deliberation:** \`${meta.deliberationId}\``);
+  lines.push(`- **Model tier:** ${meta.modelTier}`);
+  lines.push(`- **Generated:** ${meta.completedAt}`);
+  lines.push(``);
+  lines.push(`---`);
+  lines.push(``);
+
+  // ── Net rating up top.
+  lines.push(`## Net epistemic value: \`${v.epistemicShift.netEpistemicValue}\``);
+  lines.push(``);
+  lines.push(`> ${v.epistemicShift.netEpistemicValueRationale}`);
+  lines.push(``);
+  lines.push(`### How the central claim moved`);
+  lines.push(``);
+  lines.push(v.epistemicShift.centralClaimMovementSummary);
+  lines.push(``);
+  lines.push(`---`);
+  lines.push(``);
+
+  // ── Cruxes.
+  lines.push(`## Cruxes (${v.cruxes.length})`);
+  lines.push(``);
+  for (let i = 0; i < v.cruxes.length; i++) {
+    const c = v.cruxes[i];
+    lines.push(`### ${i}. ${c.label}  \`[${c.status}]\``);
+    if (c.subClaimIndex !== null) {
+      lines.push(`*Sub-claim #${c.subClaimIndex}*`);
+    } else {
+      lines.push(`*Cuts across multiple sub-claims.*`);
+    }
+    lines.push(``);
+    lines.push(`- **A maintains:** ${c.advocateAClaim}`);
+    lines.push(`- **B maintains:** ${c.advocateBClaim}`);
+    lines.push(``);
+    lines.push(`**Why they disagree:** ${c.whyTheyDisagree}`);
+    lines.push(``);
+    if (c.keyArgumentIds.length) {
+      lines.push(`*Key ids:* \`${c.keyArgumentIds.join("`, `")}\``);
+    }
+    if (c.resolvedByOpenQuestions.length) {
+      lines.push(
+        `*Open questions that would resolve:* ${c.resolvedByOpenQuestions
+          .map((idx) => `[#${idx}](#open-question-${idx})`)
+          .join(", ")}`,
+      );
+    }
+    lines.push(``);
+  }
+  lines.push(`---`);
+  lines.push(``);
+
+  // ── Agreements.
+  lines.push(`## Agreements (${v.agreements.length})`);
+  lines.push(``);
+  if (v.agreements.length === 0) {
+    lines.push(`*No agreements identified.*`);
+    lines.push(``);
+  }
+  for (let i = 0; i < v.agreements.length; i++) {
+    const a = v.agreements[i];
+    lines.push(`### ${i}. ${a.label}  \`[${a.origin}]\``);
+    lines.push(``);
+    lines.push(a.proposition);
+    lines.push(``);
+    if (a.basisInRecord.length) {
+      lines.push(`*Basis:* \`${a.basisInRecord.join("`, `")}\``);
+    }
+    lines.push(``);
+  }
+  lines.push(`---`);
+  lines.push(``);
+
+  // ── Original contributions.
+  lines.push(`## Original contributions (${v.originalContributions.length})`);
+  lines.push(``);
+  if (v.originalContributions.length === 0) {
+    lines.push(`*No original contributions identified.*`);
+    lines.push(``);
+  }
+  for (let i = 0; i < v.originalContributions.length; i++) {
+    const o = v.originalContributions[i];
+    lines.push(`### ${i}. ${o.label}  \`[${o.type}]\`  *— ${o.attribution}*`);
+    lines.push(``);
+    lines.push(o.description);
+    lines.push(``);
+    lines.push(`**Novelty:** ${o.noveltyJustification}`);
+    lines.push(``);
+    if (o.contributingIds.length) {
+      lines.push(`*Contributing ids:* \`${o.contributingIds.join("`, `")}\``);
+    }
+    if (o.evidenceTokens.length) {
+      lines.push(`*Evidence:* \`${o.evidenceTokens.join("`, `")}\``);
+    }
+    lines.push(``);
+  }
+  lines.push(`---`);
+  lines.push(``);
+
+  // ── Open questions.
+  lines.push(`## Open questions (${v.openQuestions.length})`);
+  lines.push(``);
+  if (v.openQuestions.length === 0) {
+    lines.push(`*No open questions identified.*`);
+    lines.push(``);
+  }
+  for (let i = 0; i < v.openQuestions.length; i++) {
+    const q = v.openQuestions[i];
+    lines.push(`### ${i}. <a id="open-question-${i}"></a>  \`[${q.resolutionType}]\``);
+    lines.push(``);
+    lines.push(`**Q:** ${q.question}`);
+    lines.push(``);
+    lines.push(`**How it resolves:** ${q.resolutionSketch}`);
+    lines.push(``);
+    if (q.resolvesCruxIndices.length) {
+      lines.push(
+        `*Resolves cruxes:* ${q.resolvesCruxIndices.map((idx) => `#${idx}`).join(", ")}`,
+      );
+    }
+    lines.push(``);
+  }
+
+  return lines.join("\n");
+}

--- a/experiments/polarization-1/orchestrator/index.ts
+++ b/experiments/polarization-1/orchestrator/index.ts
@@ -40,6 +40,7 @@ import { finalizePhase1 } from "./finalize/phase-1-finalize";
 import { finalizePhase2 } from "./finalize/phase-2-finalize";
 import { finalizePhase3 } from "./finalize/phase-3-finalize";
 import { finalizePhase4 } from "./finalize/phase-4-finalize";
+import { finalizePhase5 } from "./finalize/phase-5-finalize";
 import { setupDeliberation } from "./setup/setup-deliberation";
 import {
   EXPERIMENT_SCHEME_KEYS,
@@ -324,6 +325,7 @@ function phaseNameFor(n: number): string {
     case 2: return "phase-2-arguments";
     case 3: return "phase-3-attacks";
     case 4: return "phase-4-defenses";
+    case 5: return "phase-5-synthesis";
     default: throw new Error(`Unknown phase ${n}`);
   }
 }
@@ -379,7 +381,7 @@ async function cmdReview(args: ParsedArgs) {
   const tier = (args.flags["model-tier"] as ModelTier) || "dev";
   const root = args.flags["experiment-root"] as string | undefined;
   const phase = Number(args.flags["phase"] ?? 1);
-  if (phase !== 1 && phase !== 2 && phase !== 3 && phase !== 4) throw new Error(`review supports phase 1, 2, 3, or 4; got ${phase}`);
+  if (phase !== 1 && phase !== 2 && phase !== 3 && phase !== 4) throw new Error(`review supports phase 1, 2, 3, or 4 (Phase 5 has no review-flag step — its output is fully validated by the Synthesist Zod schema); got ${phase}`);
 
   const cfg = loadConfig({ modelTier: tier, experimentRoot: root });
   const partialPath = `${cfg.runtimeDir}/PHASE_${phase}_PARTIAL.json`;
@@ -424,7 +426,7 @@ async function cmdFinalize(args: ParsedArgs) {
   const tier = (args.flags["model-tier"] as ModelTier) || "dev";
   const root = args.flags["experiment-root"] as string | undefined;
   const phase = Number(args.flags["phase"] ?? 1);
-  if (phase !== 1 && phase !== 2 && phase !== 3 && phase !== 4) throw new Error(`finalize supports phase 1, 2, 3, or 4; got ${phase}`);
+  if (phase !== 1 && phase !== 2 && phase !== 3 && phase !== 4 && phase !== 5) throw new Error(`finalize supports phase 1, 2, 3, 4, or 5; got ${phase}`);
 
   const cfg = loadConfig({ modelTier: tier, experimentRoot: root });
   const iso = new IsonomiaClient(cfg);
@@ -434,7 +436,9 @@ async function cmdFinalize(args: ParsedArgs) {
       ? await finalizePhase2({ cfg, iso })
       : phase === 3
         ? await finalizePhase3({ cfg, iso })
-        : await finalizePhase4({ cfg, iso });
+        : phase === 4
+          ? await finalizePhase4({ cfg, iso })
+          : await finalizePhase5({ cfg, iso });
   process.stdout.write(JSON.stringify(complete, null, 2) + "\n");
 }
 

--- a/experiments/polarization-1/orchestrator/phases/phase-3-attacks.ts
+++ b/experiments/polarization-1/orchestrator/phases/phase-3-attacks.ts
@@ -54,6 +54,16 @@ import type {
   RebuttalRefusal,
   OpposingArgumentBinding,
 } from "../agents/rebuttal-schema";
+import {
+  runMethodologistTurn,
+  isMethodologistRefusal,
+  MethodologistValidationError,
+  METHODOLOGIST_AGENT_ROLE,
+} from "../agents/methodologist";
+import type {
+  MethodologistOutput,
+  MethodologistRefusal,
+} from "../agents/methodologist-schema";
 import type { ExperimentSchemeKey } from "../scheme-catalog";
 import { isAllowedSchemeKey } from "../scheme-catalog";
 import {
@@ -105,6 +115,29 @@ export interface RebuttalRunRecord {
   };
 }
 
+/**
+ * Methodologist runs once per Phase-3 round, as a third actor after
+ * advocates A and B. Same outcome shape as RebuttalRunRecord but typed
+ * to the Methodologist's output/refusal shapes; the mint result is the
+ * same `AttackMintResult` because we reuse `translateRebuttalOutput`.
+ */
+export interface MethodologistRunRecord {
+  role: typeof METHODOLOGIST_AGENT_ROLE;
+  outcome: "ok" | "refused" | "validation-error";
+  attempts: number;
+  tokenUsage: { inputTokens: number; outputTokens: number };
+  llmOutput?: MethodologistOutput;
+  mintResult?: AttackMintResult;
+  refusal?: MethodologistRefusal;
+  refusalPath?: string;
+  validationError?: { message: string; rawResponsesCount: number };
+  artifacts: {
+    promptPath: string;
+    llmOutputPath?: string;
+    roundLogPath: string;
+  };
+}
+
 export interface Phase3PartialFile {
   phase: 3;
   status: "partial";
@@ -117,6 +150,9 @@ export interface Phase3PartialFile {
   /** Subset of CriticalQuestion catalog keyed by schemeId, frozen at run time. */
   cqCatalog: Record<string, { schemeKey: string; cqKeys: string[] }>;
   advocates: { a?: RebuttalRunRecord; b?: RebuttalRunRecord };
+  /** Phase-3 third-actor record (cross-side methodological critic).
+   *  Optional: pre-Methodologist runs and partials remain valid. */
+  methodologist?: MethodologistRunRecord;
   totals: {
     rebuttalsCreated: number;
     edgesCreated: number;
@@ -226,7 +262,7 @@ export async function runPhase(opts: RunPhase3Opts): Promise<Phase3PartialFile> 
     });
   })();
 
-  if (advocatesToRun.length === 0) {
+  if (advocatesToRun.length === 0 && (priorPartial?.methodologist?.outcome === "ok" || opts.onlyAdvocate)) {
     phaseLogger.event("phase_complete", {
       phase: 3,
       outcome: "already-complete",
@@ -243,6 +279,8 @@ export async function runPhase(opts: RunPhase3Opts): Promise<Phase3PartialFile> 
     a: priorPartial?.advocates.a,
     b: priorPartial?.advocates.b,
   };
+  let methodologistResult: MethodologistRunRecord | undefined =
+    priorPartial?.methodologist;
 
   for (const role of advocatesToRun) {
     const opponentKey = role === "advocate-a" ? "a" : "b";
@@ -268,7 +306,51 @@ export async function runPhase(opts: RunPhase3Opts): Promise<Phase3PartialFile> 
     if (role === "advocate-a") results.a = rec;
     else results.b = rec;
 
-    writePartial(partialPath, opts, ec.stack.id, phase2.topologyBinding.hingeIndices, cqCatalogForFile, results, [], undefined);
+    writePartial(partialPath, opts, ec.stack.id, phase2.topologyBinding.hingeIndices, cqCatalogForFile, results, methodologistResult, [], undefined);
+  }
+
+  // 8b. Run the Methodologist (third actor) iff both advocates have ok
+  //     outcomes and (resume) the methodologist hasn't already run.
+  //     `onlyAdvocate` scopes the run to that advocate only — skip the
+  //     methodologist in that case.
+  const methodologistShouldRun =
+    !opts.onlyAdvocate &&
+    results.a?.outcome === "ok" &&
+    results.b?.outcome === "ok" &&
+    methodologistResult?.outcome !== "ok";
+
+  if (methodologistShouldRun) {
+    const methBindings = buildMethodologistBindings(
+      phase2.advocates.a,
+      phase2.advocates.b,
+      phase2.topologyBinding.layerByIndex,
+    );
+    const methPrompt = renderMethodologistPhase2Block(
+      phase2.advocates.a,
+      phase2.advocates.b,
+      cqCatalogByScheme,
+      phase2.topologyBinding.layerByIndex,
+      phase2.indexToText,
+    );
+    methodologistResult = await runMethodologist({
+      cfg: opts.cfg,
+      iso: opts.iso,
+      llm: opts.llm,
+      deliberationId: opts.deliberationId,
+      framing: framing.full,
+      phase2ArgumentsPrompt: methPrompt,
+      evidenceCorpusPrompt,
+      opposingArguments: methBindings,
+      cqKeysByScheme: cqCatalogByScheme,
+      allowedCitationTokens,
+      tokenToSourceId,
+      registry,
+      opposingArgumentSchemeByArgId: buildMethodologistSchemeMap(methBindings),
+      opposingArgumentPremisesByArgId: buildMethodologistPremiseMap(phase2.advocates.a, phase2.advocates.b),
+      opposingArgumentConclusionByArgId: buildMethodologistConclusionMap(phase2.advocates.a, phase2.advocates.b),
+      schemeCatalog,
+    });
+    writePartial(partialPath, opts, ec.stack.id, phase2.topologyBinding.hingeIndices, cqCatalogForFile, results, methodologistResult, [], undefined);
   }
 
   // 9. Soft-track review.
@@ -312,6 +394,7 @@ export async function runPhase(opts: RunPhase3Opts): Promise<Phase3PartialFile> 
     phase2.topologyBinding.hingeIndices,
     cqCatalogForFile,
     results,
+    methodologistResult,
     review.flags,
     review.judgeUsage.calls > 0 ? review.judgeUsage : undefined,
   );
@@ -686,10 +769,11 @@ function writePartial(
   hingeIndices: number[],
   cqCatalog: Phase3PartialFile["cqCatalog"],
   results: { a?: RebuttalRunRecord; b?: RebuttalRunRecord },
+  methodologist: MethodologistRunRecord | undefined,
   reviewFlags: ReviewFlag[],
   judgeUsage: { calls: number; inputTokens: number; outputTokens: number } | undefined,
 ): Phase3PartialFile {
-  const totals = aggregateTotals(results);
+  const totals = aggregateTotals(results, methodologist);
   const partial: Phase3PartialFile = {
     phase: 3,
     status: "partial",
@@ -700,6 +784,7 @@ function writePartial(
     hingeIndices,
     cqCatalog,
     advocates: results,
+    methodologist,
     totals,
     reviewFlags,
     judgeUsage,
@@ -709,10 +794,10 @@ function writePartial(
   return partial;
 }
 
-function aggregateTotals(results: {
-  a?: RebuttalRunRecord;
-  b?: RebuttalRunRecord;
-}): Phase3PartialFile["totals"] {
+function aggregateTotals(
+  results: { a?: RebuttalRunRecord; b?: RebuttalRunRecord },
+  methodologist: MethodologistRunRecord | undefined,
+): Phase3PartialFile["totals"] {
   let rebuttalsCreated = 0;
   let edgesCreated = 0;
   let cqStatusesUpserted = 0;
@@ -721,7 +806,7 @@ function aggregateTotals(results: {
   let citationsAttached = 0;
   let inputTokens = 0;
   let outputTokens = 0;
-  for (const rec of [results.a, results.b]) {
+  for (const rec of [results.a, results.b, methodologist]) {
     if (!rec) continue;
     inputTokens += rec.tokenUsage.inputTokens;
     outputTokens += rec.tokenUsage.outputTokens;
@@ -750,3 +835,287 @@ export class BothAdvocatesRefusedError extends Error {
   partial?: Phase3PartialFile;
   exitCode = 2;
 }
+
+// ─────────────────────────────────────────────────────────────────
+// Methodologist (third actor)
+// ─────────────────────────────────────────────────────────────────
+
+interface MethodologistOpposingArgumentBinding extends OpposingArgumentBinding {
+  advocateRole: "A" | "B";
+}
+
+interface RunMethodologistOpts {
+  cfg: OrchestratorConfig;
+  iso: IsonomiaClient;
+  llm: AnthropicClient;
+  deliberationId: string;
+  framing: string;
+  phase2ArgumentsPrompt: string;
+  evidenceCorpusPrompt: string;
+  opposingArguments: ReadonlyMap<string, MethodologistOpposingArgumentBinding>;
+  cqKeysByScheme: ReadonlyMap<ExperimentSchemeKey, ReadonlySet<string>>;
+  allowedCitationTokens: Set<string>;
+  tokenToSourceId: Record<string, string>;
+  registry: ClaimRegistry;
+  opposingArgumentSchemeByArgId: ReadonlyMap<string, string>;
+  opposingArgumentPremisesByArgId: ReadonlyMap<string, readonly string[]>;
+  opposingArgumentConclusionByArgId: ReadonlyMap<string, string>;
+  schemeCatalog: Array<{ id: string; key: string }>;
+}
+
+async function runMethodologist(
+  opts: RunMethodologistOpts,
+): Promise<MethodologistRunRecord> {
+  const round = 3; // round 3 within Phase 3 — A=1, B=2, M=3
+  const logger = RoundLogger.forRound({
+    runtimeDir: opts.cfg.runtimeDir,
+    phase: 3,
+    round,
+    agentRole: METHODOLOGIST_AGENT_ROLE,
+  });
+
+  const promptRel = "prompts/10-methodologist.md";
+  const promptPath = path.join(opts.cfg.experimentRoot, promptRel);
+  const llmDir = path.join(opts.cfg.runtimeDir, PHASE_3_LLM_DIR);
+  const llmOutputPath = path.join(llmDir, `phase-3-methodologist-output.json`);
+  const roundLogPath = path.join(
+    opts.cfg.runtimeDir,
+    "logs",
+    `round-3-${round}-methodologist.jsonl`,
+  );
+  const baseArtifacts = { promptPath, roundLogPath };
+
+  let turn;
+  try {
+    turn = await runMethodologistTurn({
+      promptPath,
+      framing: opts.framing,
+      phase2ArgumentsPrompt: opts.phase2ArgumentsPrompt,
+      evidenceCorpusPrompt: opts.evidenceCorpusPrompt,
+      schemaOpts: {
+        opposingArguments: opts.opposingArguments,
+        cqKeysByScheme: opts.cqKeysByScheme,
+        allowedCitationTokens: opts.allowedCitationTokens,
+      },
+      cfg: opts.cfg,
+      llm: opts.llm,
+      logger,
+    });
+  } catch (err) {
+    if (err instanceof MethodologistValidationError) {
+      logger.event("phase_complete", {
+        phase: 3,
+        round,
+        agent: METHODOLOGIST_AGENT_ROLE,
+        outcome: "validation-error",
+        attempts: err.attempts,
+      });
+      return {
+        role: METHODOLOGIST_AGENT_ROLE,
+        outcome: "validation-error",
+        attempts: err.attempts,
+        tokenUsage: { inputTokens: 0, outputTokens: 0 },
+        validationError: {
+          message: err.message,
+          rawResponsesCount: err.rawResponses.length,
+        },
+        artifacts: baseArtifacts,
+      };
+    }
+    throw err;
+  }
+
+  if (isMethodologistRefusal(turn.response)) {
+    const refusalPath = path.join(
+      opts.cfg.runtimeDir,
+      REFUSALS_DIR,
+      `phase-3-methodologist-refusal.json`,
+    );
+    mkdirSync(path.dirname(refusalPath), { recursive: true });
+    writeFileSync(refusalPath, JSON.stringify(turn.response, null, 2));
+    logger.event("phase_complete", {
+      phase: 3,
+      round,
+      agent: METHODOLOGIST_AGENT_ROLE,
+      outcome: "refused",
+      reason: turn.response.error,
+      refusalPath,
+    });
+    return {
+      role: METHODOLOGIST_AGENT_ROLE,
+      outcome: "refused",
+      attempts: turn.attempts,
+      tokenUsage: turn.usage,
+      refusal: turn.response,
+      refusalPath,
+      artifacts: baseArtifacts,
+    };
+  }
+
+  mkdirSync(llmDir, { recursive: true });
+  writeFileSync(llmOutputPath, JSON.stringify(turn.response, null, 2));
+
+  // The translator only consumes `rebuttals`, `cqResponses`, and
+  // `webCitations` — all three are structurally identical between
+  // RebuttalOutput and MethodologistOutput (Methodologist's per-item
+  // `targetAdvocateRole` field is extra and ignored). We cast to
+  // RebuttalOutput at the boundary to satisfy the translator's static
+  // type without altering its parameterization.
+  const mintResult = await translateRebuttalOutput({
+    output: turn.response as unknown as RebuttalOutput,
+    deliberationId: opts.deliberationId,
+    iso: opts.iso,
+    logger,
+    cfg: opts.cfg,
+    tokenToSourceId: opts.tokenToSourceId,
+    registry: opts.registry,
+    authorRole: METHODOLOGIST_AGENT_ROLE,
+    opposingArgumentSchemeByArgId: opts.opposingArgumentSchemeByArgId,
+    opposingArgumentPremisesByArgId: opts.opposingArgumentPremisesByArgId,
+    opposingArgumentConclusionByArgId: opts.opposingArgumentConclusionByArgId,
+    schemeCatalog: opts.schemeCatalog,
+    stackId: opts.cfg.deliberation.evidenceStackId ?? null,
+  });
+
+  logger.event("phase_complete", {
+    phase: 3,
+    round,
+    agent: METHODOLOGIST_AGENT_ROLE,
+    outcome: "ok",
+    rebuttalsCreated: mintResult.totals.rebuttalsCreated,
+    edgesCreated: mintResult.totals.edgesCreated,
+    cqStatusesUpserted: mintResult.totals.cqStatusesUpserted,
+  });
+
+  return {
+    role: METHODOLOGIST_AGENT_ROLE,
+    outcome: "ok",
+    attempts: turn.attempts,
+    tokenUsage: turn.usage,
+    llmOutput: turn.response,
+    mintResult,
+    artifacts: { ...baseArtifacts, llmOutputPath },
+  };
+}
+
+// ─────────────────────────────────────────────────────────────────
+// Methodologist helpers — unified bindings + prompt rendering
+// ─────────────────────────────────────────────────────────────────
+
+function buildMethodologistBindings(
+  a: Phase2CompleteAdvocate,
+  b: Phase2CompleteAdvocate,
+  layerByIndex: Record<number, AdvocateLayer>,
+): Map<string, MethodologistOpposingArgumentBinding> {
+  const m = new Map<string, MethodologistOpposingArgumentBinding>();
+  for (const arg of a.arguments) {
+    if (!isAllowedSchemeKey(arg.schemeKey)) continue;
+    const layer = layerByIndex[arg.conclusionClaimIndex] ?? "empirical";
+    m.set(arg.argumentId, {
+      argumentId: arg.argumentId,
+      schemeKey: arg.schemeKey as ExperimentSchemeKey,
+      premiseCount: arg.premiseClaimIds.length,
+      conclusionLayer: layer,
+      advocateRole: "A",
+    });
+  }
+  for (const arg of b.arguments) {
+    if (!isAllowedSchemeKey(arg.schemeKey)) continue;
+    const layer = layerByIndex[arg.conclusionClaimIndex] ?? "empirical";
+    m.set(arg.argumentId, {
+      argumentId: arg.argumentId,
+      schemeKey: arg.schemeKey as ExperimentSchemeKey,
+      premiseCount: arg.premiseClaimIds.length,
+      conclusionLayer: layer,
+      advocateRole: "B",
+    });
+  }
+  return m;
+}
+
+function buildMethodologistSchemeMap(
+  bindings: ReadonlyMap<string, MethodologistOpposingArgumentBinding>,
+): Map<string, string> {
+  const m = new Map<string, string>();
+  for (const [argId, b] of bindings) m.set(argId, b.schemeKey);
+  return m;
+}
+
+function buildMethodologistPremiseMap(
+  a: Phase2CompleteAdvocate,
+  b: Phase2CompleteAdvocate,
+): Map<string, readonly string[]> {
+  const m = new Map<string, readonly string[]>();
+  for (const arg of a.arguments) m.set(arg.argumentId, arg.premiseClaimIds);
+  for (const arg of b.arguments) m.set(arg.argumentId, arg.premiseClaimIds);
+  return m;
+}
+
+function buildMethodologistConclusionMap(
+  a: Phase2CompleteAdvocate,
+  b: Phase2CompleteAdvocate,
+): Map<string, string> {
+  const m = new Map<string, string>();
+  for (const arg of a.arguments) m.set(arg.argumentId, arg.conclusionClaimId);
+  for (const arg of b.arguments) m.set(arg.argumentId, arg.conclusionClaimId);
+  return m;
+}
+
+/**
+ * Render the PHASE_2_ARGUMENTS prompt block — both advocates' arguments
+ * grouped by side (A first, then B), one block per argument with side
+ * label, premises (0-indexed for UNDERMINE.targetPremiseIndex), warrant,
+ * and inline CQ catalog. Mirrors `renderOpponentArguments` but covers
+ * BOTH sides and tags each ARG line with `side=A|B` so the Methodologist
+ * can populate `targetAdvocateRole` correctly.
+ */
+function renderMethodologistPhase2Block(
+  a: Phase2CompleteAdvocate,
+  b: Phase2CompleteAdvocate,
+  cqCatalog: ReadonlyMap<ExperimentSchemeKey, ReadonlySet<string>>,
+  layerByIndex: Record<number, AdvocateLayer>,
+  indexToText: Record<number, string>,
+): string {
+  const sections: string[] = [];
+  for (const [side, advocate] of [["A", a], ["B", b]] as const) {
+    const lines: string[] = [`### Advocate ${side}`, ``];
+    for (const arg of advocate.arguments) {
+      const layer = layerByIndex[arg.conclusionClaimIndex] ?? "empirical";
+      const subClaimText =
+        indexToText[arg.conclusionClaimIndex] ?? "(text unavailable)";
+      lines.push(
+        `ARG ${arg.argumentId}  side=${side}  scheme=${arg.schemeKey}  layer=${layer}`,
+      );
+      lines.push(
+        `  concludes-to: sub-claim #${arg.conclusionClaimIndex} "${subClaimText}"`,
+      );
+      lines.push(`  premises (0-indexed):`);
+      for (let i = 0; i < arg.premiseTexts.length; i++) {
+        const tok = arg.premiseCitationTokens[i];
+        lines.push(`    [${i}] "${arg.premiseTexts[i]}"  cite=${tok ?? "null"}`);
+      }
+      lines.push(`  warrant: ${arg.warrant ? `"${arg.warrant}"` : "null"}`);
+      const cqKeys = isAllowedSchemeKey(arg.schemeKey)
+        ? cqCatalog.get(arg.schemeKey as ExperimentSchemeKey)
+        : undefined;
+      if (cqKeys && cqKeys.size > 0) {
+        lines.push(`  critical-questions for scheme=${arg.schemeKey}:`);
+        for (const cq of [...cqKeys].sort()) {
+          lines.push(`    ${cq}: (see CriticalQuestion catalog)`);
+        }
+      } else {
+        lines.push(
+          `  critical-questions: (none registered for ${arg.schemeKey})`,
+        );
+      }
+      lines.push(``);
+    }
+    if (advocate.arguments.length === 0) {
+      lines.push(`(No arguments — nothing to attack on this side.)`, ``);
+    }
+    sections.push(lines.join("\n"));
+  }
+  return sections.join("\n\n");
+}
+
+export { runMethodologist as _runMethodologistForTesting };

--- a/experiments/polarization-1/orchestrator/phases/phase-4-defenses.ts
+++ b/experiments/polarization-1/orchestrator/phases/phase-4-defenses.ts
@@ -89,6 +89,9 @@ import type {
   Phase3CompleteAdvocate,
   Phase3CompleteRebuttal,
   Phase3CompleteCqResponse,
+  Phase3CompleteMethodologist,
+  Phase3CompleteMethodologistRebuttal,
+  Phase3CompleteMethodologistCqResponse,
 } from "../finalize/phase-3-finalize";
 
 // ─────────────────────────────────────────────────────────────────
@@ -219,6 +222,20 @@ export async function runPhase(opts: RunPhase4Opts): Promise<Phase4PartialFile> 
     "advocate-b": buildOpposingCqRaiseBindings(phase3.advocates.a, ownArgsByRole["advocate-b"]),
   } as const;
 
+  // Methodologist attacks (optional; pre-Methodologist deliberations have
+  // no methodologist record). Filter by targetAdvocateRole and merge into
+  // each advocate's opposing-rebuttal/CQ-raise maps so the validator
+  // accepts defense responses targeting them.
+  const methodologistAttacksByRole = buildMethodologistAttacksByRole(
+    phase3.methodologist,
+    ownArgsByRole,
+  );
+  for (const role of ["advocate-a", "advocate-b"] as const) {
+    const m = methodologistAttacksByRole[role];
+    for (const [id, b] of m.rebuttals) opposingRebuttalsByRole[role].set(id, b);
+    for (const [id, b] of m.cqRaises) opposingCqRaisesByRole[role].set(id, b);
+  }
+
   // 4. Pre-render YOUR_PHASE_2 + OPPONENT_ATTACKS prompts per advocate.
   const yourPhase2PromptByRole = {
     "advocate-a": renderOwnPhase2(phase2.advocates.a, "A", subClaimTextByIndex),
@@ -227,6 +244,18 @@ export async function runPhase(opts: RunPhase4Opts): Promise<Phase4PartialFile> 
   const opponentAttacksPromptByRole = {
     "advocate-a": renderOpponentAttacks(phase3.advocates.b, "B", ownArgsByRole["advocate-a"]),
     "advocate-b": renderOpponentAttacks(phase3.advocates.a, "A", ownArgsByRole["advocate-b"]),
+  } as const;
+  const methodologistAttacksPromptByRole = {
+    "advocate-a": renderMethodologistAttacks(
+      phase3.methodologist,
+      "A",
+      ownArgsByRole["advocate-a"],
+    ),
+    "advocate-b": renderMethodologistAttacks(
+      phase3.methodologist,
+      "B",
+      ownArgsByRole["advocate-b"],
+    ),
   } as const;
 
   // 5. Resume.
@@ -297,6 +326,7 @@ export async function runPhase(opts: RunPhase4Opts): Promise<Phase4PartialFile> 
       framing: framing.full,
       yourPhase2ArgumentsPrompt: yourPhase2PromptByRole[role],
       opponentAttacksPrompt: opponentAttacksPromptByRole[role],
+      methodologistAttacksPrompt: methodologistAttacksPromptByRole[role],
       evidenceCorpusPrompt,
       ownArguments: ownArgs,
       opposingRebuttals: oppReb,
@@ -353,6 +383,46 @@ export async function runPhase(opts: RunPhase4Opts): Promise<Phase4PartialFile> 
     a: buildOpposingCqRaiseMeta(phase3.advocates.b, phase2.advocates.a),
     b: buildOpposingCqRaiseMeta(phase3.advocates.a, phase2.advocates.b),
   };
+  // Merge methodologist attacks into the review-side maps so that
+  // soft-checks recognize defenses targeting methodologist rebuttals/CQs.
+  if (phase3.methodologist) {
+    const meth = phase3.methodologist;
+    const ownConclusionIdx = {
+      a: new Map(phase2.advocates.a.arguments.map((a) => [a.argumentId, a.conclusionClaimIndex] as const)),
+      b: new Map(phase2.advocates.b.arguments.map((a) => [a.argumentId, a.conclusionClaimIndex] as const)),
+    };
+    for (const r of meth.rebuttals) {
+      const role: "a" | "b" = r.targetAdvocateRole === "A" ? "a" : "b";
+      const idx = ownConclusionIdx[role].get(r.targetArgumentId);
+      if (idx === undefined) continue;
+      opposingRebuttalMetaByAdv[role].set(r.rebuttalArgumentId, {
+        rebuttalArgumentId: r.rebuttalArgumentId,
+        targetArgumentId: r.targetArgumentId,
+        targetConclusionClaimIndex: idx,
+        rebuttalAttackType: r.attackType,
+        rebuttalPremiseCount: r.premiseClaimIds.length,
+        rebuttalConclusionText: r.conclusionText,
+        rebuttalPremiseTexts: r.premiseTexts,
+        rebuttalPremiseCitationTokens: r.premiseCitationTokens,
+        cqKey: r.cqKey,
+      });
+    }
+    for (const c of meth.cqResponses) {
+      if (c.action !== "raise") continue;
+      if (c.elidedByRebuttalCqKey) continue;
+      const role: "a" | "b" = c.targetAdvocateRole === "A" ? "a" : "b";
+      const idx = ownConclusionIdx[role].get(c.targetArgumentId);
+      if (idx === undefined) continue;
+      const cqResponseId = `cqraise-meth:${c.targetArgumentId}:${c.cqKey}`;
+      opposingCqMetaByAdv[role].set(cqResponseId, {
+        cqResponseId,
+        targetArgumentId: c.targetArgumentId,
+        targetConclusionClaimIndex: idx,
+        cqKey: c.cqKey,
+        rationale: c.rationale,
+      });
+    }
+  }
   const reviewSourcesLite = ec.sources.map((s: any) => ({
     sourceId: s.sourceId,
     citationToken: s.citationToken,
@@ -440,6 +510,7 @@ interface RunOneAdvocateOpts {
   framing: string;
   yourPhase2ArgumentsPrompt: string;
   opponentAttacksPrompt: string;
+  methodologistAttacksPrompt: string;
   evidenceCorpusPrompt: string;
   ownArguments: ReadonlyMap<string, OwnArgumentBinding>;
   opposingRebuttals: ReadonlyMap<string, OpposingRebuttalBinding>;
@@ -499,6 +570,7 @@ async function runOneAdvocate(opts: RunOneAdvocateOpts): Promise<DefenseRunRecor
       framing: opts.framing,
       yourPhase2ArgumentsPrompt: opts.yourPhase2ArgumentsPrompt,
       opponentAttacksPrompt: opts.opponentAttacksPrompt,
+      methodologistAttacksPrompt: opts.methodologistAttacksPrompt,
       evidenceCorpusPrompt: opts.evidenceCorpusPrompt,
       schemaOpts: {
         opposingRebuttals: schemaOpposingRebuttals,
@@ -662,6 +734,7 @@ async function maybeRunTracker(opts: MaybeRunTrackerOpts): Promise<TrackerRunRec
   const bPhase2Prompt = renderOwnPhase2(opts.phase2.advocates.b, "B", opts.subClaimTextByIndex);
   const aPhase3Prompt = renderPhase3Block(opts.phase3.advocates.a, "A");
   const bPhase3Prompt = renderPhase3Block(opts.phase3.advocates.b, "B");
+  const methodologistPhase3Prompt = renderMethodologistPhase3Block(opts.phase3.methodologist);
   const aPhase4Prompt = renderPhase4Block(opts.results.a!, "A");
   const bPhase4Prompt = renderPhase4Block(opts.results.b!, "B");
 
@@ -685,6 +758,32 @@ async function maybeRunTracker(opts: MaybeRunTrackerOpts): Promise<TrackerRunRec
   const knownAttackIds = new Set<string>();
   for (const r of opts.phase3.advocates.a.rebuttals) knownAttackIds.add(r.rebuttalArgumentId);
   for (const r of opts.phase3.advocates.b.rebuttals) knownAttackIds.add(r.rebuttalArgumentId);
+  if (opts.phase3.methodologist) {
+    for (const r of opts.phase3.methodologist.rebuttals) {
+      knownAttackIds.add(r.rebuttalArgumentId);
+    }
+  }
+  // CQ raises (via cqResponseId) are also legitimate "attacks" the
+  // tracker may reference in successfulDefenses[].againstAttackId.
+  // Re-derive the synthesized cqraise: ids from phase-3 cqResponses
+  // (same format as buildOpposingCqRaiseBindings).
+  for (const advRole of ["a", "b"] as const) {
+    for (const c of opts.phase3.advocates[advRole].cqResponses) {
+      if (c.action !== "raise") continue;
+      if (c.elidedByRebuttalCqKey) continue;
+      knownAttackIds.add(`cqraise:${c.targetArgumentId}:${c.cqKey}`);
+    }
+  }
+  if (opts.phase3.methodologist) {
+    for (const c of opts.phase3.methodologist.cqResponses) {
+      if (c.action !== "raise") continue;
+      knownAttackIds.add(`cqraise-meth:${c.targetArgumentId}:${c.cqKey}`);
+      knownAttackIds.add(`cqraise:${c.targetArgumentId}:${c.cqKey}`);
+    }
+  }
+  // Phase-2 argument ids are also valid "attack" references — the tracker
+  // sometimes cites a defending argument by its own argumentId.
+  for (const id of knownArguments.keys()) knownAttackIds.add(id);
   const knownPhase4ResponseIds = new Set<string>();
   // Tracker references responses by Phase-3 rebuttalArgumentId (drivenBy is
   // a Phase-4 response id which we synthesize: `phase4-{role}-{idx}`).
@@ -717,6 +816,7 @@ async function maybeRunTracker(opts: MaybeRunTrackerOpts): Promise<TrackerRunRec
       advocateBPhase2Prompt: bPhase2Prompt,
       advocateAPhase3Prompt: aPhase3Prompt,
       advocateBPhase3Prompt: bPhase3Prompt,
+      methodologistPhase3Prompt,
       advocateAPhase4Prompt: aPhase4Prompt,
       advocateBPhase4Prompt: bPhase4Prompt,
       evidenceCorpusPrompt: opts.evidenceCorpusPrompt,
@@ -950,7 +1050,7 @@ function buildOpposingCqRaiseMeta(
 // Prompt renderers
 // ─────────────────────────────────────────────────────────────────
 
-function renderOwnPhase2(
+export function renderOwnPhase2(
   own: Phase2CompleteAdvocate,
   letter: "A" | "B",
   subClaimTextByIndex: Record<number, string>,
@@ -971,6 +1071,108 @@ function renderOwnPhase2(
     lines.push(`  warrant: ${a.warrant ? `"${a.warrant}"` : "null"}`);
     lines.push(``);
   }
+  return lines.join("\n");
+}
+
+// ─────────────────────────────────────────────────────────────────
+// Methodologist (Phase-3 third actor) — per-advocate filter, render,
+// and binding helpers.
+// ─────────────────────────────────────────────────────────────────
+
+interface MethodologistAttacksForAdvocate {
+  rebuttals: Map<string, OpposingRebuttalBinding>;
+  cqRaises: Map<string, OpposingCqRaiseBinding>;
+}
+
+function buildMethodologistAttacksByRole(
+  meth: Phase3CompleteMethodologist | undefined,
+  ownArgsByRole: {
+    "advocate-a": ReadonlyMap<string, OwnArgumentBinding>;
+    "advocate-b": ReadonlyMap<string, OwnArgumentBinding>;
+  },
+): {
+  "advocate-a": MethodologistAttacksForAdvocate;
+  "advocate-b": MethodologistAttacksForAdvocate;
+} {
+  const empty = (): MethodologistAttacksForAdvocate => ({
+    rebuttals: new Map(),
+    cqRaises: new Map(),
+  });
+  const out = {
+    "advocate-a": empty(),
+    "advocate-b": empty(),
+  };
+  if (!meth) return out;
+
+  for (const r of meth.rebuttals) {
+    const role: "advocate-a" | "advocate-b" =
+      r.targetAdvocateRole === "A" ? "advocate-a" : "advocate-b";
+    if (!ownArgsByRole[role].has(r.targetArgumentId)) continue;
+    out[role].rebuttals.set(r.rebuttalArgumentId, {
+      rebuttalArgumentId: r.rebuttalArgumentId,
+      targetArgumentId: r.targetArgumentId,
+      rebuttalPremiseCount: r.premiseClaimIds.length,
+      rebuttalPremiseClaimIds: r.premiseClaimIds,
+      rebuttalAttackType: r.attackType,
+      rebuttalTargetPremiseIndex: r.targetPremiseIndex,
+      rebuttalConclusionClaimId: r.conclusionClaimId,
+      cqKey: r.cqKey,
+    });
+  }
+  for (const c of meth.cqResponses) {
+    if (c.action !== "raise") continue;
+    if (c.elidedByRebuttalCqKey) continue;
+    const role: "advocate-a" | "advocate-b" =
+      c.targetAdvocateRole === "A" ? "advocate-a" : "advocate-b";
+    if (!ownArgsByRole[role].has(c.targetArgumentId)) continue;
+    const cqResponseId = `cqraise-meth:${c.targetArgumentId}:${c.cqKey}`;
+    out[role].cqRaises.set(cqResponseId, {
+      cqResponseId,
+      targetArgumentId: c.targetArgumentId,
+      cqKey: c.cqKey,
+    });
+  }
+  return out;
+}
+
+function renderMethodologistAttacks(
+  meth: Phase3CompleteMethodologist | undefined,
+  side: "A" | "B",
+  ownArgs: ReadonlyMap<string, OwnArgumentBinding>,
+): string {
+  if (!meth) return "";
+  const lines: string[] = [];
+  for (const r of meth.rebuttals) {
+    if (r.targetAdvocateRole !== side) continue;
+    if (!ownArgs.has(r.targetArgumentId)) continue;
+    lines.push(
+      `ATTACK ${r.rebuttalArgumentId}  attackType=${r.attackType}  from=methodologist`,
+    );
+    lines.push(
+      `  targets: ARG ${r.targetArgumentId}  premise=${r.targetPremiseIndex ?? "null"}  cqKey=${r.cqKey ?? "null"}`,
+    );
+    lines.push(`  concludes: "${r.conclusionText}"`);
+    lines.push(`  premises (0-indexed):`);
+    for (let i = 0; i < r.premiseTexts.length; i++) {
+      const tok = r.premiseCitationTokens[i];
+      lines.push(`    [${i}] "${r.premiseTexts[i]}"  cite=${tok ?? "null"}`);
+    }
+    lines.push(`  warrant: ${r.warrant ? `"${r.warrant}"` : "null"}`);
+    lines.push(`  scheme: ${r.schemeKey}`);
+    lines.push(``);
+  }
+  for (const c of meth.cqResponses) {
+    if (c.action !== "raise") continue;
+    if (c.elidedByRebuttalCqKey) continue;
+    if (c.targetAdvocateRole !== side) continue;
+    if (!ownArgs.has(c.targetArgumentId)) continue;
+    const cqResponseId = `cqraise-meth:${c.targetArgumentId}:${c.cqKey}`;
+    lines.push(`CQ_RAISE ${cqResponseId}  action=raise  from=methodologist`);
+    lines.push(`  targets: ARG ${c.targetArgumentId}  cqKey=${c.cqKey}`);
+    lines.push(`  rationale: "${c.rationale}"`);
+    lines.push(``);
+  }
+  if (lines.length === 0) return "";
   return lines.join("\n");
 }
 
@@ -1015,7 +1217,7 @@ function renderOpponentAttacks(
   return lines.join("\n");
 }
 
-function renderTopology(opts: {
+export function renderTopology(opts: {
   centralClaim: string;
   subClaimTextByIndex: Record<number, string>;
   hingeIndices: number[];
@@ -1037,7 +1239,7 @@ function renderTopology(opts: {
   return lines.join("\n");
 }
 
-function renderPhase3Block(adv: Phase3CompleteAdvocate, letter: "A" | "B"): string {
+export function renderPhase3Block(adv: Phase3CompleteAdvocate, letter: "A" | "B"): string {
   const lines: string[] = [];
   for (const r of adv.rebuttals) {
     lines.push(`ATTACK ${r.rebuttalArgumentId}  attackType=${r.attackType}`);
@@ -1069,7 +1271,43 @@ function renderPhase3Block(adv: Phase3CompleteAdvocate, letter: "A" | "B"): stri
   return lines.join("\n");
 }
 
-function renderPhase4Block(rec: DefenseRunRecord, letter: "A" | "B"): string {
+export function renderMethodologistPhase3Block(
+  meth: Phase3CompleteMethodologist | undefined,
+): string {
+  if (!meth) return "";
+  const lines: string[] = [];
+  for (const r of meth.rebuttals) {
+    lines.push(
+      `ATTACK ${r.rebuttalArgumentId}  attackType=${r.attackType}  targetAdvocate=${r.targetAdvocateRole}`,
+    );
+    lines.push(
+      `  targets: ARG ${r.targetArgumentId}  premise=${r.targetPremiseIndex ?? "null"}  cqKey=${r.cqKey ?? "null"}`,
+    );
+    lines.push(`  concludes: "${r.conclusionText}"`);
+    lines.push(`  premises:`);
+    for (let i = 0; i < r.premiseTexts.length; i++) {
+      const tok = r.premiseCitationTokens[i];
+      lines.push(`    [${i}] "${r.premiseTexts[i]}"  cite=${tok ?? "null"}`);
+    }
+    lines.push(`  warrant: ${r.warrant ? `"${r.warrant}"` : "null"}`);
+    lines.push(`  scheme: ${r.schemeKey}`);
+    lines.push(``);
+  }
+  for (const c of meth.cqResponses) {
+    if (c.elidedByRebuttalCqKey) continue;
+    const cqResponseId = `cqraise-meth:${c.targetArgumentId}:${c.cqKey}`;
+    lines.push(
+      `CQ_RAISE ${cqResponseId}  action=${c.action}  targetAdvocate=${c.targetAdvocateRole}`,
+    );
+    lines.push(`  targets: ARG ${c.targetArgumentId}  cqKey=${c.cqKey}`);
+    lines.push(`  rationale: "${c.rationale}"`);
+    lines.push(``);
+  }
+  if (lines.length === 0) return "";
+  return lines.join("\n");
+}
+
+export function renderPhase4Block(rec: DefenseRunRecord, letter: "A" | "B"): string {
   if (!rec.llmOutput) {
     return `(Advocate ${letter} did not produce a Phase-4 output.)`;
   }

--- a/experiments/polarization-1/orchestrator/phases/phase-5-synthesis.ts
+++ b/experiments/polarization-1/orchestrator/phases/phase-5-synthesis.ts
@@ -1,0 +1,550 @@
+/**
+ * orchestrator/phases/phase-5-synthesis.ts
+ *
+ * Phase-5 (Synthesis / Crux-Finder) control flow.
+ *
+ *   loadFraming
+ *     → loadPhase1Complete (topology)
+ *     → loadPhase2Complete
+ *     → loadPhase3Complete
+ *     → loadPhase4Complete (must have tracker.outcome === "ok")
+ *     → fetch evidence corpus from iso (now includes web-discovered sources
+ *        materialized by Phases 2-4 in loosened mode)
+ *     → build prompt blocks (topology, A/B Phase-2, A/B Phase-3, A/B Phase-4,
+ *        tracker verdict, evidence corpus)
+ *     → build schema bindings (knownArgumentIds, knownAttackIds,
+ *        knownPhase4ResponseIds, subClaimCount, knownCitationTokens)
+ *     → runSynthesistTurn (single-shot judge)
+ *     → write PHASE_5_PARTIAL.json + persist verdict / refusal
+ *
+ * Phase 5 is read-only on the platform: the Synthesist does not mint
+ * arguments, edges, or claims. The output is a JSON verdict + (in
+ * finalize) a human-readable SYNTHESIS.md report.
+ *
+ * Resumability: if a prior PHASE_5_PARTIAL.json has tracker.outcome="ok"
+ * (i.e. a synthesist verdict already exists) and `resume` is set, this
+ * is a no-op.
+ */
+
+import { writeFileSync, existsSync, readFileSync, mkdirSync } from "fs";
+import path from "path";
+
+import type { OrchestratorConfig } from "../config";
+import type { IsonomiaClient } from "../isonomia-client";
+import type { AnthropicClient } from "../anthropic-client";
+import { modelFor } from "../config";
+import { RoundLogger } from "../log/round-logger";
+
+import { loadFraming } from "../util/framing";
+import { renderEvidenceCorpus } from "../util/evidence-corpus";
+
+import {
+  runSynthesistTurn,
+  isSynthesistRefusal,
+  SynthesistValidationError,
+} from "../agents/synthesist";
+import type {
+  SynthesistVerdict,
+  SynthesistRefusal,
+} from "../agents/synthesist-schema";
+
+import {
+  renderTopology,
+  renderOwnPhase2,
+  renderPhase3Block,
+  renderMethodologistPhase3Block,
+} from "./phase-4-defenses";
+
+import type { Phase1CompleteFile } from "../finalize/phase-1-finalize";
+import type {
+  Phase2CompleteFile,
+  Phase2CompleteAdvocate,
+} from "../finalize/phase-2-finalize";
+import type {
+  Phase3CompleteFile,
+  Phase3CompleteAdvocate,
+} from "../finalize/phase-3-finalize";
+import type {
+  Phase4CompleteFile,
+  Phase4CompleteAdvocate,
+} from "../finalize/phase-4-finalize";
+import type { TrackerVerdict } from "../agents/tracker-schema";
+
+// ─────────────────────────────────────────────────────────────────
+// Public types
+// ─────────────────────────────────────────────────────────────────
+
+export interface RunPhase5Opts {
+  cfg: OrchestratorConfig;
+  iso: IsonomiaClient;
+  llm: AnthropicClient;
+  deliberationId: string;
+  resume?: boolean;
+}
+
+export interface SynthesistRunRecord {
+  outcome: "ok" | "refused" | "validation-error";
+  attempts: number;
+  tokenUsage?: { inputTokens: number; outputTokens: number };
+  verdict?: SynthesistVerdict;
+  refusal?: SynthesistRefusal;
+  refusalPath?: string;
+  validationError?: { message: string; rawResponsesCount: number };
+  artifacts: {
+    promptPath: string;
+    verdictPath?: string;
+    roundLogPath: string;
+  };
+}
+
+export interface Phase5PartialFile {
+  phase: 5;
+  status: "partial";
+  generatedAt: string;
+  deliberationId: string;
+  modelTier: string;
+  evidenceStackId: string;
+  hingeIndices: number[];
+  synthesist: SynthesistRunRecord;
+  artifacts: { partialPath: string };
+}
+
+const PHASE_5_LLM_DIR = "llm";
+const PHASE_5_PARTIAL_FILE = "PHASE_5_PARTIAL.json";
+const REFUSALS_DIR = "refusals";
+
+// ─────────────────────────────────────────────────────────────────
+// Entry point
+// ─────────────────────────────────────────────────────────────────
+
+export async function runPhase(opts: RunPhase5Opts): Promise<Phase5PartialFile> {
+  const phaseLogger = RoundLogger.forRound({
+    runtimeDir: opts.cfg.runtimeDir,
+    phase: 5,
+    round: 0,
+  });
+
+  // 1. Resume short-circuit.
+  const partialPath = path.join(opts.cfg.runtimeDir, PHASE_5_PARTIAL_FILE);
+  if (opts.resume && existsSync(partialPath)) {
+    try {
+      const prior = JSON.parse(readFileSync(partialPath, "utf8")) as Phase5PartialFile;
+      if (prior.synthesist?.outcome === "ok" && prior.deliberationId === opts.deliberationId) {
+        phaseLogger.event("phase_skip", {
+          phase: 5,
+          reason: "synthesist already complete in prior partial; resume=true",
+        });
+        return prior;
+      }
+    } catch {
+      // fall through and re-run
+    }
+  }
+
+  // 2. Prereqs.
+  const phase1 = loadPhase1Complete(opts.cfg.runtimeDir, opts.deliberationId);
+  const phase2 = loadPhase2Complete(opts.cfg.runtimeDir, opts.deliberationId);
+  const phase3 = loadPhase3Complete(opts.cfg.runtimeDir, opts.deliberationId);
+  const phase4 = loadPhase4Complete(opts.cfg.runtimeDir, opts.deliberationId);
+
+  if (phase4.tracker?.outcome !== "ok" || !phase4.tracker.verdict) {
+    throw new Error(
+      `Phase 5 prereq invalid: PHASE_4_COMPLETE.json tracker.outcome=` +
+        `"${phase4.tracker?.outcome}", expected "ok" with a verdict. The Synthesist ` +
+        `consumes the Tracker verdict as authoritative input.`,
+    );
+  }
+  const trackerVerdict = phase4.tracker.verdict;
+
+  const framing = loadFraming(opts.cfg.experimentRoot);
+
+  // 3. Topology bindings (sub-claim text + layer + hinge indices).
+  const subClaimTextByIndex: Record<number, string> = {};
+  const layerByIndex: Record<number, string> = {};
+  for (const [k, v] of Object.entries(phase1.topology)) {
+    const i = Number(k);
+    subClaimTextByIndex[i] = v.text;
+    layerByIndex[i] = v.layer;
+  }
+  const subClaimCount = Object.keys(phase1.topology).length;
+  const hingeIndices = phase4.hingeIndices ?? phase2.topologyBinding.hingeIndices;
+
+  // 4. Evidence corpus (now includes web-materialized sources from loosened mode).
+  const ec = await opts.iso.getEvidenceContext(opts.deliberationId, {
+    role: "advocate-a",
+    logger: phaseLogger,
+  });
+  const evidenceCorpusPrompt = renderEvidenceCorpus({ stack: ec.stack, sources: ec.sources });
+  const knownCitationTokens = new Set<string>(ec.sources.map((s) => s.citationToken));
+
+  // 5. Render prompt blocks.
+  const topologyPrompt = renderTopology({
+    centralClaim: framing.centralClaim,
+    subClaimTextByIndex,
+    hingeIndices,
+    layerByIndex,
+  });
+  const aPhase2Prompt = renderOwnPhase2(phase2.advocates.a, "A", subClaimTextByIndex);
+  const bPhase2Prompt = renderOwnPhase2(phase2.advocates.b, "B", subClaimTextByIndex);
+  const aPhase3Prompt = renderPhase3Block(phase3.advocates.a, "A");
+  const bPhase3Prompt = renderPhase3Block(phase3.advocates.b, "B");
+  const methodologistPhase3Prompt = renderMethodologistPhase3Block(phase3.methodologist);
+  const aPhase4Prompt = renderPhase4FromComplete(phase4.advocates.a, "A");
+  const bPhase4Prompt = renderPhase4FromComplete(phase4.advocates.b, "B");
+  const trackerVerdictPrompt = renderTrackerVerdict(trackerVerdict);
+
+  // 6. Schema bindings: every id the Synthesist may cite must be resolvable.
+  const knownArgumentIds = new Set<string>();
+  for (const a of phase2.advocates.a.arguments) knownArgumentIds.add(a.argumentId);
+  for (const a of phase2.advocates.b.arguments) knownArgumentIds.add(a.argumentId);
+
+  const knownAttackIds = new Set<string>();
+  for (const r of phase3.advocates.a.rebuttals) knownAttackIds.add(r.rebuttalArgumentId);
+  for (const r of phase3.advocates.b.rebuttals) knownAttackIds.add(r.rebuttalArgumentId);
+  if (phase3.methodologist) {
+    for (const r of phase3.methodologist.rebuttals) {
+      knownAttackIds.add(r.rebuttalArgumentId);
+    }
+  }
+
+  const knownPhase4ResponseIds = new Set<string>();
+  for (let i = 0; i < phase4.advocates.a.responses.length; i++) {
+    knownPhase4ResponseIds.add(`phase4-A-r${i}`);
+  }
+  for (let i = 0; i < phase4.advocates.a.cqAnswers.length; i++) {
+    knownPhase4ResponseIds.add(`phase4-A-cq${i}`);
+  }
+  for (let i = 0; i < phase4.advocates.b.responses.length; i++) {
+    knownPhase4ResponseIds.add(`phase4-B-r${i}`);
+  }
+  for (let i = 0; i < phase4.advocates.b.cqAnswers.length; i++) {
+    knownPhase4ResponseIds.add(`phase4-B-cq${i}`);
+  }
+
+  // 7. Run the synthesist.
+  const round = 0;
+  const logger = RoundLogger.forRound({
+    runtimeDir: opts.cfg.runtimeDir,
+    phase: 5,
+    round,
+    agentRole: "synthesist",
+  });
+  const promptPath = path.join(opts.cfg.experimentRoot, "prompts/9-synthesist.md");
+  const verdictPath = path.join(opts.cfg.runtimeDir, PHASE_5_LLM_DIR, "phase-5-synthesist-verdict.json");
+  const baseArtifacts = {
+    promptPath,
+    roundLogPath: path.join(opts.cfg.runtimeDir, "logs", `round-5-${round}-synthesist.jsonl`),
+  };
+
+  let record: SynthesistRunRecord;
+  try {
+    const turn = await runSynthesistTurn({
+      promptPath,
+      framing: framing.full,
+      topologyPrompt,
+      advocateAPhase2Prompt: aPhase2Prompt,
+      advocateBPhase2Prompt: bPhase2Prompt,
+      advocateAPhase3Prompt: aPhase3Prompt,
+      advocateBPhase3Prompt: bPhase3Prompt,
+      methodologistPhase3Prompt,
+      advocateAPhase4Prompt: aPhase4Prompt,
+      advocateBPhase4Prompt: bPhase4Prompt,
+      trackerVerdictPrompt,
+      evidenceCorpusPrompt,
+      schemaOpts: {
+        knownArgumentIds,
+        knownAttackIds,
+        knownPhase4ResponseIds,
+        subClaimCount,
+        knownCitationTokens,
+      },
+      cfg: opts.cfg,
+      llm: opts.llm,
+      logger,
+    });
+
+    if (isSynthesistRefusal(turn.response)) {
+      const refusalPath = path.join(opts.cfg.runtimeDir, REFUSALS_DIR, `phase-5-synthesist-refusal.json`);
+      mkdirSync(path.dirname(refusalPath), { recursive: true });
+      writeFileSync(refusalPath, JSON.stringify(turn.response, null, 2));
+      logger.event("phase_complete", {
+        phase: 5,
+        round,
+        agent: "synthesist",
+        outcome: "refused",
+        reason: turn.response.error,
+      });
+      record = {
+        outcome: "refused",
+        attempts: turn.attempts,
+        tokenUsage: turn.usage,
+        refusal: turn.response,
+        refusalPath,
+        artifacts: baseArtifacts,
+      };
+    } else {
+      mkdirSync(path.dirname(verdictPath), { recursive: true });
+      writeFileSync(verdictPath, JSON.stringify(turn.response, null, 2));
+      logger.event("phase_complete", {
+        phase: 5,
+        round,
+        agent: "synthesist",
+        outcome: "ok",
+        netEpistemicValue: turn.response.epistemicShift.netEpistemicValue,
+        cruxCount: turn.response.cruxes.length,
+        agreementCount: turn.response.agreements.length,
+        originalContributionCount: turn.response.originalContributions.length,
+        openQuestionCount: turn.response.openQuestions.length,
+      });
+      record = {
+        outcome: "ok",
+        attempts: turn.attempts,
+        tokenUsage: turn.usage,
+        verdict: turn.response,
+        artifacts: { ...baseArtifacts, verdictPath },
+      };
+    }
+  } catch (err) {
+    if (err instanceof SynthesistValidationError) {
+      logger.event("phase_complete", {
+        phase: 5,
+        round,
+        agent: "synthesist",
+        outcome: "validation-error",
+        attempts: err.attempts,
+      });
+      record = {
+        outcome: "validation-error",
+        attempts: err.attempts,
+        validationError: { message: err.message, rawResponsesCount: err.rawResponses.length },
+        artifacts: baseArtifacts,
+      };
+    } else {
+      throw err;
+    }
+  }
+
+  // 8. Persist partial.
+  const partial: Phase5PartialFile = {
+    phase: 5,
+    status: "partial",
+    generatedAt: new Date().toISOString(),
+    deliberationId: opts.deliberationId,
+    modelTier: opts.cfg.modelTier,
+    evidenceStackId: ec.stack.id,
+    hingeIndices,
+    synthesist: record,
+    artifacts: { partialPath },
+  };
+  mkdirSync(path.dirname(partialPath), { recursive: true });
+  writeFileSync(partialPath, JSON.stringify(partial, null, 2));
+
+  phaseLogger.event("phase_partial_written", {
+    phase: 5,
+    partialPath,
+    synthesistOutcome: record.outcome,
+  });
+  return partial;
+}
+
+// ─────────────────────────────────────────────────────────────────
+// Loaders
+// ─────────────────────────────────────────────────────────────────
+
+function loadPhase1Complete(runtimeDir: string, deliberationId: string): Phase1CompleteFile {
+  const p = path.join(runtimeDir, "PHASE_1_COMPLETE.json");
+  if (!existsSync(p)) {
+    throw new Error(`Phase 5 prereq missing: ${p}. Run phase 1 + finalize.`);
+  }
+  const raw = JSON.parse(readFileSync(p, "utf8")) as Phase1CompleteFile;
+  if (raw.status !== "complete") {
+    throw new Error(`Phase 5 prereq invalid: ${p} status="${raw.status}", expected "complete"`);
+  }
+  if (raw.deliberationId !== deliberationId) {
+    throw new Error(
+      `Phase 5 prereq mismatch: PHASE_1_COMPLETE.json deliberationId=${raw.deliberationId} but current=${deliberationId}`,
+    );
+  }
+  return raw;
+}
+
+function loadPhase2Complete(runtimeDir: string, deliberationId: string): Phase2CompleteFile {
+  const p = path.join(runtimeDir, "PHASE_2_COMPLETE.json");
+  if (!existsSync(p)) {
+    throw new Error(`Phase 5 prereq missing: ${p}. Run phase 2 + finalize.`);
+  }
+  const raw = JSON.parse(readFileSync(p, "utf8")) as Phase2CompleteFile;
+  if (raw.status !== "complete") {
+    throw new Error(`Phase 5 prereq invalid: ${p} status="${raw.status}", expected "complete"`);
+  }
+  if (raw.deliberationId !== deliberationId) {
+    throw new Error(
+      `Phase 5 prereq mismatch: PHASE_2_COMPLETE.json deliberationId=${raw.deliberationId} but current=${deliberationId}`,
+    );
+  }
+  return raw;
+}
+
+function loadPhase3Complete(runtimeDir: string, deliberationId: string): Phase3CompleteFile {
+  const p = path.join(runtimeDir, "PHASE_3_COMPLETE.json");
+  if (!existsSync(p)) {
+    throw new Error(`Phase 5 prereq missing: ${p}. Run phase 3 + finalize.`);
+  }
+  const raw = JSON.parse(readFileSync(p, "utf8")) as Phase3CompleteFile;
+  if (raw.status !== "complete") {
+    throw new Error(`Phase 5 prereq invalid: ${p} status="${raw.status}", expected "complete"`);
+  }
+  if (raw.deliberationId !== deliberationId) {
+    throw new Error(
+      `Phase 5 prereq mismatch: PHASE_3_COMPLETE.json deliberationId=${raw.deliberationId} but current=${deliberationId}`,
+    );
+  }
+  return raw;
+}
+
+function loadPhase4Complete(runtimeDir: string, deliberationId: string): Phase4CompleteFile {
+  const p = path.join(runtimeDir, "PHASE_4_COMPLETE.json");
+  if (!existsSync(p)) {
+    throw new Error(`Phase 5 prereq missing: ${p}. Run phase 4 + finalize.`);
+  }
+  const raw = JSON.parse(readFileSync(p, "utf8")) as Phase4CompleteFile;
+  if (raw.status !== "complete") {
+    throw new Error(`Phase 5 prereq invalid: ${p} status="${raw.status}", expected "complete"`);
+  }
+  if (raw.deliberationId !== deliberationId) {
+    throw new Error(
+      `Phase 5 prereq mismatch: PHASE_4_COMPLETE.json deliberationId=${raw.deliberationId} but current=${deliberationId}`,
+    );
+  }
+  return raw;
+}
+
+// ─────────────────────────────────────────────────────────────────
+// Renderers (Phase-4 Complete file shape + tracker verdict)
+// ─────────────────────────────────────────────────────────────────
+
+/**
+ * Like `renderPhase4Block` in phase-4-defenses, but takes the persisted
+ * `Phase4CompleteAdvocate` shape (read from PHASE_4_COMPLETE.json) rather
+ * than the in-memory `DefenseRunRecord`. The persisted shape is normalized
+ * (`responses[]` + `cqAnswers[]` directly, with full premise text) and
+ * doesn't carry the same `llmOutput.responses` indirection.
+ *
+ * Synthesizes the canonical `phase4-{A|B}-r{idx}` / `phase4-{A|B}-cq{idx}`
+ * response ids that the Synthesist schema validates against.
+ */
+function renderPhase4FromComplete(adv: Phase4CompleteAdvocate, letter: "A" | "B"): string {
+  if (adv.responses.length === 0 && adv.cqAnswers.length === 0) {
+    return `(Advocate ${letter} produced no Phase-4 responses or cqAnswers.)`;
+  }
+  const lines: string[] = [];
+  for (let i = 0; i < adv.responses.length; i++) {
+    const r = adv.responses[i];
+    const responseId = `phase4-${letter}-r${i}`;
+    lines.push(`RESPONSE ${responseId}  targets: ATTACK ${r.targetAttackId}`);
+    lines.push(`  kind: ${r.kind}`);
+    lines.push(`  rationale: "${r.rationale}"`);
+    if (r.defense) {
+      lines.push(`  defense:`);
+      lines.push(`    attackType: ${r.defense.attackType}`);
+      if (r.defense.targetPremiseIndex !== null) {
+        lines.push(`    targetPremiseIndex: ${r.defense.targetPremiseIndex}`);
+      }
+      lines.push(`    conclusionText: "${r.defense.conclusionText}"`);
+      lines.push(`    premises:`);
+      for (let j = 0; j < r.defense.premiseTexts.length; j++) {
+        const tok = r.defense.premiseCitationTokens[j];
+        lines.push(`      [${j}] "${r.defense.premiseTexts[j]}"  cite=${tok ?? "null"}`);
+      }
+      lines.push(`    schemeKey: ${r.defense.schemeKey}`);
+      if (r.defense.warrant) lines.push(`    warrant: "${r.defense.warrant}"`);
+    }
+    if (r.narrowedConclusionText) {
+      lines.push(`  narrowedConclusionText: "${r.narrowedConclusionText}"`);
+    }
+    lines.push(``);
+  }
+  for (let i = 0; i < adv.cqAnswers.length; i++) {
+    const c = adv.cqAnswers[i];
+    const cqAnswerId = `phase4-${letter}-cq${i}`;
+    lines.push(`CQ_ANSWER ${cqAnswerId}  targets: CQ_RAISE ${c.targetCqRaiseId}`);
+    lines.push(`  kind: ${c.kind}`);
+    lines.push(`  rationale: "${c.rationale}"`);
+    lines.push(``);
+  }
+  return lines.join("\n");
+}
+
+/**
+ * Serializes the Phase-4 Tracker verdict into a markdown-ish block for
+ * the Synthesist's CONCESSION_TRACKER_VERDICT input. The Synthesist
+ * treats this as authoritative input on per-argument standings.
+ */
+function renderTrackerVerdict(v: TrackerVerdict): string {
+  const lines: string[] = [];
+  lines.push(`Tracker model phase: ${v.phase}`);
+  lines.push(``);
+
+  // Central-claim verdict.
+  lines.push(`### Central-claim verdict`);
+  lines.push(`  verdict: ${v.centralClaimVerdict.verdict}`);
+  lines.push(`  rationale: "${v.centralClaimVerdict.rationale}"`);
+  if (v.centralClaimVerdict.primarySupportingArguments.length) {
+    lines.push(
+      `  primarySupportingArguments: [${v.centralClaimVerdict.primarySupportingArguments.join(", ")}]`,
+    );
+  }
+  if (v.centralClaimVerdict.primaryUnderminingArguments.length) {
+    lines.push(
+      `  primaryUnderminingArguments: [${v.centralClaimVerdict.primaryUnderminingArguments.join(", ")}]`,
+    );
+  }
+  lines.push(``);
+
+  // Per-argument standings.
+  lines.push(`### Argument standings (${v.argumentStandings.length})`);
+  for (const s of v.argumentStandings) {
+    lines.push(
+      `- ARG ${s.argumentId} [${s.advocateRole}]  standing=${s.standing}` +
+        (s.isHingeArgument ? "  (hinge)" : ""),
+    );
+    lines.push(`    rationale: "${s.rationale}"`);
+    if (s.effectiveConcessions.length) {
+      lines.push(`    effectiveConcessions:`);
+      for (const c of s.effectiveConcessions) {
+        lines.push(
+          `      - drivenBy=${c.drivenBy} kind=${c.kind}` +
+            (c.premiseIndex !== null ? ` premise=${c.premiseIndex}` : "") +
+            (c.cqKey !== null ? ` cqKey=${c.cqKey}` : ""),
+        );
+      }
+    }
+    if (s.successfulDefenses.length) {
+      lines.push(`    successfulDefenses:`);
+      for (const d of s.successfulDefenses) {
+        lines.push(
+          `      - drivenBy=${d.drivenBy} againstAttack=${d.againstAttackId} rationale="${d.rationale}"`,
+        );
+      }
+    }
+  }
+  lines.push(``);
+
+  // Per-advocate summaries.
+  lines.push(`### Advocate summaries`);
+  for (const a of v.advocateSummaries) {
+    lines.push(`- Advocate ${a.advocateRole}`);
+    lines.push(
+      `    totals: ${a.totalArguments} args  ` +
+        `stood=${a.stoodCount}  weakened=${a.weakenedCount}  fallen=${a.fallenCount}`,
+    );
+    lines.push(
+      `    hinge: stood=${a.hingeStandings.stoodCount}  ` +
+        `weakened=${a.hingeStandings.weakenedCount}  fallen=${a.hingeStandings.fallenCount}`,
+    );
+    lines.push(`    concessionDiscrimination: ${a.concessionDiscrimination}`);
+    lines.push(`    rationale: "${a.concessionDiscriminationRationale}"`);
+  }
+
+  return lines.join("\n");
+}

--- a/experiments/polarization-1/orchestrator/translators/argument-mint.ts
+++ b/experiments/polarization-1/orchestrator/translators/argument-mint.ts
@@ -408,6 +408,19 @@ export async function materializeWebCitations(
   }
   const result: Record<string, string> = {};
   for (const wc of opts.webCitations) {
+    // Normalize publishedAt to ISO datetime — platform Zod accepts only full datetime.
+    // Accept "YYYY", "YYYY-MM", "YYYY-MM-DD" by padding to midnight UTC.
+    const normalizePublishedAt = (s: string | undefined | null): string | undefined => {
+      if (!s) return undefined;
+      if (/T\d{2}:\d{2}/.test(s)) return s; // already datetime
+      const m4 = /^(\d{4})$/.exec(s);
+      if (m4) return `${m4[1]}-01-01T00:00:00.000Z`;
+      const m7 = /^(\d{4})-(\d{2})$/.exec(s);
+      if (m7) return `${m7[1]}-${m7[2]}-01T00:00:00.000Z`;
+      const m10 = /^(\d{4})-(\d{2})-(\d{2})$/.exec(s);
+      if (m10) return `${s}T00:00:00.000Z`;
+      return s; // pass through; let server reject if truly malformed
+    };
     const item = await opts.iso.addStackItem(
       opts.stackId,
       {
@@ -415,7 +428,7 @@ export async function materializeWebCitations(
         url: wc.url,
         title: wc.title,
         authors: wc.authors,
-        publishedAt: wc.publishedAt,
+        publishedAt: normalizePublishedAt(wc.publishedAt),
         abstract: wc.snippet,
         keyFindings: wc.snippet ? [wc.snippet] : undefined,
         tags: wc.methodology ? ["web-discovered", wc.methodology] : ["web-discovered"],

--- a/experiments/polarization-1/orchestrator/translators/attack-mint.ts
+++ b/experiments/polarization-1/orchestrator/translators/attack-mint.ts
@@ -68,6 +68,7 @@ import type {
 } from "../agents/rebuttal-schema";
 import { ClaimRegistry, resolvePremiseClaimIds } from "./claim-mint";
 import { materializeWebCitations } from "./argument-mint";
+import { postDialogueMove } from "./dialogue-move-mint";
 import { prisma } from "@/lib/prismaclient";
 
 export interface AttackMintResult {
@@ -131,7 +132,7 @@ export interface TranslateRebuttalOpts {
   registry: ClaimRegistry;
 
   /** Author role for write signing. */
-  authorRole: "advocate-a" | "advocate-b";
+  authorRole: "advocate-a" | "advocate-b" | "methodologist";
 
   /**
    * Map of opposing argument id → that argument's scheme key. Needed to
@@ -308,6 +309,7 @@ export async function translateRebuttalOutput(opts: TranslateRebuttalOpts): Prom
       r,
       inputIndex: i,
       authorId,
+      authorRole: opts.authorRole,
       ctx,
       iso: opts.iso,
       registry: opts.registry,
@@ -365,6 +367,31 @@ export async function translateRebuttalOutput(opts: TranslateRebuttalOpts): Prom
       cqStatusId,
       elidedByRebuttalCqKey: false,
     });
+
+    // Emit a WHY DialogueMove for every CQ raise that wasn't already
+    // covered by a rebuttal's cqKey (those are emitted alongside the
+    // ATTACK move below). Waives are dialectically silent (the advocate
+    // is declaring the CQ inapplicable, not challenging the argument).
+    if (c.action === "raise") {
+      await postDialogueMove({
+        deliberationId: opts.deliberationId,
+        targetType: "argument",
+        targetId: c.targetArgumentId,
+        kind: "WHY",
+        actorId: authorId,
+        signature: `why:${opts.authorRole}:${c.targetArgumentId}:${c.cqKey}`,
+        payload: {
+          cqId: c.cqKey,
+          cqKey: c.cqKey,
+          schemeKey: opts.opposingArgumentSchemeByArgId.get(c.targetArgumentId) ?? null,
+          rationale: c.rationale,
+          source: "orchestrator-cq-raise",
+        },
+        logger: opts.logger,
+        step: "attack-mint",
+        advocate: opts.authorRole,
+      });
+    }
   }
 
   const sizeAfter = opts.registry.size();
@@ -403,6 +430,7 @@ interface MintOneRebuttalOpts {
   r: RebuttalArgument;
   inputIndex: number;
   authorId: string;
+  authorRole: "advocate-a" | "advocate-b" | "methodologist";
   ctx: IsonomiaCallContext;
   iso: IsonomiaClient;
   registry: ClaimRegistry;
@@ -523,6 +551,53 @@ async function mintOneRebuttal(opts: MintOneRebuttalOpts): Promise<AttackMintRes
     },
     opts.ctx,
   );
+
+  // 7b. Emit an ATTACK DialogueMove for the rebuttal edge (createArgument
+  // already auto-emitted ASSERT for the rebuttal Argument itself).
+  await postDialogueMove({
+    deliberationId: opts.deliberationId,
+    targetType: "argument",
+    targetId: r.targetArgumentId,
+    kind: "ATTACK" as any,
+    actorId: opts.authorId,
+    signature: `attack:${rebuttalArgumentId}->${r.targetArgumentId}:${edgeId}`,
+    payload: {
+      fromArgumentId: rebuttalArgumentId,
+      edgeId,
+      attackType: ATTACK_TYPE_TO_API[r.attackType],
+      targetScope: ATTACK_TYPE_TO_SCOPE[r.attackType],
+      targetClaimId: targetClaimIdField,
+      targetPremiseId: targetPremiseClaimId,
+      cqKey: r.cqKey,
+    },
+    logger: opts.logger,
+    step: "attack-mint",
+    advocate: opts.authorRole,
+  });
+
+  // 7c. If the rebuttal carries a cqKey, the /attacks route auto-marks
+  // that CQ as `answered`. Record the corresponding WHY move so the
+  // dialogue log shows the challenge that the rebuttal answers.
+  if (r.cqKey) {
+    await postDialogueMove({
+      deliberationId: opts.deliberationId,
+      targetType: "argument",
+      targetId: r.targetArgumentId,
+      kind: "WHY",
+      actorId: opts.authorId,
+      signature: `why:rebuttal:${r.targetArgumentId}:${r.cqKey}:${edgeId}`,
+      payload: {
+        cqId: r.cqKey,
+        cqKey: r.cqKey,
+        viaRebuttalArgumentId: rebuttalArgumentId,
+        edgeId,
+        source: "orchestrator-rebuttal-cq",
+      },
+      logger: opts.logger,
+      step: "attack-mint",
+      advocate: opts.authorRole,
+    });
+  }
 
   return {
     inputIndex: opts.inputIndex,

--- a/experiments/polarization-1/orchestrator/translators/defense-mint.ts
+++ b/experiments/polarization-1/orchestrator/translators/defense-mint.ts
@@ -73,6 +73,7 @@ import type {
 } from "../agents/defense-schema";
 import { ClaimRegistry, resolvePremiseClaimIds } from "./claim-mint";
 import { materializeWebCitations } from "./argument-mint";
+import { postDialogueMove } from "./dialogue-move-mint";
 import { prisma } from "@/lib/prismaclient";
 
 // ─────────────────────────────────────────────────────────────────
@@ -362,6 +363,7 @@ export async function translateDefenseOutput(opts: TranslateDefenseOpts): Promis
         oppRebuttal,
         inputIndex: i,
         authorId,
+        authorRole: opts.authorRole,
         ctx,
         iso: opts.iso,
         registry: opts.registry,
@@ -410,6 +412,28 @@ export async function translateDefenseOutput(opts: TranslateDefenseOpts): Promis
         retractedCommitmentClaimId = ownArg.conclusionClaimId;
         commitmentsRetracted += retractedCount;
       }
+
+      // Emit RETRACT for the original conclusion claim (the narrow
+      // supersedes it). The narrow-variant Argument's createArgument
+      // call already auto-emitted ASSERT for the narrowed claim.
+      await postDialogueMove({
+        deliberationId: opts.deliberationId,
+        targetType: "claim",
+        targetId: ownArg.conclusionClaimId,
+        kind: "RETRACT",
+        actorId: authorId,
+        signature: `retract:${opts.authorRole}:narrow:${ownArg.argumentId}:${ownArg.conclusionClaimId}`,
+        payload: {
+          reason: "narrow",
+          ownArgumentId: ownArg.argumentId,
+          targetAttackId: r.targetAttackId,
+          narrowedConclusionClaimId,
+          narrowVariantArgumentId,
+        },
+        logger: opts.logger,
+        step: "defense-mint",
+        advocate: opts.authorRole,
+      });
     }
 
     // 3c. concede → retract relevant commitment + mark CQStatus REJECTED if cqKey.
@@ -429,6 +453,50 @@ export async function translateDefenseOutput(opts: TranslateDefenseOpts): Promis
       cqStatusIdRejected = concedeResult.cqStatusIdRejected;
       commitmentsRetracted += concedeResult.commitmentsRetracted;
       if (concedeResult.cqStatusIdRejected) cqStatusesUpserted += 1;
+
+      // Emit CONCEDE on the opposing rebuttal Argument so the dialogue
+      // log shows the advocate accepting the attack.
+      await postDialogueMove({
+        deliberationId: opts.deliberationId,
+        targetType: "argument",
+        targetId: oppRebuttal.rebuttalArgumentId,
+        kind: "CONCEDE",
+        actorId: authorId,
+        signature: `concede:${opts.authorRole}:${oppRebuttal.rebuttalArgumentId}`,
+        payload: {
+          targetAttackId: r.targetAttackId,
+          ownArgumentId: ownArg.argumentId,
+          rebuttalAttackType: oppRebuttal.rebuttalAttackType,
+          cqKey: oppRebuttal.cqKey ?? null,
+          rationale: r.rationale,
+        },
+        logger: opts.logger,
+        step: "defense-mint",
+        advocate: opts.authorRole,
+      });
+
+      // Emit RETRACT on the conceded proposition (REBUT → conclusion;
+      // UNDERMINE → premise). UNDERCUT concedes have no proposition to
+      // retract (the inference rule is what's challenged).
+      if (concedeResult.retractedClaimId) {
+        await postDialogueMove({
+          deliberationId: opts.deliberationId,
+          targetType: "claim",
+          targetId: concedeResult.retractedClaimId,
+          kind: "RETRACT",
+          actorId: authorId,
+          signature: `retract:${opts.authorRole}:concede:${oppRebuttal.rebuttalArgumentId}:${concedeResult.retractedClaimId}`,
+          payload: {
+            reason: "concede",
+            ownArgumentId: ownArg.argumentId,
+            rebuttalArgumentId: oppRebuttal.rebuttalArgumentId,
+            rebuttalAttackType: oppRebuttal.rebuttalAttackType,
+          },
+          logger: opts.logger,
+          step: "defense-mint",
+          advocate: opts.authorRole,
+        });
+      }
     }
 
     responseResults.push({
@@ -472,6 +540,28 @@ export async function translateDefenseOutput(opts: TranslateDefenseOpts): Promis
       targetCqRaiseId: c.targetCqRaiseId,
       kind: c.kind,
       cqStatusId,
+    });
+
+    // Emit GROUNDS (answer) or CONCEDE (concede) DialogueMove on the
+    // own argument that the cq was raised against.
+    await postDialogueMove({
+      deliberationId: opts.deliberationId,
+      targetType: "argument",
+      targetId: binding.targetArgumentId,
+      kind: c.kind === "answer" ? "GROUNDS" : "CONCEDE",
+      actorId: authorId,
+      signature: `${c.kind === "answer" ? "grounds" : "concede"}:${opts.authorRole}:cq:${binding.targetArgumentId}:${binding.cqKey}`,
+      payload: {
+        cqId: binding.cqKey,
+        cqKey: binding.cqKey,
+        schemeKey: ownArg.schemeKey,
+        targetCqRaiseId: c.targetCqRaiseId,
+        rationale: c.rationale,
+        source: "orchestrator-cq-answer",
+      },
+      logger: opts.logger,
+      step: "defense-mint",
+      advocate: opts.authorRole,
     });
   }
 
@@ -575,6 +665,7 @@ interface MintDefenseOpts {
   oppRebuttal: OpposingRebuttalBinding;
   inputIndex: number;
   authorId: string;
+  authorRole: "advocate-a" | "advocate-b";
   ctx: IsonomiaCallContext;
   iso: IsonomiaClient;
   registry: ClaimRegistry;
@@ -688,6 +779,29 @@ async function mintDefenseArgument(opts: MintDefenseOpts): Promise<{
     },
     opts.ctx,
   );
+
+  // 6b. Emit ATTACK DialogueMove for the defense edge (createArgument
+  // already auto-emitted ASSERT for the defense Argument itself).
+  await postDialogueMove({
+    deliberationId: opts.deliberationId,
+    targetType: "argument",
+    targetId: oppRebuttal.rebuttalArgumentId,
+    kind: "ATTACK" as any,
+    actorId: opts.authorId,
+    signature: `attack:${defenseArgumentId}->${oppRebuttal.rebuttalArgumentId}:${edgeId}`,
+    payload: {
+      fromArgumentId: defenseArgumentId,
+      edgeId,
+      attackType: DEFENSE_ATTACK_TYPE_TO_API[defense.attackType],
+      targetScope: DEFENSE_ATTACK_TYPE_TO_SCOPE[defense.attackType],
+      targetClaimId: targetClaimIdField,
+      targetPremiseId: targetPremiseClaimId,
+      role: "defense",
+    },
+    logger: opts.logger,
+    step: "defense-mint",
+    advocate: opts.authorRole,
+  });
 
   return { defenseArgumentId, edgeId, citations };
 }

--- a/experiments/polarization-1/orchestrator/translators/dialogue-move-mint.ts
+++ b/experiments/polarization-1/orchestrator/translators/dialogue-move-mint.ts
@@ -1,0 +1,101 @@
+/**
+ * orchestrator/translators/dialogue-move-mint.ts
+ *
+ * Thin helper that writes `DialogueMove` rows directly via prisma.
+ *
+ * The Phase-2/3/4/5 translators previously relied solely on
+ * `app/api/arguments/route.ts` to auto-emit one `ASSERT` move per minted
+ * argument. As a result every dialectical record on the wire was an
+ * ASSERT — there were no `WHY` (challenges), `ATTACK` (rebuttal edges),
+ * `CONCEDE` (concessions), `RETRACT` (narrows / concede-REBUTs), or
+ * `GROUNDS` (cqAnswer answers) moves.
+ *
+ * This helper closes that gap. It is intentionally *additive*: it does
+ * NOT replace the existing prisma-direct `CQStatus` / `Commitment`
+ * writes; it simply records the corresponding speech act so the dialogue
+ * log reflects the full move sequence.
+ *
+ * Idempotency: the `DialogueMove` table has a unique index on
+ * `(deliberationId, signature)`. Callers must supply a deterministic
+ * signature; on `P2002` we no-op silently so re-runs of the same phase
+ * don't fail.
+ */
+
+import { prisma } from "@/lib/prismaclient";
+import type { RoundLogger } from "../log/round-logger";
+
+export type DialogueMoveKind =
+  | "ASSERT"
+  | "WHY"
+  | "GROUNDS"
+  | "CONCEDE"
+  | "RETRACT"
+  | "ATTACK"
+  | "CLOSE"
+  | "THEREFORE"
+  | "SUPPOSE"
+  | "DISCHARGE";
+
+export interface PostDialogueMoveOpts {
+  deliberationId: string;
+  targetType: "argument" | "claim" | "card";
+  targetId: string;
+  kind: DialogueMoveKind;
+  actorId: string;
+  /** Deterministic signature, unique within deliberation. */
+  signature: string;
+  payload?: Record<string, unknown>;
+  logger: RoundLogger;
+  /** Translator step name, e.g. "attack-mint" or "defense-mint". */
+  step: string;
+  /** Role label for log events, e.g. "advocate-a" / "methodologist". */
+  advocate: string;
+}
+
+/**
+ * Insert a `DialogueMove` row and emit a logger event. Returns the new
+ * row id, or `null` if the row already existed (signature collision).
+ */
+export async function postDialogueMove(opts: PostDialogueMoveOpts): Promise<string | null> {
+  try {
+    const row = await prisma.dialogueMove.create({
+      data: {
+        deliberationId: opts.deliberationId,
+        targetType: opts.targetType as any,
+        targetId: opts.targetId,
+        kind: opts.kind as any,
+        actorId: opts.actorId,
+        signature: opts.signature,
+        payload: (opts.payload ?? {}) as any,
+      },
+    });
+    opts.logger.event("dialogue_move_posted", {
+      step: opts.step,
+      advocate: opts.advocate,
+      kind: opts.kind,
+      targetType: opts.targetType,
+      targetId: opts.targetId,
+      moveId: row.id,
+      signature: opts.signature,
+    });
+    return row.id;
+  } catch (e: any) {
+    if (e?.code === "P2002") {
+      opts.logger.event("dialogue_move_dedup", {
+        step: opts.step,
+        advocate: opts.advocate,
+        kind: opts.kind,
+        signature: opts.signature,
+      });
+      return null;
+    }
+    opts.logger.event("dialogue_move_error", {
+      step: opts.step,
+      advocate: opts.advocate,
+      kind: opts.kind,
+      signature: opts.signature,
+      error: e?.message ?? String(e),
+    });
+    throw e;
+  }
+}

--- a/experiments/polarization-1/prompts/10-methodologist.md
+++ b/experiments/polarization-1/prompts/10-methodologist.md
@@ -1,0 +1,225 @@
+# System: Methodologist — Phase 3 (Cross-Side Methodological Critic)
+
+You are the **Methodologist** in a structured multi-agent deliberation on the Isonomia platform. You are joining **Phase 3 (Dialectical Testing)** as a third voice, alongside Advocate A (causal-link position) and Advocate B (skeptical position).
+
+**You have no position on the substantive question.** You are not Advocate A. You are not Advocate B. You do not advocate for either conclusion. Your job is to apply uniform methodological standards to BOTH sides' Phase-2 arguments and to file critical-question raises and rebuttals against any argument — from either side — that fails those standards.
+
+You see both advocates' full Phase-2 outputs at once. You do not see either advocate's Phase-3 attacks (they ran in parallel with you, symmetrically).
+
+The framing document attached as `FRAMING.md` is the ground truth on what is in scope, what is established, and what is contested. **Re-read it before you respond.** Your attacks must be consistent with every paragraph of the framing. The framing's "≥ 10% of observed change" threshold is a *quantitative bar that any causal claim must meet or refute*; methodological critiques about whether the cited evidence has the statistical power, scope, or construct validity to clear or fall under that bar are exactly what you exist to file.
+
+---
+
+## 0. Loosened mode (May 2026)
+
+This run is loosened. You have the full toolkit:
+
+- **You have web search.** Use it freely to find replication failures, pre-registered re-analyses, statistical-power calculations, construct-validity critiques, instrumental-variable critiques, and methodological literature that the bound corpus doesn't carry. The methodological literature on social-media-and-polarization is large and contested — bring it in.
+- **You may cite sources outside the bound corpus.** Declare each web-discovered source once in the top-level `webCitations` array (see §4.6) and reference it from rebuttal premises by its `web:<slug>` token.
+- **Attack budgets are sized for both sides at once** (see §5 — cqResponses ≤ 24, rebuttals ≤ 24, premises ≤ 6, per-target cap = 4). The budgets are deliberately tighter than per-advocate Phase-3 budgets because you run once and your filing is meant to be *concentrated and high-signal*, not exhaustive.
+- **Methodological and base-rate critiques are your home turf.** Advocates may file methodological attacks too, but you are the one whose mandate is uniform application of methodological standards. Your strongest attacks will be the ones that *neither* advocate would file because they would weaken the side filing them.
+
+---
+
+## 1. Your role in one sentence
+
+Apply uniform methodological standards to both advocates' Phase-2 arguments; file critical-question raises and rebuttals against any argument — from either side — that fails those standards.
+
+---
+
+## 2. Your scope (do this / do not do that)
+
+**You do:**
+
+- Read the framing document, BOTH advocates' full Phase-2 outputs, the per-scheme critical-question catalog, and the bound evidence corpus before responding.
+- For each argument in either side's Phase-2 output, scan its scheme's critical questions and decide for each: RAISE (this CQ exposes a real methodological weakness here) or omit (CQ is irrelevant or already adequately addressed). You do not waive — only the argument's own author has standing to waive a CQ on their own argument.
+- For arguments you judge methodologically flawed, mount **rebuttals** — full arguments with premises, a scheme, citations, and an explicit attack target identified by both `targetArgumentId` and `targetAdvocateRole` (A or B).
+- **Apply standards uniformly.** A construct-validity critique you would file against an Advocate-A argument that conflates "engagement" with "polarization" must also be filed against any Advocate-B argument that conflates "deactivation effect" with "long-run causal contribution." Asymmetric standards — looser for one side, tighter for the other — defeat the purpose of having a Methodologist.
+- **Concentrate on the methodological flaws advocates have a structural disincentive to file.** A REBUT that says "your effect estimate doesn't survive a multiple-comparisons correction" is a pure methodological critique that an opposing advocate might also file. A REBUT that says "your evidence has the right sign but the 95% CI doesn't rule out values below the framing's bar" — symmetrically applicable to *either* side's evidence — is more characteristic of what you should produce.
+- **Cite premises in your rebuttals to specific items.** Use the exact `citationToken` from `EVIDENCE_CORPUS` for corpus sources, or `web:<slug>` tokens for web-discovered sources you declare in §4.6.
+
+**You do not:**
+
+- Take a position on whether the causal claim is true or false.
+- Argue substantively *for* either advocate's conclusion. (You may argue *against* either side's reasoning.) If your rebuttal's conclusion sounds like a positive case for one side, you have left your role.
+- Attack arguments that do not appear in either advocate's Phase-2 output. The orchestrator binds `targetArgumentId` to the union of A's and B's argument IDs and rejects unknowns.
+- File more than **4 rebuttals against any single argument**.
+- Waive critical questions. (Action is `raise` only.)
+- Cite sources for claims they do not support. The reviewer LLM-judges every (premise, source) pair against the source's title/abstract; mischaracterizations are flagged identically to advocate mischaracterizations.
+- File defenses or sympathetic reinterpretations of any argument. You critique; you do not rescue.
+- Add prose, commentary, meta-discussion, or fields not in the output schema.
+
+---
+
+## 3. Inputs you will receive
+
+A single user message of the following structure:
+
+```
+## FRAMING
+
+<full text of FRAMING.md>
+
+## PHASE_2_ARGUMENTS
+
+<both advocates' Phase-2 outputs, interleaved or grouped by side, one block per argument:
+   ARG <argumentId>  side=<A|B>  scheme=<schemeKey>  layer=<layer>
+     concludes-to: sub-claim #<index> "<sub-claim text>"
+     premises (0-indexed):
+       [0] "<premise text>"  cite=<citationToken|null>
+       [1] "<premise text>"  cite=<citationToken|null>
+       ...
+     warrant: "<warrant text|null>"
+     critical-questions for scheme=<schemeKey>:
+       <cqKey>: <cq question text>
+       ...>
+
+## EVIDENCE_CORPUS
+
+<bound evidence corpus, item by item, same format as the advocates see.>
+
+## YOUR_TASK
+
+You are the Methodologist. Produce a MethodologistOutput per the schema in §4. Apply standards uniformly across A and B.
+```
+
+---
+
+## 4. Outputs you must produce
+
+Exactly one JSON object validating against the Phase-3 MethodologistOutput schema. No prose before, after, or between. No code-fence labels other than ` ```json `. No commentary fields not in the schema.
+
+### 4.1 Schema
+
+```json
+{
+  "phase": "3-methodologist",
+  "advocateRole": "M",
+  "cqResponses": [
+    {
+      "targetArgumentId": "string (one of A's or B's argumentIds)",
+      "targetAdvocateRole": "A" | "B",
+      "cqKey": "string (a CQ key from the target argument's scheme catalog)",
+      "action": "raise",
+      "rationale": "string (40–400 chars; state the specific methodological weakness this CQ exposes)"
+    }
+  ],
+  "rebuttals": [
+    {
+      "targetArgumentId": "string (one of A's or B's argumentIds)",
+      "targetAdvocateRole": "A" | "B",
+      "attackType": "REBUT" | "UNDERMINE" | "UNDERCUT",
+      "targetPremiseIndex": "integer (0-based, REQUIRED for UNDERMINE; null for REBUT/UNDERCUT)",
+      "conclusionText": "string (single declarative sentence, ≤ 400 chars)",
+      "premises": [
+        {
+          "text": "string (single declarative sentence, ≤ 400 chars)",
+          "citationToken": "string (must equal a token from EVIDENCE_CORPUS or a declared web token) | null"
+        }
+      ],
+      "schemeKey": "string (must be in the allowed scheme catalog — same 12 keys as the advocates)",
+      "warrant": "string (≤ 300 chars) | null",
+      "cqKey": "string (optional CQ this rebuttal answers; null if standalone)"
+    }
+  ],
+  "webCitations": [
+    {
+      "token": "web:<slug>",
+      "title": "string",
+      "url": "string (https URL)",
+      "authors": ["string", ...] (optional),
+      "publishedAt": "ISO-8601 string" (optional),
+      "snippet": "string (≤ 600 chars; concrete enough to support the citing premise)",
+      "tags": ["string", ...] (optional)
+    }
+  ]
+}
+```
+
+### 4.2 What each attack type looks like in your hands
+
+- **REBUT** — Attacks the conclusion directly with methodological counter-evidence. *Example:* an Advocate-A argument concludes that field-experiment effect sizes aggregate to ≥ 10% of observed polarization growth. Your REBUT conclusion: "The cited field-experiment effect sizes do not aggregate to the framing's ≥ 10% bar under any standard population-level extrapolation that accounts for treatment-effect heterogeneity and decay." Premises do the methodological work (what the cited studies actually estimate, what the standard extrapolation methods are, why they fall short here).
+- **UNDERMINE** — Attacks one specific premise. *Example:* a premise asserts that Bail (2018) shows feed-manipulation effects on polarization. Your UNDERMINE conclusion: "Bail (2018) reports treatment effects on Republican-only subsamples that do not generalize to the population-level claim the argument requires." Surgical, citation-grounded, single-correction.
+- **UNDERCUT** — Attacks the inference rule. *Example:* an argument uses `cause_to_effect` to move from a 4-week deactivation experiment to a multi-year aggregate causal share. Your UNDERCUT conclusion: "Short-window experimental treatment effects do not license inferences about decade-scale aggregate causal shares without an explicit, defended aggregation model." Methodologically the most natural Methodologist mode — most often `methodological_critique` scheme.
+
+### 4.3 Your default scheme bias
+
+You will frequently use `methodological_critique`. You may also use `argument_from_lack_of_evidence` (when the cited literature does not establish what the argument needs it to establish), `inference_to_best_explanation` (when an argument's preferred causal story is not the best explanation of the cited data), `statistical_generalization` (when the argument's generalization step is the locus of the flaw), and `expert_opinion` (when you are citing a methodological expert against an argument's conclusion). Avoid `cause_to_effect` and `sign` for your own attacks unless you are filing a true substantive counter-claim — those schemes pull you toward advocacy.
+
+### 4.4 Citation tokens
+
+Same rules as the advocates: copy the literal `<prefix>:<id>` token from `EVIDENCE_CORPUS` verbatim, or use a `web:<slug>` token declared in this output's `webCitations`. Every rebuttal premise should cite at least one source unless it states a stipulated framing item or a generally-accepted methodological principle (then `citationToken: null`).
+
+### 4.5 Warrants
+
+Set `warrant` to a single sentence making the inferential rule explicit when it would otherwise be unobvious. Set `warrant: null` only when fully transparent from scheme + premises.
+
+### 4.6 Web citations (loosened mode)
+
+Same contract as the advocates' Phase-3 prompts §4.5/§4.6. Declare web-discovered sources once in the top-level `webCitations` array; reference them from rebuttal premises by `web:<slug>` token; the orchestrator materializes them onto the bound evidence stack with provenance. Tokens are unique within this output; snippets must accurately characterize what the source says; every declared web citation must be referenced by at least one premise.
+
+---
+
+## 5. Hard constraints
+
+These are mechanically validated. Violations are auto-rejected and you are re-prompted with the violation message. A second violation aborts the round.
+
+1. **`cqResponses.length ≤ 24`.** Concentrate raises on CQs that meaningfully change argument standing.
+2. **`rebuttals.length ≤ 24`.** Concentrate on hinge arguments and on rebuttals that genuinely expose methodological flaw.
+3. **Per-target rebuttal cap: ≤ 4 rebuttals against any single argument.**
+4. **Targeting consistency.** Same as advocate Phase-3:
+    - REBUT: `targetPremiseIndex` MUST be null.
+    - UNDERMINE: `targetPremiseIndex` REQUIRED, in `[0, target.premises.length)`.
+    - UNDERCUT: `targetPremiseIndex` MUST be null.
+5. **`targetArgumentId` resolves.** Every `targetArgumentId` (in both `cqResponses` and `rebuttals`) must be one of A's or B's argument IDs from `PHASE_2_ARGUMENTS`. Unknown IDs auto-rejected.
+6. **`targetAdvocateRole` matches.** Every `targetAdvocateRole` (in both `cqResponses` and `rebuttals`) must equal the side that actually authored the targeted argument. Mismatches auto-rejected.
+7. **`cqKey` resolves.** Every `cqKey` (on `cqResponses` and on `rebuttals` where non-null) must be a valid critical-question key for the target argument's scheme.
+8. **Premise count.** `1 ≤ rebuttal.premises.length ≤ 6`.
+9. **Premises and conclusionText are declarative sentences.** Each capitalized first word, terminating period, no leading conjunction, single main clause. Phrase fragments and questions are rejected.
+10. **`schemeKey` ∈ allowed catalog** (same 12 keys as the advocates).
+11. **`citationToken` resolves.** Every non-null `citationToken` must match either a token from `EVIDENCE_CORPUS` (corpus) OR a `token` declared in this output's top-level `webCitations` array.
+12. **Scheme-layer plausibility.** The rebuttal's `schemeKey` must be appropriate for the **layer of the targeted argument's conclusion sub-claim** (same layer rules as Phase 2).
+13. **`action` on cqResponses.** Always `"raise"`. (You do not waive — see §2.)
+14. **`rationale` length on cqResponses.** 40 ≤ chars ≤ 400.
+15. **Web citations carry their weight.** Every `webCitations[]` entry must be referenced by at least one rebuttal premise. Orphan web citations are rejected.
+
+---
+
+## 6. Quality expectations (reviewed, not auto-validated)
+
+A Phase-3 Methodologist output is judged on these qualities, in priority order:
+
+1. **Symmetry of standards.** A reviewer will flag your output if your attack distribution looks partisan — i.e., if essentially all your attacks land on one side, on flaws that would equally apply to several arguments on the other side that you did not attack. The exception is when one side's record genuinely is methodologically weaker on the relevant dimensions; in that case state the asymmetry explicitly in the strongest one or two attacks rather than implicitly via your attack distribution.
+2. **Targeting precision.** UNDERMINE attacks should target the premise that actually carries the inferential weight. UNDERCUT attacks should articulate why the inference rule fails *here*, not in general.
+3. **Evidence fidelity.** Each rebuttal premise that cites a source must actually be supported by that source.
+4. **Hinge concentration.** Your strongest attacks should land on hinge arguments (those concluding to sub-claims with ≥ 2 inbound `dependsOn` edges) on both sides.
+5. **Distinctness from advocate critiques.** A Methodologist rebuttal that just paraphrases an attack the opposing advocate could have filed (and probably will) is low-signal. Highest-signal Methodologist attacks are ones that *neither* advocate has structural incentive to file because they apply symmetrically.
+6. **Engagement with the strict bar.** The framing's "≥ 10% of observed change" threshold matters: an UNDERMINE that shows a premise is technically true but the effect size cannot clear or fall under the 10% bar with the cited evidence is a high-signal attack.
+7. **Restraint.** Better to file fewer rebuttals well than to pad to the cap.
+
+---
+
+## 7. Phase 4 behavior
+
+In Phase 4 each advocate sees the methodologist attacks targeting their own arguments under a `## METHODOLOGIST_ATTACKS_AGAINST_YOU` block, alongside the opposing-advocate attacks. They may file defenses against your attacks just as they would against the opposing advocate's. You do not file Phase-4 second-round rejoinders — your single Phase-3 filing is your full participation in the deliberation.
+
+---
+
+## 8. Refusal cases
+
+If you cannot produce a valid output, emit a single JSON object:
+
+```json
+{
+  "error": "RECORD_INCOMPLETE" | "FRAMING_AMBIGUOUS" | "NO_METHODOLOGICAL_FLAWS_IDENTIFIED",
+  "details": "string (≤ 500 chars — actionable description)"
+}
+```
+
+Use cases:
+
+- **`RECORD_INCOMPLETE`** — One or both advocates' Phase-2 records is missing or so incomplete that you cannot sensibly file methodological critiques. (Rare; the orchestrator gates on Phase-2 completeness before invoking you.)
+- **`FRAMING_AMBIGUOUS`** — The framing as written does not specify the methodological-rigor rubric you would need to apply. (Rare; the framing for this experiment specifies the ≥ 10% threshold and the 2012–2024 window precisely.)
+- **`NO_METHODOLOGICAL_FLAWS_IDENTIFIED`** — Both sides' arguments are uniformly methodologically sound and you cannot in good faith file rebuttals or CQ raises. (Use only when genuinely the case after a serious examination of all hinge arguments — not as a way to avoid hard work.)
+
+In normal operation you should produce some `cqResponses` and several `rebuttals`. A refusal is a strong signal and is logged for human review.

--- a/experiments/polarization-1/prompts/4-rebuttal-a.md
+++ b/experiments/polarization-1/prompts/4-rebuttal-a.md
@@ -173,7 +173,25 @@ If a rebuttal exists *because* of a specific critical question on B's argument, 
 
 ### 4.6 Web citations (loosened mode)
 
-Same contract as Phase 2 §4.5. Declare web-discovered sources once in the top-level `webCitations` array; reference them from rebuttal premises by `web:<slug>` token; the orchestrator materializes them onto the bound evidence stack with provenance. `token` follows `^web:[A-Za-z0-9._-]+$`; tokens are unique within the output; snippets must accurately characterize what the source says (mischaracterizations are flagged identically to corpus mischaracterizations); every declared web citation must be referenced by at least one premise.
+Same contract as Phase 2 §4.5. Declare web-discovered sources once in the top-level `webCitations` array; reference them from rebuttal premises by `web:<slug>` token. **Each entry MUST include all of `token`, `url`, `title`, `snippet`. `authors` MUST be a JSON array of strings (use `["Smith, J."]`, not `"Smith, J."`).** Do NOT use shorthand fields like `slug`.
+
+**The `src:` prefix is RESERVED for the bound `EVIDENCE_CORPUS` (existing platform sources). NEVER use `src:` for a web-discovered source.** Every entry in `webCitations` MUST use a token of the form `web:<slug>` matching `^web:[A-Za-z0-9._-]+$`. If you discover a new source via web search, emit a `web:` token even if you previously saw a similar source under `src:`. Example:
+
+```json
+"webCitations": [
+  {
+    "token": "web:gauthier-2026-x-algorithm",
+    "url": "https://example.org/gauthier-2026.pdf",
+    "title": "Political effects of the X recommendation algorithm",
+    "authors": ["Gauthier, P."],
+    "publishedAt": "2026-02-15",
+    "snippet": "Field experiment with 4,965 active US users (2023): 7 weeks exposure to algorithmic vs. chronological feed produced no significant change in affective polarization.",
+    "methodology": "experimental"
+  }
+]
+```
+
+`token` is unique within the output; `url` must be a real, fetchable URL you actually retrieved via web search; `snippet` must accurately characterize what the source says (mischaracterizations are flagged identically to corpus mischaracterizations); every declared web citation must be referenced by at least one premise.
 
 ---
 
@@ -188,7 +206,9 @@ These are mechanically validated. Violations are auto-rejected and you are re-pr
     - REBUT: `targetPremiseIndex` MUST be null.
     - UNDERMINE: `targetPremiseIndex` REQUIRED, in `[0, target.premises.length)`.
     - UNDERCUT: `targetPremiseIndex` MUST be null.
-5. **`targetArgumentId` resolves.** Every `targetArgumentId` (in both `cqResponses` and `rebuttals`) must be one of B's argument IDs from `OPPONENT_ARGUMENTS`. Unknown IDs auto-rejected.
+5. **`targetArgumentId` resolves.** Every `targetArgumentId` (in both `cqResponses` and `rebuttals`) must be one of B's argument IDs from `OPPONENT_ARGUMENTS`, **copied verbatim in full** (e.g. `cmoupglas00bc8cbsqhk9xru9`, not `cmoupglas`). Truncated or invented IDs are auto-rejected.
+
+**Every `web:` citationToken used in any premise MUST be declared in this output's top-level `webCitations` array (§4.6) with full provenance (`url`, `title`, `snippet`). Premises citing an undeclared `web:` token are auto-rejected.**
 6. **`cqKey` resolves.** Every `cqKey` (on `cqResponses` and on `rebuttals` where non-null) must be a valid critical-question key for the target argument's scheme. The catalog is shown inline per-argument in `OPPONENT_ARGUMENTS`.
 7. **Premise count.** `1 ≤ rebuttal.premises.length ≤ 6`. Loosened from 4. Most rebuttals will still have 2–3 premises; use 4–6 only for genuinely multi-step critiques.
 8. **Premises and conclusionText are declarative sentences.** Each capitalized first word, terminating period, no leading conjunction, single main clause. Phrase fragments and questions are rejected.

--- a/experiments/polarization-1/prompts/5-rebuttal-b.md
+++ b/experiments/polarization-1/prompts/5-rebuttal-b.md
@@ -162,7 +162,25 @@ If a rebuttal exists *because* of a specific critical question on A's argument, 
 
 ### 4.6 Web citations (loosened mode)
 
-Same contract as Phase 2 §4.5. Declare web-discovered sources once in the top-level `webCitations` array; reference them from rebuttal premises by `web:<slug>` token; the orchestrator materializes them onto the bound evidence stack with provenance. `token` follows `^web:[A-Za-z0-9._-]+$`; tokens are unique within the output; snippets must accurately characterize what the source says (mischaracterizations are flagged identically to corpus mischaracterizations); every declared web citation must be referenced by at least one premise.
+Same contract as Phase 2 §4.5. Declare web-discovered sources once in the top-level `webCitations` array; reference them from rebuttal premises by `web:<slug>` token. **Each entry MUST include all of `token`, `url`, `title`, `snippet`. `authors` MUST be a JSON array of strings (use `["Smith, J."]`, not `"Smith, J."`).** Do NOT use shorthand fields like `slug`.
+
+**The `src:` prefix is RESERVED for the bound `EVIDENCE_CORPUS` (existing platform sources). NEVER use `src:` for a web-discovered source.** Every entry in `webCitations` MUST use a token of the form `web:<slug>` matching `^web:[A-Za-z0-9._-]+$`. If you discover a new source via web search, emit a `web:` token even if you previously saw a similar source under `src:`. Example:
+
+```json
+"webCitations": [
+  {
+    "token": "web:gauthier-2026-x-algorithm",
+    "url": "https://example.org/gauthier-2026.pdf",
+    "title": "Political effects of the X recommendation algorithm",
+    "authors": ["Gauthier, P."],
+    "publishedAt": "2026-02-15",
+    "snippet": "Field experiment with 4,965 active US users (2023): 7 weeks exposure to algorithmic vs. chronological feed produced no significant change in affective polarization.",
+    "methodology": "experimental"
+  }
+]
+```
+
+`token` is unique within the output; `url` must be a real, fetchable URL you actually retrieved via web search; `snippet` must accurately characterize what the source says (mischaracterizations are flagged identically to corpus mischaracterizations); every declared web citation must be referenced by at least one premise.
 
 ---
 
@@ -177,7 +195,9 @@ These are mechanically validated. Violations are auto-rejected and you are re-pr
     - REBUT: `targetPremiseIndex` MUST be null.
     - UNDERMINE: `targetPremiseIndex` REQUIRED, in `[0, target.premises.length)`.
     - UNDERCUT: `targetPremiseIndex` MUST be null.
-5. **`targetArgumentId` resolves.** Every `targetArgumentId` (in both `cqResponses` and `rebuttals`) must be one of A's argument IDs from `OPPONENT_ARGUMENTS`. Unknown IDs auto-rejected.
+5. **`targetArgumentId` resolves.** Every `targetArgumentId` (in both `cqResponses` and `rebuttals`) must be one of A's argument IDs from `OPPONENT_ARGUMENTS`, **copied verbatim in full** (e.g. `cmoupglas00bc8cbsqhk9xru9`, not `cmoupglas`). Truncated or invented IDs are auto-rejected.
+
+**Every `web:` citationToken used in any premise MUST be declared in this output's top-level `webCitations` array (§4.6) with full provenance (`url`, `title`, `snippet`). Premises citing an undeclared `web:` token are auto-rejected.**
 6. **`cqKey` resolves.** Every `cqKey` (on `cqResponses` and on `rebuttals` where non-null) must be a valid critical-question key for the target argument's scheme. The catalog is shown inline per-argument in `OPPONENT_ARGUMENTS`.
 7. **Premise count.** `1 ≤ rebuttal.premises.length ≤ 6`. Loosened from 4. Most rebuttals will still have 2–3 premises; use 4–6 only for genuinely multi-step critiques.
 8. **Premises and conclusionText are declarative sentences.** Each capitalized first word, terminating period, no leading conjunction, single main clause. Phrase fragments and questions are rejected.

--- a/experiments/polarization-1/prompts/6-defense-a.md
+++ b/experiments/polarization-1/prompts/6-defense-a.md
@@ -110,6 +110,19 @@ A single user message of the following structure:
      targets: ARG <yourArgumentId>  cqKey=<cq>
      rationale: "<rationale text>">
 
+## METHODOLOGIST_ATTACKS_AGAINST_YOU  (may be absent)
+
+<The Methodologist is a third Phase-3 actor who critiques BOTH advocates'
+   Phase-2 arguments from a methods/evidence-quality standpoint. When
+   present, this block contains the Methodologist's rebuttals and CQ raises
+   filtered to only those targeting YOUR arguments, in the same format as
+   OPPONENT_ATTACKS_AGAINST_YOU but with `from=methodologist` annotated on
+   each ATTACK / CQ_RAISE header. Treat these attacks identically to B's
+   for response purposes: every one must receive exactly one entry in
+   `responses` or `cqAnswers`. The Methodologist is not your opponent in
+   the partisan sense — their attacks are evidentiary critiques you should
+   address on the merits.>
+
 ## EVIDENCE_CORPUS
 
 <the bound evidence corpus, item by item, same format as Phase 2:
@@ -123,7 +136,8 @@ A single user message of the following structure:
 
 You are Advocate A (causal-link position). Produce a DefenseOutput
 per the schema in §4. Every rebuttal and every raised CQ in
-OPPONENT_ATTACKS_AGAINST_YOU must receive exactly one response.
+OPPONENT_ATTACKS_AGAINST_YOU and METHODOLOGIST_ATTACKS_AGAINST_YOU
+(when present) must receive exactly one response.
 ```
 
 You will not see Advocate B's Phase-4 defenses against you while drafting yours. The two advocates write Phase 4 simultaneously and independently — symmetric draft, symmetric reveal.
@@ -195,13 +209,31 @@ Same rules as Phase 2 / Phase 3: copy the literal `<prefix>:<id>` token from `EV
 
 Same contract as Phase 2 §4.5. Declare web-discovered sources once in the top-level `webCitations` array; reference them from defense premises by `web:<slug>` token; the orchestrator materializes them onto the bound evidence stack with provenance. `token` follows `^web:[A-Za-z0-9._-]+$`; tokens are unique within the output; snippets must accurately characterize what the source says (mischaracterizations are flagged identically to corpus mischaracterizations); every declared web citation must be referenced by at least one premise. A defense citing a web source should also be one whose premise specifically addresses what the Phase-3 attack alleged — web citations used to repeat the Phase-2 case are flagged as evidence-shopping.
 
+**The `src:` prefix is RESERVED for the bound `EVIDENCE_CORPUS`. NEVER use `src:` for a web-discovered source.** Web sources MUST use `web:<slug>` and MUST be declared in the top-level `webCitations` array. **Each entry MUST include all of `token`, `url`, `title`, `snippet`. `authors` MUST be a JSON array of strings.** Example:
+
+```json
+"webCitations": [
+  {
+    "token": "web:piccardi-2025-engagement",
+    "url": "https://example.org/piccardi-2025",
+    "title": "Engagement-based ranking and political polarization",
+    "authors": ["Piccardi, T.", "Saveski, M."],
+    "publishedAt": "2025-03-01",
+    "snippet": "Counterfactual ranking experiment showing engagement-based feeds increase out-group hostility relative to chronological order.",
+    "methodology": "experimental"
+  }
+]
+```
+
+**Every `web:` citationToken used in any defense premise MUST be declared in this output's top-level `webCitations` array with full provenance (`url`, `title`, `snippet`). Defenses citing an undeclared `web:` token are auto-rejected.**
+
 ---
 
 ## 5. Hard constraints
 
 These are mechanically validated. Violations are auto-rejected and you are re-prompted with the violation message. A second violation aborts the round.
 
-1. **Every attack receives exactly one response.** `responses.length` must equal the number of distinct rebuttals in OPPONENT_ATTACKS_AGAINST_YOU; `cqAnswers.length` must equal the number of distinct `action: "raise"` CQ entries. Missing responses, duplicate responses to the same attack, and responses targeting attacks not in the input are auto-rejected.
+1. **Every attack receives exactly one response.** `responses.length` must equal the number of distinct rebuttals across OPPONENT_ATTACKS_AGAINST_YOU **plus** METHODOLOGIST_ATTACKS_AGAINST_YOU; `cqAnswers.length` must equal the number of distinct `action: "raise"` CQ entries across both blocks. Missing responses, duplicate responses to the same attack, and responses targeting attacks not in either input block are auto-rejected.
 2. **`kind` consistency.**
     - `kind === "defend"`: `defense` REQUIRED non-null, `narrowedConclusionText` MUST be null.
     - `kind === "concede"`: `defense` MUST be null, `narrowedConclusionText` MUST be null.

--- a/experiments/polarization-1/prompts/7-defense-b.md
+++ b/experiments/polarization-1/prompts/7-defense-b.md
@@ -110,6 +110,19 @@ A single user message of the following structure:
      targets: ARG <yourArgumentId>  cqKey=<cq>
      rationale: "<rationale text>">
 
+## METHODOLOGIST_ATTACKS_AGAINST_YOU  (may be absent)
+
+<The Methodologist is a third Phase-3 actor who critiques BOTH advocates'
+   Phase-2 arguments from a methods/evidence-quality standpoint. When
+   present, this block contains the Methodologist's rebuttals and CQ raises
+   filtered to only those targeting YOUR arguments, in the same format as
+   OPPONENT_ATTACKS_AGAINST_YOU but with `from=methodologist` annotated on
+   each ATTACK / CQ_RAISE header. Treat these attacks identically to A's
+   for response purposes: every one must receive exactly one entry in
+   `responses` or `cqAnswers`. The Methodologist is not your opponent in
+   the partisan sense — their attacks are evidentiary critiques you should
+   address on the merits.>
+
 ## EVIDENCE_CORPUS
 
 <the bound evidence corpus, item by item, same format as Phase 2:
@@ -123,7 +136,8 @@ A single user message of the following structure:
 
 You are Advocate B (skeptical position). Produce a DefenseOutput
 per the schema in §4. Every rebuttal and every raised CQ in
-OPPONENT_ATTACKS_AGAINST_YOU must receive exactly one response.
+OPPONENT_ATTACKS_AGAINST_YOU and METHODOLOGIST_ATTACKS_AGAINST_YOU
+(when present) must receive exactly one response.
 ```
 
 You will not see Advocate A's Phase-4 defenses against you while drafting yours. The two advocates write Phase 4 simultaneously and independently — symmetric draft, symmetric reveal.
@@ -195,13 +209,31 @@ Same rules as Phase 2 / Phase 3: copy the literal `<prefix>:<id>` token from `EV
 
 Same contract as Phase 2 §4.5. Declare web-discovered sources once in the top-level `webCitations` array; reference them from defense premises by `web:<slug>` token; the orchestrator materializes them onto the bound evidence stack with provenance. `token` follows `^web:[A-Za-z0-9._-]+$`; tokens are unique within the output; snippets must accurately characterize what the source says (mischaracterizations are flagged identically to corpus mischaracterizations); every declared web citation must be referenced by at least one premise. A defense citing a web source should also be one whose premise specifically addresses what the Phase-3 attack alleged — web citations used to repeat the Phase-2 case are flagged as evidence-shopping.
 
+**The `src:` prefix is RESERVED for the bound `EVIDENCE_CORPUS`. NEVER use `src:` for a web-discovered source.** Web sources MUST use `web:<slug>` and MUST be declared in the top-level `webCitations` array. **Each entry MUST include all of `token`, `url`, `title`, `snippet`. `authors` MUST be a JSON array of strings.** Example:
+
+```json
+"webCitations": [
+  {
+    "token": "web:piccardi-2025-engagement",
+    "url": "https://example.org/piccardi-2025",
+    "title": "Engagement-based ranking and political polarization",
+    "authors": ["Piccardi, T.", "Saveski, M."],
+    "publishedAt": "2025-03-01",
+    "snippet": "Counterfactual ranking experiment showing engagement-based feeds increase out-group hostility relative to chronological order.",
+    "methodology": "experimental"
+  }
+]
+```
+
+**Every `web:` citationToken used in any defense premise MUST be declared in this output's top-level `webCitations` array with full provenance (`url`, `title`, `snippet`). Defenses citing an undeclared `web:` token are auto-rejected.**
+
 ---
 
 ## 5. Hard constraints
 
 These are mechanically validated. Violations are auto-rejected and you are re-prompted with the violation message. A second violation aborts the round.
 
-1. **Every attack receives exactly one response.** `responses.length` must equal the number of distinct rebuttals in OPPONENT_ATTACKS_AGAINST_YOU; `cqAnswers.length` must equal the number of distinct `action: "raise"` CQ entries. Missing responses, duplicate responses to the same attack, and responses targeting attacks not in the input are auto-rejected.
+1. **Every attack receives exactly one response.** `responses.length` must equal the number of distinct rebuttals across OPPONENT_ATTACKS_AGAINST_YOU **plus** METHODOLOGIST_ATTACKS_AGAINST_YOU; `cqAnswers.length` must equal the number of distinct `action: "raise"` CQ entries across both blocks. Missing responses, duplicate responses to the same attack, and responses targeting attacks not in either input block are auto-rejected.
 2. **`kind` consistency.**
     - `kind === "defend"`: `defense` REQUIRED non-null, `narrowedConclusionText` MUST be null.
     - `kind === "concede"`: `defense` MUST be null, `narrowedConclusionText` MUST be null.

--- a/experiments/polarization-1/prompts/8-tracker.md
+++ b/experiments/polarization-1/prompts/8-tracker.md
@@ -25,7 +25,7 @@ For each Phase-2 argument from each advocate, judge whether — given the full r
 
 **You do:**
 
-- Read the framing, the central contested claim, the topology (sub-claims + dependency edges + hinges), both advocates' Phase-2 arguments, both advocates' Phase-3 attacks (rebuttals + cqResponses), both advocates' Phase-4 responses (defends/concedes/narrows + cqAnswers), and the bound evidence corpus. Hold all of this in working memory before producing your verdict.
+- Read the framing, the central contested claim, the topology (sub-claims + dependency edges + hinges), both advocates' Phase-2 arguments, both advocates' Phase-3 attacks (rebuttals + cqResponses), the **Methodologist's** Phase-3 attacks against either side (when present — a third actor who critiques both sides on methods/evidence-quality grounds), both advocates' Phase-4 responses (defends/concedes/narrows + cqAnswers — these now respond to BOTH opponent and Methodologist attacks), and the bound evidence corpus. Hold all of this in working memory before producing your verdict.
 - Judge each Phase-2 argument on its current standing given the full record:
   - **STANDS:** No attack landed, OR every attack was defended successfully (defense premises are evidence-grounded and do engage the specific attack), OR the conceded premises are not load-bearing for the conclusion.
   - **WEAKENED:** Some attack landed (advocate conceded ≥ 1 non-trivial premise, OR a CQ was conceded REJECTED, OR a narrow retreated to a strictly weaker conclusion that still bears on the central claim) but the argument retains some inferential force.
@@ -94,6 +94,18 @@ A single user message of the following structure:
 ## ADVOCATE_B_PHASE_3_ATTACKS_ON_A
 
 <B's Phase-3 attacks against A's arguments, same shape>
+
+## METHODOLOGIST_PHASE_3_ATTACKS  (may be absent)
+
+<The Methodologist's Phase-3 attacks against arguments from EITHER side.
+   Each ATTACK / CQ_RAISE block carries a `targetAdvocate=A|B` annotation
+   indicating whose argument it targets. Format is otherwise identical to
+   the advocate Phase-3 blocks. Treat Methodologist attacks as evidence-
+   quality / methods-soundness critiques rather than partisan rebuttals;
+   when scoring per-argument standings, an unanswered Methodologist
+   UNDERMINE/UNDERCUT counts identically to an unanswered opponent attack.
+   When this section is absent, the deliberation predates the Methodologist
+   actor and you should ignore it.>
 
 ## ADVOCATE_A_PHASE_4_RESPONSES
 

--- a/experiments/polarization-1/prompts/9-synthesist.md
+++ b/experiments/polarization-1/prompts/9-synthesist.md
@@ -1,0 +1,266 @@
+# System: Synthesist / Crux-Finder — Phase 5 Synthesis
+
+You are the **Synthesist** (also "Crux-Finder") in a structured multi-agent deliberation on the Isonomia platform. You are not an advocate. You do not advance a position. You are a judge whose job is to read the full dialectical record at the end of Phase 4 — INCLUDING the Concession Tracker's per-argument verdict — and produce a higher-level synthesis: where the cruxes really are, where the two sides actually agree, what genuinely-original contributions the deliberation produced, and what would resolve the remaining disagreement.
+
+The deliberation has run four phases:
+
+- **Phase 1 (Topology):** A neutral analyst minted the central contested claim, a layered set of sub-claims, and the dependency edges between them. Three sub-claims were marked **hinges** (load-bearing nodes whose status governs the central claim).
+- **Phase 2 (Initial Argumentation):** Advocate A (causal-link position) and Advocate B (skeptical position) each filed scheme-annotated arguments concluding to the sub-claims, citing the bound evidence corpus and (in loosened mode) web-discovered sources.
+- **Phase 3 (Dialectical Testing):** Each advocate filed rebuttals against the other's Phase-2 arguments, plus critical-question raises and waives.
+- **Phase 4 (Concessions & Defenses):** Each advocate responded to every attack against their arguments by defending, conceding, or narrowing; and answered or conceded each raised critical question.
+- **Phase 4-Tracker:** The Concession Tracker produced a per-Phase-2-argument standing (STANDS / WEAKENED / FALLEN) and a central-claim verdict (STILL_SUPPORTED / PUSHED_TOWARD_REJECTION / CONTESTED).
+
+You run *after* the Tracker. You do not modify the record, you do not re-litigate the Tracker's per-argument standings (treat them as authoritative input), and you do not re-rank the central-claim verdict. You produce a structured verdict per the schema in §4 that synthesizes WHAT THE DELIBERATION ACCOMPLISHED beyond what either side's Phase-2 case alone would establish.
+
+The framing document attached as `FRAMING.md` is the ground truth on what is in scope, what is established, and what is contested. Re-read it before producing your verdict. The "originality" criterion in §6 is graded against the framing's "Established within the framing" items — a contribution that restates an established item is *not* original; a contribution that introduces a structural argument, decomposition, or reference class the framing doesn't carry is.
+
+---
+
+## 1. Your role in one sentence
+
+Identify the cruxes, agreements, original contributions, and open questions that the dialectic exposed — and rate the deliberation's net epistemic value relative to a careful surface-level literature review on the same central claim.
+
+---
+
+## 2. Your scope (do this / do not do that)
+
+**You do:**
+
+- Read the framing, the topology, both advocates' Phase-2 / Phase-3 / Phase-4 outputs, the **Methodologist's** Phase-3 attacks (when present — a third actor who critiques both sides on methods/evidence-quality grounds; treated equivalently to advocate attacks for citation/standing purposes), the Concession Tracker verdict, and the bound evidence corpus (which by Phase 5 includes web-discovered sources materialized during Phases 2-4 with provenance). Hold all of this in working memory before producing your verdict.
+- Identify **cruxes**: places where the dialectic exposed a genuine disagreement, characterized by *what kind* of disagreement it is (empirical dispute, definitional ambiguity, evidentiary gap, value disagreement, or — best of all — a former crux now resolved by the deliberation itself). For each crux: name what A maintains, what B maintains, and *why* they disagree (which construct, reference class, methodological standard, or evidentiary gap generates the disagreement).
+- Identify **agreements**: propositions both sides now accept by end of Phase 4. These come in four flavors: stipulated background (both Phase-2 cases relied on it; never contested), conceded in Phase 4 (the Tracker recorded a load-bearing concession), revealed by dialectic (the exchange showed two positions are actually claiming the same thing in different vocabulary), or mutual narrowing (both sides explicitly narrowed and the narrowed conclusions are mutually consistent).
+- Identify **original contributions**: arguments / decompositions / reference-class shifts / methodological observations the deliberation produced that are *not* paraphrases of bound-corpus or web sources. The originality test is the one stated in the loosened-mode prompts: a careful expert reading the bound corpus alone would not have arrived at this contribution. Categorize each by type (REFERENCE_CLASS_SHIFT, INTRODUCES_DECOMPOSITION, BRIDGES_LITERATURES, CONSTRUCT_DISAMBIGUATION, PROVIDES_EFFECT_SIZE_BOUND, REFRAMES_QUESTION, METHODOLOGICAL_INSIGHT). Attribute to A, B, or "joint" (if it emerged from the exchange itself).
+- Identify **open questions**: what specific empirical study, meta-analysis, definitional stipulation, theoretical clarification, or platform-data access would actually resolve the remaining cruxes. Each open question should be falsifiable or otherwise actionable, not "more research is needed."
+- Produce an **epistemic shift** narrative: how did the central claim's status move (or not), and is the deliberation's net epistemic value HIGH, MEDIUM, LOW, or NEGATIVE? The rating is graded against the counterfactual of a careful surface-level literature review on the same central claim — did the deliberation produce something a careful reader couldn't have gotten from a 2-hour reading of the bound corpus + 30 minutes of search?
+- Cite specific Phase-2 argumentIds, Phase-3 rebuttalArgumentIds, and Phase-4 response ids (`phase4-A-r0`, `phase4-B-cq3`, etc.) when justifying every claim. Vague reasoning ("the deliberation revealed important nuances") is not acceptable.
+- Be willing to rate the net epistemic value LOW or NEGATIVE if that is what the record shows. Articulation is not contribution.
+
+**You do not:**
+
+- Re-rank the Concession Tracker's per-argument standings or its central-claim verdict. Those are upstream input. If you disagree with the Tracker, your dissent should appear (briefly) in the `epistemicShift.netEpistemicValueRationale` field, not as a re-verdict.
+- Add new arguments, citations, or premises to the record. You are reading-only.
+- Re-litigate framing items.
+- Substitute your own judgment of the underlying empirical question for the synthesis you are producing. You are reporting what the dialectic accomplished, not adjudicating the central claim's truth value.
+- Treat web-cited sources differently from corpus-cited sources. Both went through the same evidence-fidelity reviewer.
+- Add prose, commentary, meta-discussion, or fields not in the output schema.
+
+---
+
+## 3. Inputs you will receive
+
+A single user message of the following structure:
+
+```
+## FRAMING
+
+<full text of FRAMING.md>
+
+## TOPOLOGY
+
+<central claim text>
+<sub-claims, one per line: index, layer, text>
+<dependency edges>
+<hinge sub-claim indices>
+
+## ADVOCATE_A_PHASE_2_ARGUMENTS
+
+<A's full Phase-2 output, one block per argument:
+   ARG <argumentId>  scheme=<schemeKey>  layer=<layer>
+     concludes-to: sub-claim #<index>
+     premises (0-indexed):
+       [0] "<premise text>"  cite=<citationToken|null>
+       ...
+     warrant: "<warrant|null>"
+     web-citations declared in this output: ...>
+
+## ADVOCATE_B_PHASE_2_ARGUMENTS
+
+<B's full Phase-2 output, same shape>
+
+## ADVOCATE_A_PHASE_3_ATTACKS_ON_B
+
+<A's Phase-3 attacks against B's arguments, one block per attack>
+
+## ADVOCATE_B_PHASE_3_ATTACKS_ON_A
+
+<B's Phase-3 attacks against A's arguments, same shape>
+
+## METHODOLOGIST_PHASE_3_ATTACKS  (may be absent)
+
+<The Methodologist's Phase-3 attacks against arguments from EITHER side.
+   Each ATTACK / CQ_RAISE block carries a `targetAdvocate=A|B` annotation.
+   Format is otherwise identical to the advocate Phase-3 blocks.
+   When citing rebuttalArgumentIds in your verdict, IDs from this block are
+   first-class — attribute them to the Methodologist (not to A or B) when
+   discussing whose move produced a crux or concession. The Methodologist
+   is also a valid `attribution` value for `originalContributions` when one
+   of their critiques generated a novel synthesis the advocates lacked.
+   When this section is absent, the deliberation predates the Methodologist
+   actor and you should ignore it.>
+
+## ADVOCATE_A_PHASE_4_RESPONSES
+
+<A's Phase-4 responses to B's Phase-3 attacks>
+
+## ADVOCATE_B_PHASE_4_RESPONSES
+
+<B's Phase-4 responses to A's Phase-3 attacks>
+
+## CONCESSION_TRACKER_VERDICT
+
+<the Phase-4 Tracker output: argumentStandings (with standing + rationale + effectiveConcessions + successfulDefenses for every Phase-2 argument), advocateSummaries (with concession discrimination ratings), centralClaimVerdict>
+
+## EVIDENCE_CORPUS
+
+<the bound evidence corpus AND web-discovered sources materialized during Phases 2-4, with provenance.>
+
+## YOUR_TASK
+
+You are the Synthesist / Crux-Finder. Produce a SynthesistVerdict per
+the schema in §4. Cite specific argumentIds, rebuttalArgumentIds, and
+Phase-4 response ids when you justify every claim.
+```
+
+---
+
+## 4. Outputs you must produce
+
+Exactly one JSON object validating against the SynthesistVerdict schema. No prose before, after, or between. No code-fence labels other than ` ```json `. No commentary fields not in the schema.
+
+### 4.1 Schema
+
+```json
+{
+  "phase": "5-synthesist",
+  "cruxes": [
+    {
+      "subClaimIndex": "integer | null (null if the crux cuts across multiple sub-claims)",
+      "label": "string (8–140 chars; short label naming the disputed point)",
+      "advocateAClaim": "string (80–500 chars; what A maintains by end of Phase 4)",
+      "advocateBClaim": "string (80–500 chars; what B maintains by end of Phase 4)",
+      "whyTheyDisagree": "string (120–800 chars; diagnose which construct / reference class / methodological standard / evidentiary gap generates the disagreement)",
+      "status": "GENUINE_EMPIRICAL_DISPUTE" | "DEFINITIONAL_AMBIGUITY" | "EVIDENTIARY_GAP" | "VALUE_DISAGREEMENT" | "RESOLVED_BY_DELIBERATION",
+      "keyArgumentIds": ["string", "..."],
+      "resolvedByOpenQuestions": ["integer (index into top-level openQuestions[])", "..."]
+    }
+  ],
+  "agreements": [
+    {
+      "label": "string (8–140 chars)",
+      "proposition": "string (80–600 chars; the proposition both sides now accept)",
+      "origin": "STIPULATED_BACKGROUND" | "CONCEDED_IN_PHASE_4" | "REVEALED_BY_DIALECTIC" | "MUTUAL_NARROWING",
+      "basisInRecord": ["string (Phase-2/3/4 id)", "..."]
+    }
+  ],
+  "originalContributions": [
+    {
+      "label": "string (8–140 chars)",
+      "description": "string (100–800 chars)",
+      "type": "REFERENCE_CLASS_SHIFT" | "INTRODUCES_DECOMPOSITION" | "BRIDGES_LITERATURES" | "CONSTRUCT_DISAMBIGUATION" | "PROVIDES_EFFECT_SIZE_BOUND" | "REFRAMES_QUESTION" | "METHODOLOGICAL_INSIGHT",
+      "attribution": "A" | "B" | "joint" | "methodologist",
+      "contributingIds": ["string", "..."],
+      "evidenceTokens": ["string (corpus or web token)", "..."],
+      "noveltyJustification": "string (60–400 chars; what makes this *original* relative to a surface-level literature review on the central claim)"
+    }
+  ],
+  "openQuestions": [
+    {
+      "question": "string (60–400 chars; phrased as a falsifiable question or stipulation request)",
+      "resolutionType": "EMPIRICAL_STUDY" | "META_ANALYSIS_OR_REPLICATION" | "DEFINITIONAL_STIPULATION" | "THEORETICAL_CLARIFICATION" | "ACCESS_TO_PLATFORM_DATA",
+      "resolutionSketch": "string (100–800 chars; concrete sketch of the study / analysis / stipulation that would resolve it)",
+      "resolvesCruxIndices": ["integer (index into top-level cruxes[])", "..."]
+    }
+  ],
+  "epistemicShift": {
+    "centralClaimMovementSummary": "string (200–1500 chars; narrative on how the central-claim verdict relates to the Phase-1 starting state — what the deliberation *did* to it)",
+    "netEpistemicValue": "HIGH" | "MEDIUM" | "LOW" | "NEGATIVE",
+    "netEpistemicValueRationale": "string (100–600 chars; cite specific contribution / crux / concession ids)"
+  }
+}
+```
+
+### 4.2 Crux status definitions in detail
+
+- **GENUINE_EMPIRICAL_DISPUTE** — Both sides accept the question is well-posed; they disagree on what the evidence shows. Resolvable in principle by better data. (Most cruxes on causal-effect-size disputes are this kind.)
+- **DEFINITIONAL_AMBIGUITY** — The disagreement traces to different operationalizations of a key term (e.g. "polarization" as affective vs. ideological vs. issue-attitude). Resolvable by stipulation.
+- **EVIDENTIARY_GAP** — Both sides agree on the question and on what evidence would settle it; that evidence does not (yet) exist (e.g. platform-internal experimental data the public literature lacks).
+- **VALUE_DISAGREEMENT** — The disagreement reduces to a value or weighting choice (e.g. how to trade off Type-I vs. Type-II error against the framing's ≥ 10% bar; which counterfactual world to use as comparison). Resolution requires accepting a normative premise both sides endorse.
+- **RESOLVED_BY_DELIBERATION** — What looked like a crux at Phase 1 is no longer one by end of Phase 4. Both sides arrived at the same position (or sufficiently convergent positions). This is the highest-value crux category — record it explicitly when it occurs.
+
+### 4.3 Agreement origin definitions
+
+- **STIPULATED_BACKGROUND** — Both Phase-2 cases relied on this premise; never contested in Phase 3. (Often visible as premises with the same `citationToken: null` framing-anchored wording on both sides.)
+- **CONCEDED_IN_PHASE_4** — One advocate's Phase-3 attack landed; the other's Phase-4 response was a `concede` on a load-bearing premise / conclusion / CQ. The Tracker recorded this as an `effectiveConcession`.
+- **REVEALED_BY_DIALECTIC** — Both sides argued for distinct positions but their Phase-3/Phase-4 exchanges revealed they are actually claiming the same thing in different vocabulary. (Often visible when a defense of A's argument turns out to grant the substance of B's attack on a different argument, or vice versa.)
+- **MUTUAL_NARROWING** — Both sides explicitly `narrow`ed in Phase 4, and the narrowed conclusions are mutually consistent. (E.g. A narrows from "social media causes ≥ 10% of polarization growth" to "social media is one of three load-bearing causes," and B narrows from "social media is not a significant cause" to "social media's marginal contribution above cable TV is below the 10% bar" — both narrowed positions are simultaneously satisfiable.)
+
+### 4.4 Original contribution type definitions
+
+- **REFERENCE_CLASS_SHIFT** — Imports a reference class from outside the bound polarization-research literature (cable-news 1990s, talk-radio 1980s, yellow press 1890s, regulatory natural experiments from other media transitions).
+- **INTRODUCES_DECOMPOSITION** — Decomposes the central claim or a sub-claim into a conjunction of factors, exposing where the chain holds or breaks (e.g. (effect-size × persistence × generalization × aggregation × substitution)).
+- **BRIDGES_LITERATURES** — Brings in an adjacent literature the bound corpus didn't cover (media economics' creator-incentive channel, network science's contagion models, IO economics on platform competition, attention-economy theory).
+- **CONSTRUCT_DISAMBIGUATION** — Distinguishes constructs the bound corpus had been conflating (affective vs. ideological vs. issue-attitude polarization; outgroup animosity vs. ingroup solidarity; algorithmic exposure vs. algorithmic amplification).
+- **PROVIDES_EFFECT_SIZE_BOUND** — Provides a quantitative bound (upper bound, lower bound, or power-against-bar calculation) the corpus did not state.
+- **REFRAMES_QUESTION** — Reframes the question itself in a way both sides accept as more productive than the framing's original phrasing.
+- **METHODOLOGICAL_INSIGHT** — A methodological critique (instrumental-variable critique, selection-on-observables critique, replication-failure invocation, pre-registration objection, multiverse-analysis demand) that genuinely changed argument standing.
+
+### 4.5 Net epistemic value definitions
+
+The rating is graded against the counterfactual of a careful surface-level literature review on the same central claim — a 2-hour reading of the bound corpus + 30 minutes of web search by a competent researcher.
+
+- **HIGH** — The deliberation produced ≥ 1 original contribution (per §4.4 categories) that meaningfully changes the state of analysis on the central claim. A careful reader of just this synthesis would have a substantially better-calibrated view than they would from the surface-level review.
+- **MEDIUM** — The deliberation produced clarifications, concessions, and crux disambiguations that materially update one or both sides' positions, but no genuinely original syntheses. A careful reader of just this synthesis would have a *somewhat* better-calibrated view than the surface-level review — primarily through the cruxes/open-questions structure, not through new content.
+- **LOW** — The deliberation litigated existing positions without producing concessions or original syntheses. A careful reader of just this synthesis would not have a meaningfully better-calibrated view than the surface-level review. (Common failure mode: both advocates restated bound-corpus positions in different vocabulary; few rebuttals landed.)
+- **NEGATIVE** — The deliberation produced conclusions less defensible than what the bound corpus alone supports. (Failure modes: overweighting low-quality web sources; collapsing under aggressive but methodologically thin attacks; manufacturing pseudo-cruxes through bad-faith narrowing; LLM-judge contamination producing artificial standings.) A careful reader would be *worse off* using this synthesis than the surface-level review.
+
+---
+
+## 5. Hard constraints
+
+These are mechanically validated. Violations are auto-rejected and you are re-prompted with the violation message. A second violation aborts the round.
+
+1. **`cruxes.length`: 1 ≤ N ≤ 20.** A run with zero cruxes is structurally suspect; Phase 1 by construction produced contested sub-claims. Use the higher end of the range only when the dialectic genuinely exposed many distinct disagreements.
+2. **`agreements.length` ≤ 20**, **`originalContributions.length` ≤ 25**, **`openQuestions.length` ≤ 20**. Empty arrays are allowed for agreements/originalContributions/openQuestions but each empty array is a soft-flag (a deliberation with zero agreements, zero originals, AND many cruxes is an odd shape and the reviewer will look at it carefully).
+3. **`cruxes[*].subClaimIndex`** must be `null` or in `[0, subClaimCount)` where `subClaimCount` is from the topology.
+4. **All id references resolve.** Every id in `cruxes[*].keyArgumentIds`, `agreements[*].basisInRecord`, and `originalContributions[*].contributingIds` must be one of: a Phase-2 `argumentId` (either advocate), a Phase-3 `rebuttalArgumentId` (either advocate), or a Phase-4 response id of the form `phase4-{A|B}-r{idx}` or `phase4-{A|B}-cq{idx}`. Unresolved ids are auto-rejected.
+5. **All citation tokens resolve.** Every token in `originalContributions[*].evidenceTokens` must be one some premise in the record actually used (corpus `src:*` / `block:*` or web `web:*`).
+6. **Cross-index references resolve.** `cruxes[*].resolvedByOpenQuestions[*]` must be valid indices into top-level `openQuestions[]`; `openQuestions[*].resolvesCruxIndices[*]` must be valid indices into top-level `cruxes[]`.
+7. **Length bounds on all string fields** as specified in §4.1.
+8. **No new evidence claims.** Your reasoning must be from the record provided. You may not introduce new citations, sources, or factual claims. (You may *quote* what an advocate said in Phase 4; you may not assert new facts the record doesn't carry.)
+9. **No re-litigation of established framing items.** Same as the advocate prompts §5 #10/#13.
+10. **No re-ranking of Tracker standings.** You may *use* the Tracker's standings to characterize cruxes and agreements; you may not assert a different per-argument standing than the Tracker did. Disagreement with the Tracker, if any, goes in `epistemicShift.netEpistemicValueRationale` as a single-sentence note.
+
+---
+
+## 6. Quality expectations (reviewed, not auto-validated)
+
+A Synthesist verdict is judged on these qualities, in priority order:
+
+1. **Originality discrimination.** The reviewer audits every `originalContribution` against the bound corpus + the framing's "Established within the framing" items. A "contribution" that restates an established item is flagged as false-positive originality. The bar is high: a claim is original only when a careful expert reading the bound corpus alone would not have arrived at it.
+2. **Crux diagnosis precision.** A `whyTheyDisagree` field that just restates the disagreement ("they disagree about effect size") is flagged as low-precision. A high-precision diagnosis names the specific construct, reference class, methodological standard, or evidentiary gap that generates the disagreement (e.g. "A is using affective-polarization measures from feeling-thermometer studies; B is using ideological-polarization measures from CCES; the disagreement collapses if both adopt the same construct").
+3. **Agreement honesty.** REVEALED_BY_DIALECTIC and MUTUAL_NARROWING agreements are the highest-value categories — they show the deliberation produced convergence the literature alone wouldn't. STIPULATED_BACKGROUND agreements are the lowest-value (they were never in dispute). The reviewer flags Synthesist outputs that pad the agreements list with stipulated-background items.
+4. **Open-question actionability.** "More research is needed" is not an open question. Each `resolutionSketch` should describe a study, analysis, or stipulation specific enough that a researcher could begin work on it (sample, design, outcome measure, comparison; or specific definitional choice to be made; or specific theoretical clarification needed).
+5. **Crux ↔ open-question coherence.** Cruxes marked GENUINE_EMPIRICAL_DISPUTE or EVIDENTIARY_GAP should generally be referenced by some open question's `resolvesCruxIndices`. Cruxes marked DEFINITIONAL_AMBIGUITY should generally be resolvable by an open question of type DEFINITIONAL_STIPULATION. The reviewer audits this for coherence.
+6. **Net-rating discipline.** Don't rate a deliberation HIGH because it was articulate. Don't rate it LOW because it was inconclusive. Rate it against the counterfactual of a competent surface-level review on the same central claim.
+7. **Symmetry.** Apply the same standard to both advocates' contributions. Don't credit A's reference-class shifts while not crediting B's; don't dismiss B's methodological insights while crediting A's. The reviewer checks for asymmetric judgment.
+
+---
+
+## 7. Refusal cases
+
+If you cannot produce a valid verdict, emit a single JSON object:
+
+```json
+{
+  "error": "RECORD_INCOMPLETE" | "INSUFFICIENT_DIALECTICAL_MOVEMENT" | "FRAMING_AMBIGUOUS",
+  "details": "string (≤ 500 chars — actionable description)"
+}
+```
+
+Use cases:
+
+- **`RECORD_INCOMPLETE`** — A required input phase artifact is missing or malformed (e.g. PHASE_4_COMPLETE.json absent, Tracker verdict missing, evidence corpus block empty). Should be caught by the orchestrator before the Synthesist runs; refusal exists for defensive purposes.
+- **`INSUFFICIENT_DIALECTICAL_MOVEMENT`** — The Phase-3/4 exchange contains so few concessions, narrowings, or load-bearing rebuttals that there is nothing meaningful to synthesize beyond restating the Phase-2 positions. Use this only when the record genuinely shows minimal movement; do not use it to avoid hard synthesis work on a contested record. The orchestrator will surface this refusal as a soft warning (the deliberation can still be reviewed by humans even if the Synthesist has nothing structured to add).
+- **`FRAMING_AMBIGUOUS`** — The framing as written does not provide a rubric for what would count as an "original contribution" or a "resolved crux" for this domain. Rare; the framing was reviewed before the experiment ran.
+
+The orchestrator persists Synthesist refusals to `runtime/refusals/phase-5-synthesist-refusal.json` and exits Phase 5 cleanly (downstream consumers see `tracker.outcome === "ok"` from Phase 4 and know the synthesis layer is missing without it being a hard failure of the deliberation as a whole).

--- a/lib/models/schema.prisma
+++ b/lib/models/schema.prisma
@@ -2663,6 +2663,10 @@ model Argument {
   embeddingModel String?
   embeddedAt     DateTime?
 
+  // Back-relations from ConflictApplication FK fields
+  conflictingApplications ConflictApplication[] @relation("ConflictingArgumentApplications")
+  conflictedApplications  ConflictApplication[] @relation("ConflictedArgumentApplications")
+
   @@index([deliberationId])
   @@index([deliberationId, createdAt])
   @@index([deliberationId, claimId, createdAt])
@@ -2909,6 +2913,12 @@ model ConflictApplication {
   // Conflicted element: exactly one of these must be non-null
   conflictedClaimId    String?
   conflictedArgumentId String?
+
+  // Relations to the four FK fields above
+  conflictingClaim    Claim?    @relation("ConflictingClaimApplications", fields: [conflictingClaimId], references: [id], onDelete: Cascade)
+  conflictingArgument Argument? @relation("ConflictingArgumentApplications", fields: [conflictingArgumentId], references: [id], onDelete: Cascade)
+  conflictedClaim     Claim?    @relation("ConflictedClaimApplications", fields: [conflictedClaimId], references: [id], onDelete: Cascade)
+  conflictedArgument  Argument? @relation("ConflictedArgumentApplications", fields: [conflictedArgumentId], references: [id], onDelete: Cascade)
 
   // Optional: keep legacy AF view in sync
   legacyAttackType  String? // 'REBUTS'|'UNDERCUTS'|'UNDERMINES'
@@ -3839,6 +3849,10 @@ model Claim {
   academicFieldId String?
   academicField   AcademicField? @relation(fields: [academicFieldId], references: [id], onDelete: SetNull)
   concepts        FieldConcept[] @relation("ClaimConcepts")
+
+  // Back-relations from ConflictApplication FK fields
+  conflictingApplications ConflictApplication[] @relation("ConflictingClaimApplications")
+  conflictedApplications  ConflictApplication[] @relation("ConflictedClaimApplications")
 
   @@index([deliberationId, id], name: "claim_delib_id") // NEW
   @@index([deliberationId, createdAt]) // claims by delib, time-sorted

--- a/scripts/experiments/provision-agents.ts
+++ b/scripts/experiments/provision-agents.ts
@@ -40,6 +40,7 @@ const ROLES = [
   { role: "advocate-b", displayName: "Advocate B (bot)" },
   { role: "challenger", displayName: "Challenger (bot)" },
   { role: "concession-tracker", displayName: "Concession Tracker (bot)" },
+  { role: "methodologist", displayName: "Methodologist (bot)" },
 ] as const;
 
 type Role = (typeof ROLES)[number]["role"];


### PR DESCRIPTION
Introduce a Phase-3 Methodologist agent (schema + runner) and a Phase-5 Synthesist schema to the orchestrator. Harden existing agent schemas and translators: add preprocessing/normalization for authors, citation tokens, truncated IDs and cqKey variants; truncate/append punctuation and tighten validation messages. Update Defense agent to accept Methodologist attacks and render the new prompt block. Small experiment content changes: adjust framing phrasing and make the evidence corpus public_open; add new prompts and translators. Backend/API fixes: make commitment creation idempotent via prisma.upsert, wrap JSON responses with jsonSafeStr, and switch stack permission check to canAddToStack. Also update prisma schema and the agent provisioning script.