### PR TITLE
Add Iter-3 multi-round support and round-2 scaffolding

### DIFF
--- a/experiments/polarization-1/orchestrator/agents/advocate.ts
+++ b/experiments/polarization-1/orchestrator/agents/advocate.ts
@@ -76,7 +76,7 @@ export async function runAdvocateTurn(input: AdvocateTurnInput): Promise<Advocat
     ? input.promptPath
     : path.join(input.cfg.experimentRoot, input.promptPath);
   const systemPrompt = readFileSync(promptPath, "utf8");
-  const model = modelFor(input.cfg);
+  const model = modelFor(input.cfg, "advocate");
 
   const advocateRole: "A" | "B" = input.role === "advocate-a" ? "A" : "B";
   const outputSchema = buildAdvocateOutputSchema({ ...input.schemaOpts, advocateRole });

--- a/experiments/polarization-1/orchestrator/agents/claim-analyst.ts
+++ b/experiments/polarization-1/orchestrator/agents/claim-analyst.ts
@@ -61,7 +61,7 @@ export { isRefusal };
 export async function runClaimAnalystTurn(input: ClaimAnalystTurnInput): Promise<ClaimAnalystTurnResult> {
   const promptPath = path.join(input.cfg.experimentRoot, "prompts", "1-claim-analyst.md");
   const systemPrompt = readFileSync(promptPath, "utf8");
-  const model = modelFor(input.cfg);
+  const model = modelFor(input.cfg, "claim-analyst");
 
   const userMessage = renderUserMessage({
     framing: input.framing,

--- a/experiments/polarization-1/orchestrator/agents/defense-schema.ts
+++ b/experiments/polarization-1/orchestrator/agents/defense-schema.ts
@@ -163,9 +163,21 @@ export type CqAnswer = z.infer<typeof CqAnswerZ>;
 // Top-level Phase-4 output
 // ─────────────────────────────────────────────────────────────────
 
+/**
+ * Iter-3 multi-round Phase 4. `"a"` = sub-round-a, defending against
+ * Phase-3 round-1 attacks (current Iter-2 behavior). `"b"` = sub-round-b,
+ * defending against Phase-3 round-2 attacks (which themselves may have
+ * targeted either THIS advocate's Phase-2 args OR THIS advocate's
+ * round-1 rebuttals). Default `"a"` preserves Iter-2 behavior.
+ */
+export const DefenseSubRoundZ = z.enum(["a", "b"]);
+export type DefenseSubRound = z.infer<typeof DefenseSubRoundZ>;
+
 const DefenseOutputZ = z.object({
   phase: z.literal("4"),
   advocateRole: z.enum(["A", "B"]),
+  /** Iter-3: which sub-round of Phase 4. Defaults to "a" so Iter-2 outputs validate. */
+  subRound: DefenseSubRoundZ.default("a"),
   responses: z.array(ResponseZ).default([]),
   cqAnswers: z.array(CqAnswerZ).default([]),
   /** Loosened-mode web sources discovered while drafting defenses. */

--- a/experiments/polarization-1/orchestrator/agents/defense.ts
+++ b/experiments/polarization-1/orchestrator/agents/defense.ts
@@ -93,7 +93,7 @@ export async function runDefenseTurn(input: DefenseTurnInput): Promise<DefenseTu
     ? input.promptPath
     : path.join(input.cfg.experimentRoot, input.promptPath);
   const systemPrompt = readFileSync(promptPath, "utf8");
-  const model = modelFor(input.cfg);
+  const model = modelFor(input.cfg, "defense");
 
   const advocateRole: "A" | "B" = input.role === "advocate-a" ? "A" : "B";
   const outputSchema = buildDefenseOutputSchema({ ...input.schemaOpts, advocateRole });

--- a/experiments/polarization-1/orchestrator/agents/methodologist-schema.ts
+++ b/experiments/polarization-1/orchestrator/agents/methodologist-schema.ts
@@ -73,9 +73,16 @@ const MethodologistPremiseZ = z.object({
 
 const TargetAdvocateRoleZ = z.enum(["A", "B"]);
 
+/** Iter-3: tag identifying which kind of object `targetArgumentId`
+ *  resolves to. Default `"phase2-arg"` preserves Iter-2 behavior. */
+const MethTargetKindZ = z.enum(["phase2-arg", "round1-rebuttal"]).default("phase2-arg");
+/** Iter-3 round indicator. Default `"1"` preserves Iter-2 behavior. */
+const MethRoundZ = z.enum(["1", "2"]).default("1");
+
 const MethodologistCqResponseZ = z.object({
-  /** Argument-id of the targeted advocate's argument. */
+  /** Argument-id of the targeted advocate's argument (or round-1 rebuttal in Iter-3 round-2). */
   targetArgumentId: z.string().min(4),
+  targetKind: MethTargetKindZ,
   /** Which advocate authored the targeted argument. */
   targetAdvocateRole: TargetAdvocateRoleZ,
   /** Critical-question key from the target argument's scheme. */
@@ -90,6 +97,7 @@ export type MethodologistCqResponse = z.infer<typeof MethodologistCqResponseZ>;
 
 const MethodologistRebuttalZ = z.object({
   targetArgumentId: z.string().min(4),
+  targetKind: MethTargetKindZ,
   targetAdvocateRole: TargetAdvocateRoleZ,
   attackType: AttackTypeZ,
   targetPremiseIndex: z.number().int().nonnegative().nullable(),
@@ -108,6 +116,8 @@ export type MethodologistRebuttal = z.infer<typeof MethodologistRebuttalZ>;
 export const MethodologistOutputZ = z.object({
   phase: z.literal("3-methodologist"),
   advocateRole: z.literal("M"),
+  /** Iter-3 multi-round indicator. Defaults to "1" so Iter-2 outputs validate. */
+  round: MethRoundZ,
   cqResponses: z.array(MethodologistCqResponseZ).default([]),
   rebuttals: z.array(MethodologistRebuttalZ).default([]),
   webCitations: z.array(WebCitationZ).max(40).optional().default([]),

--- a/experiments/polarization-1/orchestrator/agents/methodologist.ts
+++ b/experiments/polarization-1/orchestrator/agents/methodologist.ts
@@ -62,6 +62,10 @@ export interface MethodologistTurnInput {
    */
   phase2ArgumentsPrompt: string;
   evidenceCorpusPrompt: string;
+  /** Iter-3: optional content appended to system prompt (round-2 addendum). */
+  appendedSystemPrompt?: string;
+  /** Iter-3: optional extra block appended to user message. */
+  appendedUserBlock?: string;
   schemaOpts: MethodologistSchemaOpts;
   cfg: OrchestratorConfig;
   llm: AnthropicClient;
@@ -81,16 +85,22 @@ export async function runMethodologistTurn(
   const promptPath = path.isAbsolute(input.promptPath)
     ? input.promptPath
     : path.join(input.cfg.experimentRoot, input.promptPath);
-  const systemPrompt = readFileSync(promptPath, "utf8");
-  const model = modelFor(input.cfg);
+  const baseSystemPrompt = readFileSync(promptPath, "utf8");
+  const systemPrompt = input.appendedSystemPrompt
+    ? `${baseSystemPrompt}\n\n${input.appendedSystemPrompt}`
+    : baseSystemPrompt;
+  const model = modelFor(input.cfg, "methodologist");
 
   const outputSchema = buildMethodologistOutputSchema(input.schemaOpts);
 
-  const userMessage = renderUserMessage({
+  const baseUserMessage = renderUserMessage({
     framing: input.framing,
     phase2Arguments: input.phase2ArgumentsPrompt,
     evidence: input.evidenceCorpusPrompt,
   });
+  const userMessage = input.appendedUserBlock
+    ? `${baseUserMessage}\n\n${input.appendedUserBlock}`
+    : baseUserMessage;
 
   const messages: Array<{ role: "user" | "assistant"; content: string }> = [
     { role: "user", content: userMessage },

--- a/experiments/polarization-1/orchestrator/agents/rebuttal-schema.ts
+++ b/experiments/polarization-1/orchestrator/agents/rebuttal-schema.ts
@@ -61,6 +61,24 @@ export const AttackTypeZ = z.enum(["REBUT", "UNDERMINE", "UNDERCUT"]);
 export type AttackType = z.infer<typeof AttackTypeZ>;
 
 /**
+ * Iter-3 multi-round Phase 3. `"1"` = current behavior (attacks on
+ * opposing Phase-2 args). `"2"` = round-2 attacks; may target either
+ * an opposing Phase-2 arg (NEW direct attack) OR a round-1 rebuttal
+ * filed against THIS advocate's own Phase-2 args (attack-on-attack).
+ * Default `"1"` preserves Iter-2 outputs.
+ */
+export const RebuttalRoundZ = z.enum(["1", "2"]);
+export type RebuttalRound = z.infer<typeof RebuttalRoundZ>;
+
+/**
+ * Explicit tag identifying which kind of object the `targetArgumentId`
+ * resolves to. Required for Iter-3 round-2 disambiguation; defaults to
+ * `"phase2-arg"` so Iter-2 outputs validate unchanged.
+ */
+export const TargetKindZ = z.enum(["phase2-arg", "round1-rebuttal"]);
+export type TargetKind = z.infer<typeof TargetKindZ>;
+
+/**
  * A CQ raise OR waive against an opposing argument. Action `raise` opens
  * the CQ (sets `CQStatus.statusEnum = OPEN` if absent); `waive` records
  * the advocate's affirmative concession that the CQ is non-blocking
@@ -68,8 +86,10 @@ export type AttackType = z.infer<typeof AttackTypeZ>;
  * advocate marks the question moot rather than challenging it).
  */
 const CqResponseZ = z.object({
-  /** Argument-id of the opposing argument this CQ targets. */
+  /** Argument-id of the opposing argument (or round-1 rebuttal in Iter-3 round-2) this CQ targets. */
   targetArgumentId: z.string().min(4),
+  /** Iter-3: which kind of object `targetArgumentId` resolves to. */
+  targetKind: TargetKindZ.default("phase2-arg"),
   /** Critical-question key from the target argument's scheme. */
   cqKey: z.string().min(1).max(80),
   action: z.enum(["raise", "waive"]),
@@ -99,8 +119,10 @@ export type CqResponse = z.infer<typeof CqResponseZ>;
  *     (warrant attack); premises and conclusion-text describe why.
  */
 const RebuttalArgumentZ = z.object({
-  /** Argument-id of the opposing argument being attacked. */
+  /** Argument-id of the opposing argument (or round-1 rebuttal in Iter-3 round-2) being attacked. */
   targetArgumentId: z.string().min(4),
+  /** Iter-3: which kind of object `targetArgumentId` resolves to. */
+  targetKind: TargetKindZ.default("phase2-arg"),
   attackType: AttackTypeZ,
   /** 0-based premise index in the target argument; required iff attackType === "UNDERMINE". */
   targetPremiseIndex: z.number().int().nonnegative().nullable(),
@@ -140,6 +162,8 @@ export const REBUTTAL_PER_TARGET_MAX = 4;
 const RebuttalOutputZ = z.object({
   phase: z.literal("3"),
   advocateRole: z.enum(["A", "B"]),
+  /** Iter-3 multi-round indicator. Defaults to "1" so Iter-2 outputs validate. */
+  round: RebuttalRoundZ.default("1"),
   cqResponses: z.array(CqResponseZ).default([]),
   rebuttals: z.array(RebuttalArgumentZ).default([]),
   /**

--- a/experiments/polarization-1/orchestrator/agents/rebuttal.ts
+++ b/experiments/polarization-1/orchestrator/agents/rebuttal.ts
@@ -60,6 +60,12 @@ export interface RebuttalTurnInput {
   opponentArgumentsPrompt: string;
   /** Renders into the `## EVIDENCE_CORPUS` section. */
   evidenceCorpusPrompt: string;
+  /** Iter-3: optional content appended to the system prompt (e.g.
+   *  round-2 addendum). Default: none. */
+  appendedSystemPrompt?: string;
+  /** Iter-3: optional extra block appended to the user message (e.g.
+   *  rendered `## ROUND_1_ATTACKS_ON_YOU` table). Default: none. */
+  appendedUserBlock?: string;
   /** Schema-binding parameters (opposing arguments, CQ catalog, allowed citation tokens). */
   schemaOpts: Omit<RebuttalSchemaOpts, "advocateRole">;
   cfg: OrchestratorConfig;
@@ -78,18 +84,24 @@ export async function runRebuttalTurn(input: RebuttalTurnInput): Promise<Rebutta
   const promptPath = path.isAbsolute(input.promptPath)
     ? input.promptPath
     : path.join(input.cfg.experimentRoot, input.promptPath);
-  const systemPrompt = readFileSync(promptPath, "utf8");
-  const model = modelFor(input.cfg);
+  const baseSystemPrompt = readFileSync(promptPath, "utf8");
+  const systemPrompt = input.appendedSystemPrompt
+    ? `${baseSystemPrompt}\n\n${input.appendedSystemPrompt}`
+    : baseSystemPrompt;
+  const model = modelFor(input.cfg, "rebuttal");
 
   const advocateRole: "A" | "B" = input.role === "advocate-a" ? "A" : "B";
   const outputSchema = buildRebuttalOutputSchema({ ...input.schemaOpts, advocateRole });
 
-  const userMessage = renderUserMessage({
+  const baseUserMessage = renderUserMessage({
     framing: input.framing,
     opponentArguments: input.opponentArgumentsPrompt,
     evidence: input.evidenceCorpusPrompt,
     role: input.role,
   });
+  const userMessage = input.appendedUserBlock
+    ? `${baseUserMessage}\n\n${input.appendedUserBlock}`
+    : baseUserMessage;
 
   const messages: Array<{ role: "user" | "assistant"; content: string }> = [
     { role: "user", content: userMessage },

--- a/experiments/polarization-1/orchestrator/agents/synthesist.ts
+++ b/experiments/polarization-1/orchestrator/agents/synthesist.ts
@@ -95,7 +95,7 @@ export async function runSynthesistTurn(input: SynthesistTurnInput): Promise<Syn
     ? input.promptPath
     : path.join(input.cfg.experimentRoot, input.promptPath);
   const systemPrompt = readFileSync(promptPath, "utf8");
-  const model = modelFor(input.cfg);
+  const model = modelFor(input.cfg, "synthesist");
   const outputSchema = buildSynthesistVerdictSchema(input.schemaOpts);
 
   const userMessage = renderUserMessage(input);

--- a/experiments/polarization-1/orchestrator/agents/tracker.ts
+++ b/experiments/polarization-1/orchestrator/agents/tracker.ts
@@ -88,7 +88,7 @@ export async function runTrackerTurn(input: TrackerTurnInput): Promise<TrackerTu
     ? input.promptPath
     : path.join(input.cfg.experimentRoot, input.promptPath);
   const systemPrompt = readFileSync(promptPath, "utf8");
-  const model = modelFor(input.cfg);
+  const model = modelFor(input.cfg, "tracker");
   const outputSchema = buildTrackerVerdictSchema(input.schemaOpts);
 
   const userMessage = renderUserMessage(input);

--- a/experiments/polarization-1/orchestrator/config.ts
+++ b/experiments/polarization-1/orchestrator/config.ts
@@ -51,9 +51,27 @@ export interface OrchestratorConfig {
   anthropicModelDev: string;
   anthropicModelProd: string;
   modelTier: ModelTier;
+  /** Per-agent overrides. When set, beats `modelTier` for that role.
+   *  Populated from env vars `MODEL_TIER_<ROLE>` (see `loadConfig`). */
+  modelTierByRole: Partial<Record<AgentTierRole, ModelTier>>;
   agents: AgentsRuntime;
   deliberation: DeliberationRuntime;
+  /** Iter-3 gating flag. When true, Phase 3 runs two rounds (round-2 =
+   *  attacks-on-attacks + new direct attacks) and Phase 4 runs two
+   *  sub-rounds (4a / 4b). Default false preserves Iter-2 behavior.
+   *  Override via env `ITER3_MULTI_ROUND=1`. */
+  iter3MultiRound: boolean;
 }
+
+/** Roles whose model tier can be overridden independently. */
+export type AgentTierRole =
+  | "claim-analyst"
+  | "advocate"
+  | "rebuttal"
+  | "methodologist"
+  | "defense"
+  | "tracker"
+  | "synthesist";
 
 const DEFAULT_DEV_MODEL = "claude-haiku-4-5-20251001";
 // Bumped from Opus 4.5 → Opus 4.6 for the loosened, web-search-enabled
@@ -113,9 +131,47 @@ export function loadConfig(opts: LoadConfigOptions = {}): OrchestratorConfig {
     anthropicModelDev: process.env.ANTHROPIC_MODEL_DEV || DEFAULT_DEV_MODEL,
     anthropicModelProd: process.env.ANTHROPIC_MODEL_PROD || DEFAULT_PROD_MODEL,
     modelTier,
+    modelTierByRole: parseRoleTierOverrides(),
     agents,
     deliberation,
+    iter3MultiRound:
+      process.env.ITER3_MULTI_ROUND === "1" ||
+      process.env.ITER3_MULTI_ROUND === "true",
   };
+}
+
+/** Parse per-agent tier overrides from env. Recognized vars:
+ *  - `MODEL_TIER_CLAIM_ANALYST`
+ *  - `MODEL_TIER_ADVOCATE`     (both A and B)
+ *  - `MODEL_TIER_REBUTTAL`     (both A and B)
+ *  - `MODEL_TIER_METHODOLOGIST`
+ *  - `MODEL_TIER_DEFENSE`      (both A and B)
+ *  - `MODEL_TIER_TRACKER`
+ *  - `MODEL_TIER_SYNTHESIST`
+ *
+ *  Convenience preset: `MODEL_TIER_PRESET=opus-critical` is equivalent
+ *  to setting Synthesist + Methodologist + Tracker to `prod`.
+ */
+function parseRoleTierOverrides(): Partial<Record<AgentTierRole, ModelTier>> {
+  const out: Partial<Record<AgentTierRole, ModelTier>> = {};
+  function pick(env: string, role: AgentTierRole): void {
+    const v = process.env[env];
+    if (v === "prod" || v === "dev") out[role] = v;
+  }
+  // Apply preset first; explicit env vars below can still override.
+  if (process.env.MODEL_TIER_PRESET === "opus-critical") {
+    out.synthesist = "prod";
+    out.methodologist = "prod";
+    out.tracker = "prod";
+  }
+  pick("MODEL_TIER_CLAIM_ANALYST", "claim-analyst");
+  pick("MODEL_TIER_ADVOCATE", "advocate");
+  pick("MODEL_TIER_REBUTTAL", "rebuttal");
+  pick("MODEL_TIER_METHODOLOGIST", "methodologist");
+  pick("MODEL_TIER_DEFENSE", "defense");
+  pick("MODEL_TIER_TRACKER", "tracker");
+  pick("MODEL_TIER_SYNTHESIST", "synthesist");
+  return out;
 }
 
 export function requireDeliberation(cfg: OrchestratorConfig): DeliberationRuntime & { deliberationId: string } {
@@ -128,8 +184,10 @@ export function requireDeliberation(cfg: OrchestratorConfig): DeliberationRuntim
   return cfg.deliberation as DeliberationRuntime & { deliberationId: string };
 }
 
-export function modelFor(cfg: OrchestratorConfig): string {
-  return cfg.modelTier === "prod" ? cfg.anthropicModelProd : cfg.anthropicModelDev;
+export function modelFor(cfg: OrchestratorConfig, role?: AgentTierRole): string {
+  const tier =
+    (role && cfg.modelTierByRole[role]) || cfg.modelTier;
+  return tier === "prod" ? cfg.anthropicModelProd : cfg.anthropicModelDev;
 }
 
 export function agentByRole(cfg: OrchestratorConfig, role: string): AgentIdentity {

--- a/experiments/polarization-1/orchestrator/finalize/phase-3-finalize.ts
+++ b/experiments/polarization-1/orchestrator/finalize/phase-3-finalize.ts
@@ -37,8 +37,12 @@ import { prisma } from "@/lib/prismaclient";
 
 export interface Phase3CompleteRebuttal {
   inputIndex: number;
+  /** Iter-3 multi-round indicator. "1" = round 1 (Iter-2 default), "2" = round 2 attack-on-attack. */
+  round: "1" | "2";
   rebuttalArgumentId: string;
   targetArgumentId: string;
+  /** Iter-3: which kind of object `targetArgumentId` resolves to. */
+  targetKind: "phase2-arg" | "round1-rebuttal";
   edgeId: string;
   attackType: "REBUT" | "UNDERMINE" | "UNDERCUT";
   targetPremiseIndex: number | null;
@@ -57,7 +61,11 @@ export interface Phase3CompleteRebuttal {
 
 export interface Phase3CompleteCqResponse {
   inputIndex: number;
+  /** Iter-3 multi-round indicator. */
+  round: "1" | "2";
   targetArgumentId: string;
+  /** Iter-3: which kind of object `targetArgumentId` resolves to. */
+  targetKind: "phase2-arg" | "round1-rebuttal";
   cqKey: string;
   action: "raise" | "waive";
   rationale: string;
@@ -302,8 +310,10 @@ function buildCompleteAdvocate(rec: RebuttalRunRecord): Phase3CompleteAdvocate {
     const orig = inputRebuttals[m.inputIndex];
     return {
       inputIndex: m.inputIndex,
+      round: rec.llmOutput!.round ?? "1",
       rebuttalArgumentId: m.rebuttalArgumentId,
       targetArgumentId: m.targetArgumentId,
+      targetKind: orig.targetKind ?? "phase2-arg",
       edgeId: m.edgeId,
       attackType: m.attackType,
       targetPremiseIndex: m.targetPremiseIndex,
@@ -325,7 +335,9 @@ function buildCompleteAdvocate(rec: RebuttalRunRecord): Phase3CompleteAdvocate {
     const orig = inputCqResponses[m.inputIndex];
     return {
       inputIndex: m.inputIndex,
+      round: rec.llmOutput!.round ?? "1",
       targetArgumentId: m.targetArgumentId,
+      targetKind: orig.targetKind ?? "phase2-arg",
       cqKey: m.cqKey,
       action: m.action,
       rationale: orig.rationale,
@@ -363,8 +375,10 @@ function buildCompleteMethodologist(
       const orig = inputRebuttals[m.inputIndex];
       return {
         inputIndex: m.inputIndex,
+        round: rec.llmOutput!.round ?? "1",
         rebuttalArgumentId: m.rebuttalArgumentId,
         targetArgumentId: m.targetArgumentId,
+        targetKind: orig.targetKind ?? "phase2-arg",
         targetAdvocateRole: orig.targetAdvocateRole,
         edgeId: m.edgeId,
         attackType: m.attackType,
@@ -389,7 +403,9 @@ function buildCompleteMethodologist(
       const orig = inputCqResponses[m.inputIndex];
       return {
         inputIndex: m.inputIndex,
+        round: rec.llmOutput!.round ?? "1",
         targetArgumentId: m.targetArgumentId,
+        targetKind: orig.targetKind ?? "phase2-arg",
         targetAdvocateRole: orig.targetAdvocateRole,
         cqKey: m.cqKey,
         action: m.action,

--- a/experiments/polarization-1/orchestrator/finalize/phase-4-finalize.ts
+++ b/experiments/polarization-1/orchestrator/finalize/phase-4-finalize.ts
@@ -78,6 +78,8 @@ export interface Phase4CompleteCqAnswer {
 export interface Phase4CompleteAdvocate {
   outcome: "ok";
   attempts: number;
+  /** Iter-3 multi-sub-round indicator. "a" = sub-round-a (Iter-2 default), "b" = sub-round-b. */
+  subRound: "a" | "b";
   tokenUsage: { inputTokens: number; outputTokens: number };
   responses: Phase4CompleteResponse[];
   cqAnswers: Phase4CompleteCqAnswer[];
@@ -396,6 +398,7 @@ function buildCompleteAdvocate(rec: DefenseRunRecord): Phase4CompleteAdvocate {
   return {
     outcome: "ok",
     attempts: rec.attempts,
+    subRound: rec.llmOutput!.subRound ?? "a",
     tokenUsage: rec.tokenUsage,
     responses,
     cqAnswers,

--- a/experiments/polarization-1/orchestrator/phases/phase-3-round2.ts
+++ b/experiments/polarization-1/orchestrator/phases/phase-3-round2.ts
@@ -1,0 +1,142 @@
+/**
+ * phases/phase-3-round2.ts
+ *
+ * Iter-3 multi-round Phase 3 — round-2 driver. Gated behind
+ * `cfg.iter3MultiRound`. Round 1 runs via the existing `runPhase`
+ * code path; this module orchestrates round 2 (attacks-on-attacks
+ * + new direct attacks) for advocates A, B, and the Methodologist.
+ *
+ * Status: SCAFFOLD (Iter-3 in progress).
+ *
+ * What's wired:
+ *   - Reads the round-2 addendum prompts (4b/5b/10b) and appends them
+ *     to the base round-1 system prompts.
+ *   - Skeleton for fetching round-1 rebuttals + building the extended
+ *     opposing-argument bindings (round-1 rebuttalArgumentIds become
+ *     legitimate round-2 targets).
+ *   - Skeleton for rendering the `## ROUND_1_ATTACKS_ON_YOU` user
+ *     block.
+ *   - Calls `runOneAdvocate`-style logic with `round: "2"` plumbed
+ *     through to `translateRebuttalOutput`.
+ *
+ * What's TODO (marked inline):
+ *   1. `loadRound1RebuttalsForBindings`: fetch the round-1 rebuttal
+ *      Arguments + their premise/conclusion claim ids from prisma so
+ *      they can be added to the opposing-arg maps.
+ *   2. `renderRound1AttacksOnYou`: render the structured Markdown
+ *      block listing attacks the recipient must defend / can attack.
+ *   3. Persistence: extend `Phase3PartialFile` with a
+ *      `round2: { advocates, methodologist }` sub-record (or use a
+ *      flat `rebuttals[]` with `round` field — see locked design
+ *      memo `/memories/repo/polarization-1-iteration-3-design.md`).
+ *
+ * NEVER call this directly from the orchestrator CLI without the
+ * gating flag check; doing so will silently re-mint round-1 work.
+ */
+
+import path from "path";
+import { readFileSync, existsSync } from "fs";
+import type { OrchestratorConfig } from "../config";
+import type { IsonomiaClient } from "../isonomia-client";
+import type { AnthropicClient } from "../anthropic-client";
+import type { RoundLogger } from "../log/round-logger";
+
+export interface RunPhase3Round2Opts {
+  cfg: OrchestratorConfig;
+  iso: IsonomiaClient;
+  llm: AnthropicClient;
+  deliberationId: string;
+  /** Path to PHASE_3_COMPLETE.json (round-1 finalize result). */
+  phase3CompletePath: string;
+  logger: RoundLogger;
+}
+
+export interface RunPhase3Round2Result {
+  /** TODO: typed round-2 result records (rebuttals, methodologist). */
+  status: "not-implemented" | "ok";
+  notes: string[];
+}
+
+/**
+ * Read a round-2 addendum prompt by role. Returns the file content if
+ * present, or empty string if absent (defensive — addendums are
+ * scaffolding files in `experiments/polarization-1/prompts/`).
+ */
+export function readRound2Addendum(
+  cfg: OrchestratorConfig,
+  role: "advocate-a" | "advocate-b" | "methodologist",
+): string {
+  const filename =
+    role === "advocate-a"
+      ? "4b-rebuttal-a-round2-addendum.md"
+      : role === "advocate-b"
+        ? "5b-rebuttal-b-round2-addendum.md"
+        : "10b-methodologist-round2-addendum.md";
+  const p = path.join(cfg.experimentRoot, "prompts", filename);
+  if (!existsSync(p)) {
+    return "";
+  }
+  return readFileSync(p, "utf8");
+}
+
+/**
+ * TODO(Iter-3): Build the `## ROUND_1_ATTACKS_ON_YOU` Markdown block
+ * for a recipient advocate. Lists every round-1 rebuttal filed against
+ * the recipient's Phase-2 arguments by the opponent and Methodologist,
+ * with their `rebuttalArgumentId` (legal `targetArgumentId` for round-2
+ * attacks-on-attacks), conclusion text, premises, and `cqKey` (if any).
+ *
+ * Spec (from locked design memo):
+ *   - For Advocate A, list B's + Methodologist's round-1 rebuttals
+ *     against A's Phase-2 args.
+ *   - For Advocate B, list A's + Methodologist's round-1 rebuttals
+ *     against B's Phase-2 args.
+ *   - For Methodologist, list ALL round-1 rebuttals (A's + B's + own)
+ *     in `## ROUND_1_ATTACKS_ALL`.
+ */
+export function renderRound1AttacksOnYou(
+  _recipientRole: "advocate-a" | "advocate-b" | "methodologist",
+  _phase3Complete: unknown,
+): string {
+  return "## ROUND_1_ATTACKS_ON_YOU\n\n_(TODO: implement renderer in phase-3-round2.ts)_\n";
+}
+
+/**
+ * Main entry point — called from `runPhase` (phase-3-attacks.ts) after
+ * round-1 finalizes successfully and ONLY when `cfg.iter3MultiRound`
+ * is true.
+ */
+export async function runPhase3Round2(
+  opts: RunPhase3Round2Opts,
+): Promise<RunPhase3Round2Result> {
+  opts.logger.event("phase_round2_start", {
+    phase: 3,
+    round: 2,
+    deliberationId: opts.deliberationId,
+  });
+
+  // TODO(Iter-3):
+  //   1. Load PHASE_3_COMPLETE.json from `opts.phase3CompletePath`.
+  //   2. Build extended `opposingArgumentSchemeByArgId` /
+  //      `opposingArgumentPremisesByArgId` /
+  //      `opposingArgumentConclusionByArgId` maps including round-1
+  //      rebuttal ids (with their `schemeKey`, premise claims, and
+  //      conclusion claim from the persisted complete record).
+  //   3. Render `## ROUND_1_ATTACKS_ON_YOU` per recipient.
+  //   4. For each of advocate-a, advocate-b, methodologist:
+  //      a. Load base prompt; append round-2 addendum via
+  //         `runRebuttalTurn({ appendedSystemPrompt, appendedUserBlock })`
+  //         or `runMethodologistTurn({ ... })`.
+  //      b. On ok, call `translateRebuttalOutput({ ..., round: "2" })`
+  //         (translator skips orphan-guard automatically).
+  //   5. Write PHASE_3_ROUND2_PARTIAL.json (same shape as round-1
+  //      partial) and let finalize merge.
+
+  return {
+    status: "not-implemented",
+    notes: [
+      "round-2 driver is scaffold-only; complete the TODOs in phase-3-round2.ts.",
+      "schemas, translator, prompts, and finalize already accept round-2 inputs.",
+    ],
+  };
+}

--- a/experiments/polarization-1/orchestrator/translators/attack-mint.ts
+++ b/experiments/polarization-1/orchestrator/translators/attack-mint.ts
@@ -135,6 +135,20 @@ export interface TranslateRebuttalOpts {
   authorRole: "advocate-a" | "advocate-b" | "methodologist";
 
   /**
+   * Iter-3 round indicator. Defaults to `"1"` (Iter-2 behavior). When
+   * `"2"`:
+   *   - The orphan guard is skipped (round-1 rebuttals + cqStatuses are
+   *     preserved as valid prior state).
+   *   - The translator's behavior is otherwise identical: the driver is
+   *     responsible for populating `opposingArgumentSchemeByArgId` /
+   *     `opposingArgumentPremisesByArgId` /
+   *     `opposingArgumentConclusionByArgId` with round-1 rebuttal ids
+   *     when those are valid round-2 targets (`targetKind === "round1-rebuttal"`).
+   *   - DialogueMove ATTACK emissions tag `payload.round = 2`.
+   */
+  round?: "1" | "2";
+
+  /**
    * Map of opposing argument id → that argument's scheme key. Needed to
    * compute the `schemeKey` field on CQStatus rows (the unique constraint
    * is `(targetType, targetId, schemeKey, cqKey)`).
@@ -190,46 +204,61 @@ export async function translateRebuttalOutput(opts: TranslateRebuttalOpts): Prom
   // identify rebuttals (vs. Phase-2 arguments) by the presence of an
   // outgoing ArgumentEdge created by this bot — Phase-2 arguments never
   // have outgoing edges. Cascade deletes the edges.
-  const priorRebuttalIds = await prisma.argument.findMany({
-    where: {
-      deliberationId: opts.deliberationId,
-      authorId,
-      outgoingEdges: {
-        some: { deliberationId: opts.deliberationId, createdById: authorId },
-      },
-    },
-    select: { id: true },
-  });
-  if (priorRebuttalIds.length > 0) {
-    const droppedRebuttals = await prisma.argument.deleteMany({
-      where: { id: { in: priorRebuttalIds.map((r) => r.id) } },
-    });
-    opts.logger.event("orphan_cleanup", {
-      step: "attack-mint",
-      advocate: opts.authorRole,
-      droppedRebuttalArguments: droppedRebuttals.count,
-    });
-  }
-
-  // Delete prior CQStatus rows by this bot pointing at any opposing
-  // argument. The unique constraint is (targetType, targetId, schemeKey,
-  // cqKey) so we can delete by createdById + targetType + targetId-set.
-  const opposingIds = [...opts.opposingArgumentSchemeByArgId.keys()];
-  if (opposingIds.length > 0) {
-    const droppedCq = await prisma.cQStatus.deleteMany({
+  //
+  // Iter-3 round-2: SKIP this guard. Round-1 rebuttals are valid prior
+  // state and must be preserved (round-2 attacks may target them).
+  // Re-running round-2 in-place therefore requires the driver to clean
+  // up prior round-2 attempts itself (or accept duplicates).
+  const skipOrphanGuard =
+    (opts.output as any).round === "2" || opts.round === "2";
+  if (!skipOrphanGuard) {
+    const priorRebuttalIds = await prisma.argument.findMany({
       where: {
-        createdById: authorId,
-        targetType: "argument",
-        targetId: { in: opposingIds },
+        deliberationId: opts.deliberationId,
+        authorId,
+        outgoingEdges: {
+          some: { deliberationId: opts.deliberationId, createdById: authorId },
+        },
       },
+      select: { id: true },
     });
-    if (droppedCq.count > 0) {
+    if (priorRebuttalIds.length > 0) {
+      const droppedRebuttals = await prisma.argument.deleteMany({
+        where: { id: { in: priorRebuttalIds.map((r) => r.id) } },
+      });
       opts.logger.event("orphan_cleanup", {
         step: "attack-mint",
         advocate: opts.authorRole,
-        droppedCqStatuses: droppedCq.count,
+        droppedRebuttalArguments: droppedRebuttals.count,
       });
     }
+
+    // Delete prior CQStatus rows by this bot pointing at any opposing
+    // argument. The unique constraint is (targetType, targetId, schemeKey,
+    // cqKey) so we can delete by createdById + targetType + targetId-set.
+    const opposingIds = [...opts.opposingArgumentSchemeByArgId.keys()];
+    if (opposingIds.length > 0) {
+      const droppedCq = await prisma.cQStatus.deleteMany({
+        where: {
+          createdById: authorId,
+          targetType: "argument",
+          targetId: { in: opposingIds },
+        },
+      });
+      if (droppedCq.count > 0) {
+        opts.logger.event("orphan_cleanup", {
+          step: "attack-mint",
+          advocate: opts.authorRole,
+          droppedCqStatuses: droppedCq.count,
+        });
+      }
+    }
+  } else {
+    opts.logger.event("orphan_cleanup_skipped", {
+      step: "attack-mint",
+      advocate: opts.authorRole,
+      reason: "round-2: preserve round-1 rebuttals + cqStatuses",
+    });
   }
 
   // ─────────────────────────────────────────────────────────────────
@@ -319,6 +348,7 @@ export async function translateRebuttalOutput(opts: TranslateRebuttalOpts): Prom
       opposingPremisesByArgId: opts.opposingArgumentPremisesByArgId,
       opposingConclusionByArgId: opts.opposingArgumentConclusionByArgId,
       logger: opts.logger,
+      round: ((opts.output as any).round ?? opts.round ?? "1") as "1" | "2",
     });
     rebuttalResults.push(result);
     citationsAttached += result.citations.length;
@@ -440,6 +470,8 @@ interface MintOneRebuttalOpts {
   opposingPremisesByArgId: ReadonlyMap<string, readonly string[]>;
   opposingConclusionByArgId: ReadonlyMap<string, string>;
   logger: RoundLogger;
+  /** Iter-3 round indicator. Defaults to "1". */
+  round?: "1" | "2";
 }
 
 async function mintOneRebuttal(opts: MintOneRebuttalOpts): Promise<AttackMintResult["rebuttals"][number]> {
@@ -569,6 +601,8 @@ async function mintOneRebuttal(opts: MintOneRebuttalOpts): Promise<AttackMintRes
       targetClaimId: targetClaimIdField,
       targetPremiseId: targetPremiseClaimId,
       cqKey: r.cqKey,
+      round: opts.round ?? "1",
+      targetKind: (r as any).targetKind ?? "phase2-arg",
     },
     logger: opts.logger,
     step: "attack-mint",

--- a/experiments/polarization-1/prompts/10b-methodologist-round2-addendum.md
+++ b/experiments/polarization-1/prompts/10b-methodologist-round2-addendum.md
@@ -1,0 +1,49 @@
+# Phase 3 — Round 2 addendum (Methodologist)
+
+This addendum is appended to `10-methodologist.md` whenever the
+Methodologist runs the Iter-3 round-2 turn. It does NOT replace any
+§1–§5 rule of the base prompt; it adds a round-2 mode and amends the
+output schema.
+
+## §6 (round-2 mode)
+
+You are now executing the SECOND of two Phase-3 rounds. In round 1
+you (and the two advocates) filed attacks against the advocates'
+Phase-2 arguments. Your task in round 2:
+
+1. **Critique round-1 attacks from EITHER side** — file new attacks
+   against round-1 rebuttals from A or B, using the same methodologist
+   posture (cross-side critic, not partisan). The `targetArgumentId`
+   field MUST be a `rebuttalArgumentId` from
+   `## ROUND_1_ATTACKS_ALL` (the union of A's, B's, and your own
+   round-1 attacks), and `targetKind` MUST equal `"round1-rebuttal"`.
+   Set `targetAdvocateRole` to the side **whose Phase-2 argument the
+   round-1 rebuttal attacked** (i.e., the side defended by your
+   round-2 attack).
+
+2. **New direct critiques (optional)** — file new methodologist
+   rebuttals against either advocate's Phase-2 arguments you did NOT
+   target in round 1. `targetKind` MUST equal `"phase2-arg"`;
+   `targetAdvocateRole` is the author of the targeted Phase-2 arg.
+
+You may continue to raise CQs in either mode.
+
+## §7 (round-2 output schema delta)
+
+- Top-level: `"round": "2"`.
+- Each `cqResponses[*]` and `rebuttals[*]`: `"targetKind"` ∈
+  `{"phase2-arg", "round1-rebuttal"}` AND
+  `"targetAdvocateRole"` ∈ `{"A", "B"}`.
+
+## §8 (round-2 budget)
+
+- `rebuttalsMax`: 12 (Methodologist round-2 should be more selective).
+- `cqResponsesMax`: 12.
+
+## §9 (style)
+
+You are critiquing methodology, not picking a side. If a round-1
+attack is itself methodologically sound, leave it alone; if it
+overreaches (e.g., draws causal inference from purely correlational
+evidence), file an attack-on-attack. Refuse with
+`NO_METHODOLOGICAL_FLAWS` rather than filling quota.

--- a/experiments/polarization-1/prompts/4b-rebuttal-a-round2-addendum.md
+++ b/experiments/polarization-1/prompts/4b-rebuttal-a-round2-addendum.md
@@ -1,0 +1,53 @@
+# Phase 3 — Round 2 addendum (Advocate A)
+
+This addendum is appended to `4-rebuttal-a.md` whenever Advocate A runs
+the Iter-3 round-2 rebuttal turn. It does NOT replace any §1–§5 rule of
+the base prompt; it adds a round-2 mode and amends the output schema.
+
+## §6 (round-2 mode)
+
+You are now executing the SECOND of two Phase-3 rounds. Round 1 has
+finalized; B and the Methodologist have already filed their round-1
+attacks against your Phase-2 arguments. Your task in round 2:
+
+1. **Defend** — file new attacks against the round-1 rebuttals that
+   were filed against YOUR Phase-2 arguments. These are
+   "attacks-on-attacks" and target the rebuttal Argument's own
+   premises / warrant / conclusion using REBUT, UNDERMINE, or UNDERCUT.
+   The `targetArgumentId` field MUST be a `rebuttalArgumentId` from
+   `## ROUND_1_ATTACKS_ON_YOU`, and `targetKind` MUST equal
+   `"round1-rebuttal"`.
+
+2. **New direct attacks (optional)** — file new round-2 rebuttals
+   against opponent B's Phase-2 arguments that you did NOT attack in
+   round 1, OR refine an attack you already made. The `targetArgumentId`
+   field MUST be a Phase-2 `argumentId` from `## OPPONENT_PHASE_2`, and
+   `targetKind` MUST equal `"phase2-arg"`.
+
+You may file CQ raises in either mode using the same `targetKind`
+discrimination (CQs raised against a round-1 rebuttal are bound to that
+rebuttal's `schemeKey`'s CQ catalog).
+
+## §7 (round-2 output schema delta)
+
+Same shape as round 1, with two REQUIRED fields on every item:
+
+- Top-level: `"round": "2"` (replaces the implicit `"1"` from round 1).
+- Each `cqResponses[*]` and `rebuttals[*]`: `"targetKind"` ∈
+  `{"phase2-arg", "round1-rebuttal"}`.
+
+Per-target rebuttal cap (`rebuttalsPerTargetMax = 4`) applies
+**per-round**: you may file up to 4 round-2 attacks against the same
+target even if you filed 4 in round 1.
+
+## §8 (round-2 budget)
+
+- `rebuttalsMax`: 16 (half of round 1's 32 — round-2 should be focused).
+- `cqResponsesMax`: 16.
+
+## §9 (style)
+
+Round-2 attacks should advance the dialectic, not restate round 1.
+If you cannot produce at least one substantive new attack OR
+attack-on-attack, refuse with `NO_DEFENSIBLE_ATTACKS` rather than
+filling quota.

--- a/experiments/polarization-1/prompts/5b-rebuttal-b-round2-addendum.md
+++ b/experiments/polarization-1/prompts/5b-rebuttal-b-round2-addendum.md
@@ -1,0 +1,50 @@
+# Phase 3 — Round 2 addendum (Advocate B)
+
+This addendum is appended to `5-rebuttal-b.md` whenever Advocate B runs
+the Iter-3 round-2 rebuttal turn. It does NOT replace any §1–§5 rule of
+the base prompt; it adds a round-2 mode and amends the output schema.
+
+## §6 (round-2 mode)
+
+You are now executing the SECOND of two Phase-3 rounds. Round 1 has
+finalized; A and the Methodologist have already filed their round-1
+attacks against your Phase-2 arguments. Your task in round 2:
+
+1. **Defend** — file new attacks against the round-1 rebuttals that
+   were filed against YOUR Phase-2 arguments. These are
+   "attacks-on-attacks" and target the rebuttal Argument's own
+   premises / warrant / conclusion using REBUT, UNDERMINE, or UNDERCUT.
+   The `targetArgumentId` field MUST be a `rebuttalArgumentId` from
+   `## ROUND_1_ATTACKS_ON_YOU`, and `targetKind` MUST equal
+   `"round1-rebuttal"`.
+
+2. **New direct attacks (optional)** — file new round-2 rebuttals
+   against opponent A's Phase-2 arguments that you did NOT attack in
+   round 1, OR refine an attack you already made. The `targetArgumentId`
+   field MUST be a Phase-2 `argumentId` from `## OPPONENT_PHASE_2`, and
+   `targetKind` MUST equal `"phase2-arg"`.
+
+You may file CQ raises in either mode using the same `targetKind`
+discrimination.
+
+## §7 (round-2 output schema delta)
+
+Same as Advocate A round-2 addendum:
+
+- Top-level: `"round": "2"`.
+- Each `cqResponses[*]` and `rebuttals[*]`: `"targetKind"` ∈
+  `{"phase2-arg", "round1-rebuttal"}`.
+
+Per-target rebuttal cap applies **per-round**.
+
+## §8 (round-2 budget)
+
+- `rebuttalsMax`: 16.
+- `cqResponsesMax`: 16.
+
+## §9 (style)
+
+Round-2 attacks should advance the dialectic, not restate round 1.
+If you cannot produce at least one substantive new attack OR
+attack-on-attack, refuse with `NO_DEFENSIBLE_ATTACKS` rather than
+filling quota.

--- a/experiments/polarization-1/prompts/6b-defense-a-subroundb-addendum.md
+++ b/experiments/polarization-1/prompts/6b-defense-a-subroundb-addendum.md
@@ -1,0 +1,48 @@
+# Phase 4 — Sub-round B addendum (Defense A)
+
+This addendum is appended to `6-defense-a.md` whenever Advocate A runs
+the Iter-3 sub-round-b defense turn. It does NOT replace any §1–§5
+rule of the base prompt; it adds a sub-round-b mode and amends the
+output schema.
+
+## §6 (sub-round-b mode)
+
+You are now executing the SECOND of two Phase-4 sub-rounds. Sub-round-a
+has finalized; you have already defended (or conceded / narrowed) every
+round-1 rebuttal filed against your Phase-2 arguments. Your task in
+sub-round-b:
+
+For every **round-2** attack the opponent (or Methodologist) filed
+against you, emit exactly one response: defend / concede / narrow.
+Round-2 attacks may target either:
+
+1. **Your Phase-2 arguments directly** (new direct attacks the opponent
+   did not file in round 1). Treat the same as sub-round-a defenses.
+
+2. **Your round-1 rebuttals** (attacks-on-attacks). Defending here
+   means defending one of YOUR own round-1 rebuttals against an
+   opponent's round-2 attack. The `targetAttackId` field will be the
+   round-2 `rebuttalArgumentId` (the opponent's attack on your
+   rebuttal). The `defense.attackType` you emit attacks THAT round-2
+   rebuttal — same shape as sub-round-a, just one level deeper in the
+   chain.
+
+You also see in the prompt your own sub-round-a defenses (in
+`## YOUR_SUB_ROUND_A_DEFENSES`) so you can avoid restating arguments
+you already made.
+
+## §7 (sub-round-b output schema delta)
+
+- Top-level: `"subRound": "b"` (replaces the implicit `"a"`).
+- Same `responses[]` and `cqAnswers[]` shape; targets resolve to
+  round-2 attack ids instead of round-1.
+
+## §8 (sub-round-b budget)
+
+Same caps as sub-round-a; no per-target multiplication.
+
+## §9 (style)
+
+If a round-2 attack-on-attack is methodologically vapid (just restates
+the round-1 attack with stronger adjectives), prefer concede with a
+brief rationale over a defense that would itself be vapid.

--- a/experiments/polarization-1/prompts/7b-defense-b-subroundb-addendum.md
+++ b/experiments/polarization-1/prompts/7b-defense-b-subroundb-addendum.md
@@ -1,0 +1,42 @@
+# Phase 4 — Sub-round B addendum (Defense B)
+
+This addendum is appended to `7-defense-b.md` whenever Advocate B runs
+the Iter-3 sub-round-b defense turn. Symmetric to
+`6b-defense-a-subroundb-addendum.md`.
+
+## §6 (sub-round-b mode)
+
+You are now executing the SECOND of two Phase-4 sub-rounds. Sub-round-a
+has finalized; you have already defended (or conceded / narrowed) every
+round-1 rebuttal filed against your Phase-2 arguments. Your task in
+sub-round-b:
+
+For every **round-2** attack the opponent (or Methodologist) filed
+against you, emit exactly one response: defend / concede / narrow.
+Round-2 attacks may target either:
+
+1. **Your Phase-2 arguments directly** (new direct attacks the opponent
+   did not file in round 1). Treat the same as sub-round-a defenses.
+
+2. **Your round-1 rebuttals** (attacks-on-attacks). Defending here
+   means defending one of YOUR own round-1 rebuttals against an
+   opponent's round-2 attack. The `targetAttackId` field will be the
+   round-2 `rebuttalArgumentId`. The `defense.attackType` you emit
+   attacks THAT round-2 rebuttal.
+
+You also see in the prompt your own sub-round-a defenses (in
+`## YOUR_SUB_ROUND_A_DEFENSES`).
+
+## §7 (sub-round-b output schema delta)
+
+- Top-level: `"subRound": "b"`.
+- Same `responses[]` and `cqAnswers[]` shape.
+
+## §8 (sub-round-b budget)
+
+Same caps as sub-round-a.
+
+## §9 (style)
+
+Prefer concede with a brief rationale over a defense that would itself
+be methodologically vapid.


### PR DESCRIPTION
Introduce Iter-3 multi-round plumbing and round-2 scaffolding across the orchestrator.

Key changes:
- Config: add iter3MultiRound flag, per-role modelTier overrides (AgentTierRole + parseRoleTierOverrides), and modelFor(cfg, role) to select per-agent models.
- Agents: pass role into modelFor for advocate/defense/rebuttal/methodologist/synthesist/tracker/claim-analyst; methodologist/rebuttal accept appendedSystemPrompt/appendedUserBlock to support round-2 addenda.
- Schemas: extend rebuttal/methodologist/defense schemas with round/targetKind/subRound enums (defaults preserve Iter-2 behavior) so round-2 targets (phase2-arg vs round1-rebuttal) are explicit.
- Translator (attack-mint): add round support, skip orphan-cleanup when running round-2 (preserve round-1 rebuttals/CQStatus), tag minted rebuttals with round and targetKind, and pass round through translation.
- Finalize: persist round / targetKind / subRound fields into Phase-3 / Phase-4 finalize outputs.
- Add phase-3-round2 driver (scaffolded; gated by cfg.iter3MultiRound) and new round-2/addendum prompt files for advocates, methodologist, and defense sub-round-b prompts.

Compatibility: defaults keep Iter-2 behavior unless iter3MultiRound or explicit round/tier overrides are used. Several TODOs in phase-3-round2.ts mark remaining implementation steps for round-2 orchestration.