### PR TITLE
Add Iter-3 multi-round support (round-2 / sub-round-b)

### DIFF
--- a/experiments/polarization-1/orchestrator/agents/advocate-schema.ts
+++ b/experiments/polarization-1/orchestrator/agents/advocate-schema.ts
@@ -93,7 +93,7 @@ const PremiseZ = z.object({
     .refine((s) => !/\?\s*$/.test(s.trim()), {
       message: "premise text must be declarative, not a question",
     }),
-  citationToken: CitationTokenZ.nullable(),
+  citationToken: CitationTokenZ.nullish().transform((v) => v ?? null),
 });
 
 const ArgumentZ = z.object({

--- a/experiments/polarization-1/orchestrator/agents/defense-schema.ts
+++ b/experiments/polarization-1/orchestrator/agents/defense-schema.ts
@@ -56,6 +56,7 @@ const DefensePremiseZ = z.object({
     ),
   citationToken: z.preprocess(
     (v) => {
+      if (v == null) return null;
       if (typeof v !== "string") return v;
       // If LLM concatenates multiple tokens (comma/space/pipe-separated),
       // keep only the first well-formed token.
@@ -63,7 +64,7 @@ const DefensePremiseZ = z.object({
       if (parts.length > 1) return parts[0];
       return v;
     },
-    CitationTokenZ.nullable(),
+    CitationTokenZ.nullish().transform((v) => v ?? null),
   ),
 });
 

--- a/experiments/polarization-1/orchestrator/agents/defense.ts
+++ b/experiments/polarization-1/orchestrator/agents/defense.ts
@@ -74,6 +74,19 @@ export interface DefenseTurnInput {
   methodologistAttacksPrompt?: string;
   /** Renders into `## EVIDENCE_CORPUS`. */
   evidenceCorpusPrompt: string;
+  /**
+   * Optional Iter-3 sub-round-b addendum content. When present, appended
+   * verbatim to the base system prompt (after a blank line). Iter-2 and
+   * sub-round-a code paths leave this undefined and behavior is unchanged.
+   */
+  appendedSystemPrompt?: string;
+  /**
+   * Optional Iter-3 sub-round-b user-message addendum (e.g. the
+   * `## ROUND_2_ATTACKS_AGAINST_YOU` block). When present, appended to
+   * the rendered user message between `## EVIDENCE_CORPUS` and
+   * `## YOUR_TASK`.
+   */
+  appendedUserBlock?: string;
   /** Schema-binding parameters (opposing rebuttals, opposing CQ raises, allowed citation tokens). */
   schemaOpts: Omit<DefenseSchemaOpts, "advocateRole">;
   cfg: OrchestratorConfig;
@@ -92,7 +105,11 @@ export async function runDefenseTurn(input: DefenseTurnInput): Promise<DefenseTu
   const promptPath = path.isAbsolute(input.promptPath)
     ? input.promptPath
     : path.join(input.cfg.experimentRoot, input.promptPath);
-  const systemPrompt = readFileSync(promptPath, "utf8");
+  const baseSystemPrompt = readFileSync(promptPath, "utf8");
+  const systemPrompt =
+    input.appendedSystemPrompt && input.appendedSystemPrompt.trim().length > 0
+      ? `${baseSystemPrompt}\n\n${input.appendedSystemPrompt.trim()}\n`
+      : baseSystemPrompt;
   const model = modelFor(input.cfg, "defense");
 
   const advocateRole: "A" | "B" = input.role === "advocate-a" ? "A" : "B";
@@ -104,6 +121,7 @@ export async function runDefenseTurn(input: DefenseTurnInput): Promise<DefenseTu
     opponentAttacks: input.opponentAttacksPrompt,
     methodologistAttacks: input.methodologistAttacksPrompt ?? "",
     evidence: input.evidenceCorpusPrompt,
+    appendedUserBlock: input.appendedUserBlock ?? "",
     role: input.role,
   });
 
@@ -241,6 +259,7 @@ function renderUserMessage(opts: {
   opponentAttacks: string;
   methodologistAttacks: string;
   evidence: string;
+  appendedUserBlock: string;
   role: DefenseAgentRole;
 }): string {
   const taskLine =
@@ -276,6 +295,13 @@ function renderUserMessage(opts: {
     "## EVIDENCE_CORPUS",
     "",
     opts.evidence.trim(),
+  );
+
+  if (opts.appendedUserBlock.trim().length > 0) {
+    sections.push("", opts.appendedUserBlock.trim());
+  }
+
+  sections.push(
     "",
     "## YOUR_TASK",
     "",

--- a/experiments/polarization-1/orchestrator/agents/methodologist-schema.ts
+++ b/experiments/polarization-1/orchestrator/agents/methodologist-schema.ts
@@ -68,7 +68,7 @@ const MethodologistPremiseZ = z.object({
     .refine((s) => !/\?\s*$/.test(s.trim()), {
       message: "premise text must be declarative, not a question",
     }),
-  citationToken: CitationTokenZ.nullable(),
+  citationToken: CitationTokenZ.nullish().transform((v) => v ?? null),
 });
 
 const TargetAdvocateRoleZ = z.enum(["A", "B"]);

--- a/experiments/polarization-1/orchestrator/agents/methodologist.ts
+++ b/experiments/polarization-1/orchestrator/agents/methodologist.ts
@@ -273,5 +273,10 @@ function validationFollowupMessage(err: ZodError): string {
     formatZodIssues(err),
     "",
     "Re-emit the entire JSON object with these issues fixed. Do not include any prose outside the JSON.",
+    "",
+    "Common traps to double-check before re-emitting:",
+    "- `targetAdvocateRole` MUST equal the author of `targetArgumentId`, irrespective of which side your attack ultimately defends. For `targetKind: \"phase2-arg\"`, look up the `side=A|B` tag on the ARG line in `## PHASE_2_ARGUMENTS`. For `targetKind: \"round1-rebuttal\"`, set it to the side whose Phase-2 argument that round-1 rebuttal attacked (shown as `side=<X>-defender` in `## ROUND_1_ATTACKS_ALL`).",
+    "- `cqKey` must be copied verbatim from the target argument's own scheme catalog (`critical-questions for scheme=<schemeKey>:`). Do NOT mix keys across schemes; do NOT add or strip a trailing `?`.",
+    "- `citationToken` must include its prefix (e.g. `src:bail2018`, `block:cmoq...`, `web:<slug>`) and match `^[a-z]+:[A-Za-z0-9._-]+$`. A bare cuid is hard-rejected.",
   ].join("\n");
 }

--- a/experiments/polarization-1/orchestrator/agents/rebuttal-schema.ts
+++ b/experiments/polarization-1/orchestrator/agents/rebuttal-schema.ts
@@ -53,7 +53,12 @@ const RebuttalPremiseZ = z.object({
     .refine((s) => !/\?\s*$/.test(s.trim()), {
       message: "premise text must be declarative, not a question",
     }),
-  citationToken: CitationTokenZ.nullable(),
+  // `.nullish().transform(... ?? null)` — accept either an explicit
+  // `null` or a missing field and normalize both to `null`. LLMs
+  // frequently omit the field on premises with no citation; the
+  // post-validation pass still catches every actually-present token
+  // that fails to resolve in EVIDENCE_CORPUS / webCitations.
+  citationToken: CitationTokenZ.nullish().transform((v) => v ?? null),
 });
 
 /** Attack types map onto ArgumentEdge.attackType. */
@@ -291,7 +296,15 @@ export function buildRebuttalOutputSchema(opts: RebuttalSchemaOpts) {
     for (const r of data.rebuttals) {
       r.targetArgumentId = resolveArgId(r.targetArgumentId);
       const target = opposingArguments.get(r.targetArgumentId);
-      if (target && r.cqKey != null) r.cqKey = normalizeCqKey(r.cqKey, target.schemeKey);
+      if (target && r.cqKey != null) {
+        r.cqKey = normalizeCqKey(r.cqKey, target.schemeKey);
+        // If still not a valid CQ for the target's scheme (i.e. the model
+        // picked a key from a DIFFERENT scheme's catalog), null it. The
+        // rebuttal's substantive content is unaffected; only the optional
+        // CQ-link annotation is dropped.
+        const cqs = cqKeysByScheme.get(target.schemeKey);
+        if (cqs && !cqs.has(r.cqKey)) r.cqKey = null;
+      }
     }
 
     if (data.advocateRole !== advocateRole) {
@@ -438,17 +451,15 @@ export function buildRebuttalOutputSchema(opts: RebuttalSchemaOpts) {
         });
       }
 
-      // Optional cqKey on rebuttal: must be a real CQ for the target's scheme.
-      if (r.cqKey !== null) {
-        const cqs = cqKeysByScheme.get(target.schemeKey);
-        if (cqs && !cqs.has(r.cqKey)) {
-          ctx.addIssue({
-            code: z.ZodIssueCode.custom,
-            message: `rebuttals[${i}].cqKey "${r.cqKey}" is not a valid CQ for scheme "${target.schemeKey}"`,
-            path: ["rebuttals", i, "cqKey"],
-          });
-        }
-      }
+      // Optional cqKey on rebuttal: should be a real CQ for the target's
+      // scheme, but this is a pure annotation linking the rebuttal to a
+      // critical question on the target. Invalid keys are silently coerced
+      // to null in a post-process transform below; the rebuttal itself
+      // (premises, conclusion, attack-type) is unaffected. Soft-checks may
+      // surface a warning. We do NOT hard-reject here because the rebuttal's
+      // substantive content is independent of this annotation, and Haiku
+      // frequently picks a key from its own scheme's catalog instead of
+      // the target's.
     }
   });
 }

--- a/experiments/polarization-1/orchestrator/agents/rebuttal.ts
+++ b/experiments/polarization-1/orchestrator/agents/rebuttal.ts
@@ -274,5 +274,10 @@ function validationFollowupMessage(err: ZodError): string {
     formatZodIssues(err),
     "",
     "Re-emit the COMPLETE response (not a diff) addressing every issue. Same schema, single JSON object, no prose.",
+    "",
+    "Common traps to double-check before re-emitting:",
+    "- `cqKey` must be copied verbatim from the target argument's own scheme catalog shown inline as `critical-questions for scheme=<schemeKey>:` — do NOT use a key from a different scheme, and do NOT add or strip a trailing `?`.",
+    "- `citationToken` must include its prefix (e.g. `src:bail2018`, `block:cmoq...`, `web:<slug>`) and match `^[a-z]+:[A-Za-z0-9._-]+$`. A bare cuid is hard-rejected.",
+    "- If you are running round 2 and target a round-1 rebuttal, set `targetKind: \"round1-rebuttal\"` and use the rebuttal's `rebuttalArgumentId` as `targetArgumentId`.",
   ].join("\n");
 }

--- a/experiments/polarization-1/orchestrator/agents/synthesist.ts
+++ b/experiments/polarization-1/orchestrator/agents/synthesist.ts
@@ -75,6 +75,14 @@ export interface SynthesistTurnInput {
   /** Renders into `## EVIDENCE_CORPUS` — both bound corpus sources and
    *  web-discovered sources materialized during Phase 2-4. */
   evidenceCorpusPrompt: string;
+  /**
+   * Optional Iter-3 multi-round addendum block. When present, appended
+   * to the rendered user message between `## EVIDENCE_CORPUS` and
+   * `## YOUR_TASK`. Driver uses this to surface
+   * `## ROUND_2_ATTACKS` + `## SUB_ROUND_B_RESPONSES` sections.
+   * Iter-2 path leaves this undefined and behavior is unchanged.
+   */
+  appendedUserBlock?: string;
   /** Schema-binding parameters (known argument ids, attack ids, response
    *  ids, sub-claim count, citation tokens). */
   schemaOpts: SynthesistSchemaOpts;
@@ -281,6 +289,14 @@ function renderUserMessage(input: SynthesistTurnInput): string {
     "## EVIDENCE_CORPUS",
     "",
     input.evidenceCorpusPrompt.trim(),
+  );
+
+  const appended = (input.appendedUserBlock ?? "").trim();
+  if (appended.length > 0) {
+    sections.push("", appended);
+  }
+
+  sections.push(
     "",
     "## YOUR_TASK",
     "",

--- a/experiments/polarization-1/orchestrator/agents/tracker.ts
+++ b/experiments/polarization-1/orchestrator/agents/tracker.ts
@@ -69,6 +69,14 @@ export interface TrackerTurnInput {
   advocateBPhase4Prompt: string;
   /** Renders into `## EVIDENCE_CORPUS`. */
   evidenceCorpusPrompt: string;
+  /**
+   * Optional Iter-3 multi-round addendum block. When present, appended
+   * to the rendered user message between `## EVIDENCE_CORPUS` and
+   * `## YOUR_TASK`. Driver uses this to surface
+   * `## ROUND_2_ATTACKS` + `## SUB_ROUND_B_RESPONSES` sections.
+   * Iter-2 path leaves this undefined and behavior is unchanged.
+   */
+  appendedUserBlock?: string;
   /** Schema-binding parameters (known arguments, attack ids, response ids). */
   schemaOpts: TrackerSchemaOpts;
   cfg: OrchestratorConfig;
@@ -289,6 +297,9 @@ function renderUserMessage(input: TrackerTurnInput): string {
     "## EVIDENCE_CORPUS",
     "",
     input.evidenceCorpusPrompt.trim(),
+    ...((input.appendedUserBlock ?? "").trim().length > 0
+      ? ["", input.appendedUserBlock!.trim()]
+      : []),
     "",
     "## YOUR_TASK",
     "",

--- a/experiments/polarization-1/orchestrator/finalize/phase-3-finalize.ts
+++ b/experiments/polarization-1/orchestrator/finalize/phase-3-finalize.ts
@@ -31,6 +31,7 @@ import type {
   RebuttalRunRecord,
   MethodologistRunRecord,
 } from "../phases/phase-3-attacks";
+import type { Phase3Round2PartialFile } from "../phases/phase-3-round2";
 import type { ReviewFlag } from "../review/phase-3-checks";
 import { parseReport, reportPathFor } from "../review/report";
 import { prisma } from "@/lib/prismaclient";
@@ -103,6 +104,24 @@ export interface Phase3CompleteMethodologist {
   cqResponses: Phase3CompleteMethodologistCqResponse[];
 }
 
+/** Iter-3: per-actor summary of the round-2 pass, recorded on
+ *  `Phase3CompleteFile.round2` for audit. Mints are merged inline. */
+export interface Round2ActorSummary {
+  outcome: string;
+  attempts: number;
+  rebuttalsMerged: number;
+  cqResponsesMerged: number;
+  tokenUsage: { inputTokens: number; outputTokens: number };
+}
+
+/** Iter-3 task #6: round-2 soft-check coverage summary. Aggregates
+ *  per-rule flag counts produced by `runPhase3Round2SoftChecks`. */
+export interface Round2ReviewSummary {
+  totalFlags: number;
+  flagsByRule: Record<string, number>;
+  judgeUsage?: { calls: number; inputTokens: number; outputTokens: number };
+}
+
 export interface Phase3CompleteFile {
   phase: 3;
   status: "complete";
@@ -118,6 +137,22 @@ export interface Phase3CompleteFile {
    *  was introduced will not have this field. */
   methodologist?: Phase3CompleteMethodologist;
   totals: Phase3PartialFile["totals"];
+  /** Iter-3: per-actor outcome summary for the round-2 attack-on-attack
+   *  pass. Absent when `iter3MultiRound` is off or the round-2 driver
+   *  never ran. Mints from "ok" actors are merged inline into
+   *  `advocates.{a,b}.rebuttals`/`cqResponses` and
+   *  `methodologist.rebuttals`/`cqResponses` tagged `round: "2"`;
+   *  non-"ok" actors are recorded here for audit only. */
+  round2?: {
+    a?: Round2ActorSummary;
+    b?: Round2ActorSummary;
+    methodologist?: Round2ActorSummary;
+    totals: Phase3Round2PartialFile["totals"];
+    /** Iter-3 task #6: round-2 soft-check flag counts (merged into the
+     *  unified `reviewSummary` for human review; surfaced separately
+     *  here for audit of the round-2 deterministic+judge pass). */
+    review?: Round2ReviewSummary;
+  };
   reviewSummary: {
     totalFlags: number;
     accepted: number;
@@ -138,6 +173,15 @@ export async function finalizePhase3(opts: {
     throw new Error(`PHASE_3_PARTIAL.json not found. Run \`npm run orchestrator -- phase 3\` first.`);
   }
   const partial = JSON.parse(readFileSync(partialPath, "utf8")) as Phase3PartialFile;
+
+  // ── Iter-3: load round-2 partial when present + flag enabled ──
+  let round2: Phase3Round2PartialFile | null = null;
+  if (opts.cfg.iter3MultiRound) {
+    const round2Path = path.join(opts.cfg.runtimeDir, "PHASE_3_ROUND2_PARTIAL.json");
+    if (existsSync(round2Path)) {
+      round2 = JSON.parse(readFileSync(round2Path, "utf8")) as Phase3Round2PartialFile;
+    }
+  }
 
   // ── 1. Both advocates must have outcome === "ok" ──
   const a = partial.advocates.a;
@@ -175,6 +219,22 @@ export async function finalizePhase3(opts: {
       `Phase 3 finalize refused: methodologist record present but outcome="${meth.outcome}". ` +
         `Re-run \`npm run orchestrator -- phase 3 --resume\` to retry the methodologist.`,
     );
+  }
+
+  // Iter-3: include round-2 "ok" actor mints in the audit set.
+  if (round2) {
+    const round2Actors = [
+      round2.actors.a,
+      round2.actors.b,
+      round2.actors.methodologist,
+    ] as const;
+    for (const rec of round2Actors) {
+      if (!rec || rec.outcome !== "ok" || !rec.mintResult) continue;
+      for (const r of rec.mintResult.rebuttals) {
+        expectedArgIds.add(r.rebuttalArgumentId);
+        expectedEdgeIds.add(r.edgeId);
+      }
+    }
   }
 
   const divergences: string[] = [];
@@ -216,9 +276,100 @@ export async function finalizePhase3(opts: {
   }
 
   // ── 3. Review-flag gating ──
+  // Round-1 reviewFlags participate in the human-review report.
+  // Iter-3 round-2 reviewFlags are surfaced separately on
+  // `complete.round2.review` for analyst inspection and do NOT gate
+  // finalization (they are diagnostic — the round-2 mints are
+  // already validated by the same Zod + per-mint checks as round 1).
   const reviewSummary = await buildReviewSummary(opts.cfg, partial.reviewFlags);
 
   // ── 4. Build complete file ──
+  const completeA = buildCompleteAdvocate(a!);
+  const completeB = buildCompleteAdvocate(b!);
+  const completeMeth =
+    meth?.outcome === "ok" ? buildCompleteMethodologist(meth) : undefined;
+
+  // Iter-3: merge round-2 mints into the round-1 records (per-item
+  // `round` field discriminates). Non-"ok" actors contribute nothing
+  // but are summarized in `round2.{a,b,methodologist}`.
+  let round2Summary: Phase3CompleteFile["round2"] | undefined;
+  if (round2) {
+    const summarize = (
+      rec:
+        | RebuttalRunRecord
+        | MethodologistRunRecord
+        | undefined,
+      mergedRebuttals: number,
+      mergedCqs: number,
+    ): Round2ActorSummary | undefined =>
+      rec
+        ? {
+            outcome: rec.outcome,
+            attempts: rec.attempts,
+            rebuttalsMerged: mergedRebuttals,
+            cqResponsesMerged: mergedCqs,
+            tokenUsage: rec.tokenUsage,
+          }
+        : undefined;
+
+    const r2a = round2.actors.a;
+    if (r2a?.outcome === "ok" && r2a.mintResult && r2a.llmOutput) {
+      const built = buildCompleteAdvocate(r2a);
+      completeA.rebuttals.push(...built.rebuttals);
+      completeA.cqResponses.push(...built.cqResponses);
+      completeA.attempts += r2a.attempts;
+      completeA.tokenUsage.inputTokens += r2a.tokenUsage.inputTokens;
+      completeA.tokenUsage.outputTokens += r2a.tokenUsage.outputTokens;
+    }
+    const r2b = round2.actors.b;
+    if (r2b?.outcome === "ok" && r2b.mintResult && r2b.llmOutput) {
+      const built = buildCompleteAdvocate(r2b);
+      completeB.rebuttals.push(...built.rebuttals);
+      completeB.cqResponses.push(...built.cqResponses);
+      completeB.attempts += r2b.attempts;
+      completeB.tokenUsage.inputTokens += r2b.tokenUsage.inputTokens;
+      completeB.tokenUsage.outputTokens += r2b.tokenUsage.outputTokens;
+    }
+    const r2m = round2.actors.methodologist;
+    if (r2m?.outcome === "ok" && r2m.mintResult && r2m.llmOutput && completeMeth) {
+      const built = buildCompleteMethodologist(r2m);
+      completeMeth.rebuttals.push(...built.rebuttals);
+      completeMeth.cqResponses.push(...built.cqResponses);
+      completeMeth.attempts += r2m.attempts;
+      completeMeth.tokenUsage.inputTokens += r2m.tokenUsage.inputTokens;
+      completeMeth.tokenUsage.outputTokens += r2m.tokenUsage.outputTokens;
+    }
+
+    round2Summary = {
+      a: summarize(
+        r2a,
+        r2a?.outcome === "ok" ? (r2a.mintResult?.rebuttals.length ?? 0) : 0,
+        r2a?.outcome === "ok" ? (r2a.mintResult?.cqResponses.length ?? 0) : 0,
+      ),
+      b: summarize(
+        r2b,
+        r2b?.outcome === "ok" ? (r2b.mintResult?.rebuttals.length ?? 0) : 0,
+        r2b?.outcome === "ok" ? (r2b.mintResult?.cqResponses.length ?? 0) : 0,
+      ),
+      methodologist: summarize(
+        r2m,
+        r2m?.outcome === "ok" ? (r2m.mintResult?.rebuttals.length ?? 0) : 0,
+        r2m?.outcome === "ok" ? (r2m.mintResult?.cqResponses.length ?? 0) : 0,
+      ),
+      totals: round2.totals,
+      review: round2.reviewFlags
+        ? {
+            totalFlags: round2.reviewFlags.length,
+            flagsByRule: round2.reviewFlags.reduce<Record<string, number>>((acc, f) => {
+              acc[f.ruleId] = (acc[f.ruleId] ?? 0) + 1;
+              return acc;
+            }, {}),
+            judgeUsage: round2.judgeUsage,
+          }
+        : undefined,
+    };
+  }
+
   const complete: Phase3CompleteFile = {
     phase: 3,
     status: "complete",
@@ -228,13 +379,10 @@ export async function finalizePhase3(opts: {
     evidenceStackId: partial.evidenceStackId,
     hingeIndices: partial.hingeIndices,
     cqCatalog: partial.cqCatalog,
-    advocates: {
-      a: buildCompleteAdvocate(a!),
-      b: buildCompleteAdvocate(b!),
-    },
-    methodologist:
-      meth?.outcome === "ok" ? buildCompleteMethodologist(meth) : undefined,
+    advocates: { a: completeA, b: completeB },
+    methodologist: completeMeth,
     totals: partial.totals,
+    round2: round2Summary,
     reviewSummary,
     judgeUsage: partial.judgeUsage,
   };

--- a/experiments/polarization-1/orchestrator/finalize/phase-4-finalize.ts
+++ b/experiments/polarization-1/orchestrator/finalize/phase-4-finalize.ts
@@ -33,6 +33,7 @@ import type {
   DefenseRunRecord,
   TrackerRunRecord,
 } from "../phases/phase-4-defenses";
+import type { Phase4SubRoundBPartialFile } from "../phases/phase-4-subround-b";
 import type { ReviewFlag } from "../review/phase-4-checks";
 import { parseReport, reportPathFor } from "../review/report";
 import { prisma } from "@/lib/prismaclient";
@@ -44,6 +45,11 @@ import { recomputeGroundedForDelib } from "@/lib/ceg/grounded";
 
 export interface Phase4CompleteResponse {
   inputIndex: number;
+  /** Iter-3: which sub-round the response was filed in. "a" =
+   *  sub-round-a (Iter-2 default), "b" = sub-round-b (defends round-2
+   *  attacks). Items merged from `PHASE_4_SUBROUNDB_PARTIAL.json`
+   *  carry `"b"`. */
+  subRound: "a" | "b";
   targetAttackId: string;
   kind: "defend" | "concede" | "narrow";
   rationale: string;
@@ -69,6 +75,8 @@ export interface Phase4CompleteResponse {
 
 export interface Phase4CompleteCqAnswer {
   inputIndex: number;
+  /** Iter-3: which sub-round the cqAnswer was filed in. */
+  subRound: "a" | "b";
   targetCqRaiseId: string;
   kind: "answer" | "concede";
   rationale: string;
@@ -85,6 +93,15 @@ export interface Phase4CompleteAdvocate {
   cqAnswers: Phase4CompleteCqAnswer[];
 }
 
+/** Iter-3: per-advocate summary of the sub-round-b pass. */
+export interface SubRoundBAdvocateSummary {
+  outcome: string;
+  attempts: number;
+  responsesMerged: number;
+  cqAnswersMerged: number;
+  tokenUsage: { inputTokens: number; outputTokens: number };
+}
+
 export interface Phase4CompleteFile {
   phase: 4;
   status: "complete";
@@ -96,6 +113,17 @@ export interface Phase4CompleteFile {
   advocates: { a: Phase4CompleteAdvocate; b: Phase4CompleteAdvocate };
   tracker: TrackerRunRecord;
   totals: Phase4PartialFile["totals"];
+  /** Iter-3: per-advocate summary for the sub-round-b pass. Absent when
+   *  `iter3MultiRound` is off or the sub-round-b driver never ran.
+   *  Mints from "ok" advocates are merged inline into
+   *  `advocates.{a,b}.responses` / `cqAnswers` (each tagged
+   *  `subRound: "b"`); non-"ok" advocates are recorded here for audit
+   *  only. */
+  subRoundB?: {
+    a?: SubRoundBAdvocateSummary;
+    b?: SubRoundBAdvocateSummary;
+    totals: Phase4SubRoundBPartialFile["totals"];
+  };
   reviewSummary: {
     totalFlags: number;
     accepted: number;
@@ -123,6 +151,15 @@ export async function finalizePhase4(opts: {
     throw new Error(`PHASE_4_PARTIAL.json not found. Run \`npm run orchestrator -- phase 4\` first.`);
   }
   const partial = JSON.parse(readFileSync(partialPath, "utf8")) as Phase4PartialFile;
+
+  // ── Iter-3: load sub-round-b partial when present + flag enabled ──
+  let subRoundB: Phase4SubRoundBPartialFile | null = null;
+  if (opts.cfg.iter3MultiRound) {
+    const subbPath = path.join(opts.cfg.runtimeDir, "PHASE_4_SUBROUNDB_PARTIAL.json");
+    if (existsSync(subbPath)) {
+      subRoundB = JSON.parse(readFileSync(subbPath, "utf8")) as Phase4SubRoundBPartialFile;
+    }
+  }
 
   // ── 1. Both advocates must have outcome === "ok" + tracker must have run ──
   const a = partial.advocates.a;
@@ -162,6 +199,24 @@ export async function finalizePhase4(opts: {
     }
     for (const c of rec.mintResult.cqAnswers) {
       if (c.cqStatusId) expectedCqStatusIds.add(c.cqStatusId);
+    }
+  }
+
+  // Iter-3: include sub-round-b "ok" advocate mints in the audit set.
+  if (subRoundB) {
+    const subActors = [subRoundB.advocates.a, subRoundB.advocates.b] as const;
+    for (const rec of subActors) {
+      if (!rec || rec.outcome !== "ok" || !rec.mintResult) continue;
+      for (const r of rec.mintResult.responses) {
+        if (r.defenseArgumentId) expectedDefenseArgIds.add(r.defenseArgumentId);
+        if (r.defenseEdgeId) expectedDefenseEdgeIds.add(r.defenseEdgeId);
+        if (r.narrowVariantArgumentId) expectedNarrowArgIds.add(r.narrowVariantArgumentId);
+        if (r.retractedCommitmentClaimId) expectedRetractedClaimIds.add(r.retractedCommitmentClaimId);
+        if (r.cqStatusIdRejected) expectedCqStatusIds.add(r.cqStatusIdRejected);
+      }
+      for (const c of rec.mintResult.cqAnswers) {
+        if (c.cqStatusId) expectedCqStatusIds.add(c.cqStatusId);
+      }
     }
   }
 
@@ -265,6 +320,62 @@ export async function finalizePhase4(opts: {
   }
 
   // ── 5. Build complete file ──
+  const completeA = buildCompleteAdvocate(a!);
+  const completeB = buildCompleteAdvocate(b!);
+
+  // Iter-3: merge sub-round-b mints into the sub-round-a records
+  // (per-item `subRound` field discriminates).
+  let subRoundBSummary: Phase4CompleteFile["subRoundB"] | undefined;
+  if (subRoundB) {
+    const summarize = (
+      rec: DefenseRunRecord | undefined,
+      mergedResponses: number,
+      mergedCqs: number,
+    ): SubRoundBAdvocateSummary | undefined =>
+      rec
+        ? {
+            outcome: rec.outcome,
+            attempts: rec.attempts,
+            responsesMerged: mergedResponses,
+            cqAnswersMerged: mergedCqs,
+            tokenUsage: rec.tokenUsage,
+          }
+        : undefined;
+
+    const sbA = subRoundB.advocates.a;
+    if (sbA?.outcome === "ok" && sbA.mintResult && sbA.llmOutput) {
+      const built = buildCompleteAdvocate(sbA);
+      completeA.responses.push(...built.responses);
+      completeA.cqAnswers.push(...built.cqAnswers);
+      completeA.attempts += sbA.attempts;
+      completeA.tokenUsage.inputTokens += sbA.tokenUsage.inputTokens;
+      completeA.tokenUsage.outputTokens += sbA.tokenUsage.outputTokens;
+    }
+    const sbB = subRoundB.advocates.b;
+    if (sbB?.outcome === "ok" && sbB.mintResult && sbB.llmOutput) {
+      const built = buildCompleteAdvocate(sbB);
+      completeB.responses.push(...built.responses);
+      completeB.cqAnswers.push(...built.cqAnswers);
+      completeB.attempts += sbB.attempts;
+      completeB.tokenUsage.inputTokens += sbB.tokenUsage.inputTokens;
+      completeB.tokenUsage.outputTokens += sbB.tokenUsage.outputTokens;
+    }
+
+    subRoundBSummary = {
+      a: summarize(
+        sbA,
+        sbA?.outcome === "ok" ? (sbA.mintResult?.responses.length ?? 0) : 0,
+        sbA?.outcome === "ok" ? (sbA.mintResult?.cqAnswers.length ?? 0) : 0,
+      ),
+      b: summarize(
+        sbB,
+        sbB?.outcome === "ok" ? (sbB.mintResult?.responses.length ?? 0) : 0,
+        sbB?.outcome === "ok" ? (sbB.mintResult?.cqAnswers.length ?? 0) : 0,
+      ),
+      totals: subRoundB.totals,
+    };
+  }
+
   const complete: Phase4CompleteFile = {
     phase: 4,
     status: "complete",
@@ -273,12 +384,10 @@ export async function finalizePhase4(opts: {
     modelTier: partial.modelTier,
     evidenceStackId: partial.evidenceStackId,
     hingeIndices: partial.hingeIndices,
-    advocates: {
-      a: buildCompleteAdvocate(a!),
-      b: buildCompleteAdvocate(b!),
-    },
+    advocates: { a: completeA, b: completeB },
     tracker: partial.tracker,
     totals: partial.totals,
+    subRoundB: subRoundBSummary,
     reviewSummary,
     judgeUsage: partial.judgeUsage,
     standingsRecompute: {
@@ -354,11 +463,13 @@ function buildCompleteAdvocate(rec: DefenseRunRecord): Phase4CompleteAdvocate {
   }
   const inputResponses = rec.llmOutput.responses;
   const inputCqAnswers = rec.llmOutput.cqAnswers;
+  const subRound: "a" | "b" = rec.llmOutput.subRound ?? "a";
 
   const responses: Phase4CompleteResponse[] = rec.mintResult.responses.map((m) => {
     const orig = inputResponses[m.inputIndex];
     return {
       inputIndex: m.inputIndex,
+      subRound,
       targetAttackId: m.targetAttackId,
       kind: m.kind,
       rationale: orig.rationale,
@@ -388,6 +499,7 @@ function buildCompleteAdvocate(rec: DefenseRunRecord): Phase4CompleteAdvocate {
     const orig = inputCqAnswers[m.inputIndex];
     return {
       inputIndex: m.inputIndex,
+      subRound,
       targetCqRaiseId: m.targetCqRaiseId,
       kind: m.kind,
       rationale: orig.rationale,
@@ -398,7 +510,7 @@ function buildCompleteAdvocate(rec: DefenseRunRecord): Phase4CompleteAdvocate {
   return {
     outcome: "ok",
     attempts: rec.attempts,
-    subRound: rec.llmOutput!.subRound ?? "a",
+    subRound,
     tokenUsage: rec.tokenUsage,
     responses,
     cqAnswers,

--- a/experiments/polarization-1/orchestrator/index.ts
+++ b/experiments/polarization-1/orchestrator/index.ts
@@ -259,6 +259,10 @@ async function cmdPhase(phaseNum: number, args: ParsedArgs) {
   const tier = (args.flags["model-tier"] as ModelTier) || "dev";
   const root = args.flags["experiment-root"] as string | undefined;
 
+  // Validate `--round` early (before preflight network calls) so users get
+  // fast feedback on bad CLI invocations.
+  const roundFilter = parseRoundFilter(phaseNum, args.flags["round"]);
+
   const pre = await runPreflight({
     modelTier: tier,
     experimentRoot: root,
@@ -313,6 +317,7 @@ async function cmdPhase(phaseNum: number, args: ParsedArgs) {
     deliberationId: delib.deliberationId,
     maxRounds: args.flags["max-rounds"] ? Number(args.flags["max-rounds"]) : undefined,
     resume: args.flags["resume"] === true || args.flags["resume"] === "true",
+    roundFilter,
   });
 
   logger.event("phase_complete", { phase: phaseNum, result });
@@ -328,6 +333,39 @@ function phaseNameFor(n: number): string {
     case 5: return "phase-5-synthesis";
     default: throw new Error(`Unknown phase ${n}`);
   }
+}
+
+/**
+ * Iter-3 `--round` flag for resume granularity. Maps the raw flag value
+ * to the per-phase enum the phase module accepts.
+ *
+ * - `--phase 3 --round 1|2`: gates Phase-3 round-1 vs round-2 hook.
+ * - `--phase 4 --round a|b`: gates Phase-4 sub-round-a vs sub-round-b hook.
+ *
+ * Other phases reject `--round`. Returns undefined when not set.
+ */
+function parseRoundFilter(
+  phaseNum: number,
+  raw: string | true | undefined,
+): "1" | "2" | "a" | "b" | undefined {
+  if (raw === undefined) return undefined;
+  if (raw === true) {
+    throw new Error(`--round requires a value (e.g. --round 2 for phase 3, --round b for phase 4).`);
+  }
+  const v = String(raw).trim().toLowerCase();
+  if (phaseNum === 3) {
+    if (v !== "1" && v !== "2") {
+      throw new Error(`--phase 3 --round expects "1" or "2"; got "${v}".`);
+    }
+    return v;
+  }
+  if (phaseNum === 4) {
+    if (v !== "a" && v !== "b") {
+      throw new Error(`--phase 4 --round expects "a" or "b"; got "${v}".`);
+    }
+    return v;
+  }
+  throw new Error(`--round is only meaningful for --phase 3 (1|2) or --phase 4 (a|b); got phase ${phaseNum}.`);
 }
 
 // ────────────────────────────────────────────────────────────────────────────
@@ -480,7 +518,9 @@ function usage(): string {
     "  state                          Print composed deliberation state JSON (no LLM calls)",
     "  setup [--force] [--stack-id ID] [--stack-name S] [--experiment-mode] [--role R]",
     "                                 Create stack + deliberation + bind evidence; writes runtime/deliberation.json",
-    "  phase <N> [--max-rounds N] [--resume]  Run phase N",
+    "  phase <N> [--max-rounds N] [--resume] [--round R]  Run phase N",
+    "                                                      --round 1|2 (phase 3) or a|b (phase 4)",
+    "                                                      gates Iter-3 multi-round halves for resume.",
     "  review --phase N [--apply] [--force]    Produce or apply phase-N review report",
     "  finalize --phase N             Validate platform state and write PHASE_N_COMPLETE.json",
     "",

--- a/experiments/polarization-1/orchestrator/phases/phase-3-attacks.ts
+++ b/experiments/polarization-1/orchestrator/phases/phase-3-attacks.ts
@@ -83,6 +83,7 @@ import type {
   Phase2CompleteArgument,
 } from "../finalize/phase-2-finalize";
 import type { AdvocateLayer } from "../agents/advocate-schema";
+import { runPhase3Round2 } from "./phase-3-round2";
 
 // ─────────────────────────────────────────────────────────────────
 // Public types
@@ -96,6 +97,14 @@ export interface RunPhase3Opts {
   onlyAdvocate?: RebuttalAgentRole;
   resume?: boolean;
   maxRounds?: number;
+  /**
+   * Iter-3 round filter for resume granularity.
+   * - undefined: default behavior (round-1 then iter3 round-2 hook if flag set).
+   * - "1": run only round-1; skip the iter3 round-2 hook even when flag set.
+   * - "2": skip round-1 actor loop (must be ok in PHASE_3_PARTIAL.json);
+   *        run only the round-2 hook. Requires `cfg.iter3MultiRound`.
+   */
+  roundFilter?: "1" | "2";
 }
 
 export interface RebuttalRunRecord {
@@ -252,7 +261,27 @@ export async function runPhase(opts: RunPhase3Opts): Promise<Phase3PartialFile> 
   }
 
   // 6. Decide which advocates to run.
+  //    Iter-3 `--round 2` short-circuits the round-1 actor loop entirely:
+  //    round-1 must already be complete in PHASE_3_PARTIAL.json.
+  if (opts.roundFilter === "2") {
+    if (!opts.cfg.iter3MultiRound) {
+      throw new Error(
+        "--round 2 requires ITER3_MULTI_ROUND=1 (set the env var or `iter3MultiRound: true` in agents.json).",
+      );
+    }
+    if (
+      !priorPartial ||
+      priorPartial.advocates.a?.outcome !== "ok" ||
+      priorPartial.advocates.b?.outcome !== "ok" ||
+      priorPartial.methodologist?.outcome !== "ok"
+    ) {
+      throw new Error(
+        "--round 2 requires PHASE_3_PARTIAL.json with all 3 round-1 actors `outcome=ok`. Run `--phase 3 --round 1` (or `--phase 3`) first.",
+      );
+    }
+  }
   const advocatesToRun: RebuttalAgentRole[] = (() => {
+    if (opts.roundFilter === "2") return [];
     if (opts.onlyAdvocate) return [opts.onlyAdvocate];
     const all: RebuttalAgentRole[] = ["advocate-a", "advocate-b"];
     if (!priorPartial) return all;
@@ -262,7 +291,24 @@ export async function runPhase(opts: RunPhase3Opts): Promise<Phase3PartialFile> 
     });
   })();
 
-  if (advocatesToRun.length === 0 && (priorPartial?.methodologist?.outcome === "ok" || opts.onlyAdvocate)) {
+  // Iter-3 `--round 2` skips this short-circuit because the round-2 hook
+  // below is the entire point of the run. Iter-3 default also bypasses
+  // when the round-2 partial doesn't yet exist on disk, so re-running
+  // `--phase 3` after round-1 completes still triggers the round-2 hook.
+  const round2PartialExists = existsSync(
+    path.join(opts.cfg.runtimeDir, "PHASE_3_ROUND2_PARTIAL.json"),
+  );
+  const skipShortCircuitForRound2 =
+    opts.roundFilter === "2" ||
+    (opts.cfg.iter3MultiRound &&
+      opts.roundFilter !== "1" &&
+      !opts.onlyAdvocate &&
+      !round2PartialExists);
+  if (
+    !skipShortCircuitForRound2 &&
+    advocatesToRun.length === 0 &&
+    (priorPartial?.methodologist?.outcome === "ok" || opts.onlyAdvocate)
+  ) {
     phaseLogger.event("phase_complete", {
       phase: 3,
       outcome: "already-complete",
@@ -314,6 +360,7 @@ export async function runPhase(opts: RunPhase3Opts): Promise<Phase3PartialFile> 
   //     `onlyAdvocate` scopes the run to that advocate only — skip the
   //     methodologist in that case.
   const methodologistShouldRun =
+    opts.roundFilter !== "2" &&
     !opts.onlyAdvocate &&
     results.a?.outcome === "ok" &&
     results.b?.outcome === "ok" &&
@@ -353,12 +400,8 @@ export async function runPhase(opts: RunPhase3Opts): Promise<Phase3PartialFile> 
     writePartial(partialPath, opts, ec.stack.id, phase2.topologyBinding.hingeIndices, cqCatalogForFile, results, methodologistResult, [], undefined);
   }
 
-  // 9. Soft-track review.
-  const rebuttalOutputs = {
-    a: results.a?.outcome === "ok" ? results.a.llmOutput : undefined,
-    b: results.b?.outcome === "ok" ? results.b.llmOutput : undefined,
-  };
-  const anyOk = Boolean(rebuttalOutputs.a || rebuttalOutputs.b);
+  // Build EvidenceSourceLite list once — consumed by both the iter-3
+  // round-2 soft-check pass (below) and the round-1 soft-check pass (§9).
   const reviewSourcesLite = ec.sources.map((s: any) => ({
     sourceId: s.sourceId,
     citationToken: s.citationToken,
@@ -369,6 +412,86 @@ export async function runPhase(opts: RunPhase3Opts): Promise<Phase3PartialFile> 
     keyFindings: Array.isArray(s.keyFindings) ? s.keyFindings : [],
     tags: Array.isArray(s.tags) ? s.tags : [],
   }));
+
+  // 8c. Iter-3 multi-round: run round 2 immediately if all 3 round-1
+  //     actors are ok and the gate flag is set. Round-2 mints to the
+  //     DB (translator skips orphan-guard) and writes its own
+  //     PHASE_3_ROUND2_PARTIAL.json. Round-1 partial is untouched.
+  if (
+    opts.cfg.iter3MultiRound &&
+    opts.roundFilter !== "1" &&
+    !opts.onlyAdvocate &&
+    results.a?.outcome === "ok" &&
+    results.b?.outcome === "ok" &&
+    methodologistResult?.outcome === "ok"
+  ) {
+    const methBindings = buildMethodologistBindings(
+      phase2.advocates.a,
+      phase2.advocates.b,
+      phase2.topologyBinding.layerByIndex,
+    );
+    const methPrompt = renderMethodologistPhase2Block(
+      phase2.advocates.a,
+      phase2.advocates.b,
+      cqCatalogByScheme,
+      phase2.topologyBinding.layerByIndex,
+      phase2.indexToText,
+    );
+    const phase2ArgSideById = new Map<string, "A" | "B">();
+    for (const arg of phase2.advocates.a.arguments) phase2ArgSideById.set(arg.argumentId, "A");
+    for (const arg of phase2.advocates.b.arguments) phase2ArgSideById.set(arg.argumentId, "B");
+    try {
+      await runPhase3Round2({
+        cfg: opts.cfg,
+        iso: opts.iso,
+        llm: opts.llm,
+        deliberationId: opts.deliberationId,
+        framing: framing.full,
+        evidenceCorpusPrompt,
+        allowedCitationTokens,
+        tokenToSourceId,
+        schemeCatalog,
+        schemeIdByKey,
+        cqCatalogByScheme,
+        registry,
+        round1: {
+          a: results.a!,
+          b: results.b!,
+          methodologist: methodologistResult!,
+        },
+        phase2OpponentBindings: opponentBindings,
+        phase2OpponentPrompts: opponentPrompts,
+        methodologistPhase2Prompt: methPrompt,
+        methodologistPhase2Bindings: methBindings,
+        phase2PremiseMaps: {
+          a: buildPremiseMap(phase2.advocates.b),
+          b: buildPremiseMap(phase2.advocates.a),
+        },
+        phase2ConclusionMaps: {
+          a: buildConclusionMap(phase2.advocates.b),
+          b: buildConclusionMap(phase2.advocates.a),
+        },
+        methodologistPhase2PremiseMap: buildMethodologistPremiseMap(phase2.advocates.a, phase2.advocates.b),
+        methodologistPhase2ConclusionMap: buildMethodologistConclusionMap(phase2.advocates.a, phase2.advocates.b),
+        phase2ArgSideById,
+        sources: reviewSourcesLite,
+      });
+    } catch (err) {
+      // Round-2 failure must NOT poison round-1 partial. Log and
+      // continue to soft-track review on round-1 results.
+      phaseLogger.event("round_summary", {
+        step: "round-2-error",
+        error: (err as Error).message,
+      });
+    }
+  }
+
+  // 9. Soft-track review.
+  const rebuttalOutputs = {
+    a: results.a?.outcome === "ok" ? results.a.llmOutput : undefined,
+    b: results.b?.outcome === "ok" ? results.b.llmOutput : undefined,
+  };
+  const anyOk = Boolean(rebuttalOutputs.a || rebuttalOutputs.b);
   const review = anyOk
     ? await runPhase3SoftChecks({
         rebuttals: rebuttalOutputs,
@@ -633,7 +756,7 @@ function loadPhase2Complete(runtimeDir: string, deliberationId: string): Phase2C
  * keyed by scheme KEY (not id) so it matches the rebuttal-schema's
  * `cqKeysByScheme` shape.
  */
-async function loadCqCatalog(
+export async function loadCqCatalog(
   usedSchemeKeys: ReadonlySet<string>,
   schemeIdByKey: ReadonlyMap<string, string>,
 ): Promise<Map<ExperimentSchemeKey, Set<string>>> {
@@ -699,19 +822,19 @@ function buildOpponentMetaMap(opp: Phase2CompleteAdvocate): Map<string, Opposing
   return m;
 }
 
-function buildSchemeMap(bindings: ReadonlyMap<string, OpposingArgumentBinding>): Map<string, string> {
+export function buildSchemeMap(bindings: ReadonlyMap<string, OpposingArgumentBinding>): Map<string, string> {
   const m = new Map<string, string>();
   for (const [argId, b] of bindings) m.set(argId, b.schemeKey);
   return m;
 }
 
-function buildPremiseMap(opp: Phase2CompleteAdvocate): Map<string, readonly string[]> {
+export function buildPremiseMap(opp: Phase2CompleteAdvocate): Map<string, readonly string[]> {
   const m = new Map<string, readonly string[]>();
   for (const a of opp.arguments) m.set(a.argumentId, a.premiseClaimIds);
   return m;
 }
 
-function buildConclusionMap(opp: Phase2CompleteAdvocate): Map<string, string> {
+export function buildConclusionMap(opp: Phase2CompleteAdvocate): Map<string, string> {
   const m = new Map<string, string>();
   for (const a of opp.arguments) m.set(a.argumentId, a.conclusionClaimId);
   return m;
@@ -840,7 +963,7 @@ export class BothAdvocatesRefusedError extends Error {
 // Methodologist (third actor)
 // ─────────────────────────────────────────────────────────────────
 
-interface MethodologistOpposingArgumentBinding extends OpposingArgumentBinding {
+export interface MethodologistOpposingArgumentBinding extends OpposingArgumentBinding {
   advocateRole: "A" | "B";
 }
 

--- a/experiments/polarization-1/orchestrator/phases/phase-3-round2.ts
+++ b/experiments/polarization-1/orchestrator/phases/phase-3-round2.ts
@@ -3,66 +3,1009 @@
  *
  * Iter-3 multi-round Phase 3 — round-2 driver. Gated behind
  * `cfg.iter3MultiRound`. Round 1 runs via the existing `runPhase`
- * code path; this module orchestrates round 2 (attacks-on-attacks
- * + new direct attacks) for advocates A, B, and the Methodologist.
+ * code path; this module is invoked from `runPhase` AFTER round 1's
+ * methodologist has succeeded.
  *
- * Status: SCAFFOLD (Iter-3 in progress).
+ * Round-2 semantics (per locked design memo):
+ *   - Actors: advocate-a, advocate-b, methodologist (same three).
+ *   - Each actor may emit:
+ *       (a) NEW direct attacks on opponent's Phase-2 args
+ *           (`targetKind = "phase2-arg"` — same as round 1).
+ *       (b) Attacks-on-attacks against round-1 rebuttals filed
+ *           against the actor's own Phase-2 args
+ *           (`targetKind = "round1-rebuttal"`).
+ *   - CQ raises in round 2 are bound to the TARGET's scheme — for
+ *     attacks-on-attacks, that's the round-1 rebuttal's `schemeKey`.
  *
- * What's wired:
- *   - Reads the round-2 addendum prompts (4b/5b/10b) and appends them
- *     to the base round-1 system prompts.
- *   - Skeleton for fetching round-1 rebuttals + building the extended
- *     opposing-argument bindings (round-1 rebuttalArgumentIds become
- *     legitimate round-2 targets).
- *   - Skeleton for rendering the `## ROUND_1_ATTACKS_ON_YOU` user
- *     block.
- *   - Calls `runOneAdvocate`-style logic with `round: "2"` plumbed
- *     through to `translateRebuttalOutput`.
+ * Outputs:
+ *   - DB: argument + edge rows for round-2 rebuttals (translator
+ *     handles minting; orphan-guard is skipped per `round: "2"`).
+ *   - File: `PHASE_3_ROUND2_PARTIAL.json` next to PHASE_3_PARTIAL.json
+ *     (separate file — finalize-merge into PHASE_3_COMPLETE is a
+ *     follow-up task; tracker reads attacks from DB regardless).
  *
- * What's TODO (marked inline):
- *   1. `loadRound1RebuttalsForBindings`: fetch the round-1 rebuttal
- *      Arguments + their premise/conclusion claim ids from prisma so
- *      they can be added to the opposing-arg maps.
- *   2. `renderRound1AttacksOnYou`: render the structured Markdown
- *      block listing attacks the recipient must defend / can attack.
- *   3. Persistence: extend `Phase3PartialFile` with a
- *      `round2: { advocates, methodologist }` sub-record (or use a
- *      flat `rebuttals[]` with `round` field — see locked design
- *      memo `/memories/repo/polarization-1-iteration-3-design.md`).
- *
- * NEVER call this directly from the orchestrator CLI without the
- * gating flag check; doing so will silently re-mint round-1 work.
+ * Failure mode: if any actor refuses or validation-errors, round-2
+ * partial still records the failure record; round-1 results are
+ * untouched. User can re-resume with the same gate flag.
  */
 
 import path from "path";
-import { readFileSync, existsSync } from "fs";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "fs";
+
 import type { OrchestratorConfig } from "../config";
 import type { IsonomiaClient } from "../isonomia-client";
 import type { AnthropicClient } from "../anthropic-client";
-import type { RoundLogger } from "../log/round-logger";
+import { RoundLogger } from "../log/round-logger";
+import { ClaimRegistry } from "../translators/claim-mint";
+
+import {
+  loadCqCatalog,
+  buildSchemeMap,
+  buildPremiseMap,
+  buildConclusionMap,
+  type RebuttalRunRecord,
+  type MethodologistRunRecord,
+  type Phase3PartialFile,
+  type MethodologistOpposingArgumentBinding,
+} from "./phase-3-attacks";
+
+import {
+  runRebuttalTurn,
+  RebuttalValidationError,
+  isRebuttalRefusal,
+  type RebuttalAgentRole,
+} from "../agents/rebuttal";
+import {
+  runMethodologistTurn,
+  MethodologistValidationError,
+  isMethodologistRefusal,
+  METHODOLOGIST_AGENT_ROLE,
+} from "../agents/methodologist";
+import {
+  type OpposingArgumentBinding,
+} from "../agents/rebuttal-schema";
+import type { ExperimentSchemeKey } from "../scheme-catalog";
+import { isAllowedSchemeKey } from "../scheme-catalog";
+import { translateRebuttalOutput } from "../translators/attack-mint";
+import {
+  type RebuttalOutput,
+} from "../agents/rebuttal-schema";
+import type { Phase3CompleteRebuttal, Phase3CompleteMethodologistRebuttal } from "../finalize/phase-3-finalize";
+import {
+  runPhase3Round2SoftChecks,
+  type OpposingArgumentMeta,
+  type ReviewFlag,
+  type EvidenceSourceLite,
+} from "../review/phase-3-checks";
+
+// ─────────────────────────────────────────────────────────────────
+// Shared types
+// ─────────────────────────────────────────────────────────────────
+
+const PHASE_3_LLM_DIR = "llm";
+const PHASE_3_ROUND2_PARTIAL_FILE = "PHASE_3_ROUND2_PARTIAL.json";
+const REFUSALS_DIR = "refusals";
+
+/** Round-1 rebuttal record viewed as a potential round-2 target. */
+interface Round1RebuttalRef {
+  rebuttalArgumentId: string;
+  /** Scheme of the round-1 rebuttal (target schema for CQ raises). */
+  schemeKey: string;
+  premiseClaimIds: readonly string[];
+  conclusionClaimId: string;
+  conclusionText: string;
+  premiseTexts: readonly string[];
+  warrant: string | null;
+  cqKey: string | null;
+  /** Phase-2 argumentId this round-1 rebuttal attacked. */
+  targetPhase2ArgId: string;
+  attackType: "REBUT" | "UNDERMINE" | "UNDERCUT";
+  /** Author role of the round-1 rebuttal. */
+  authorRole: "advocate-a" | "advocate-b" | "methodologist";
+  /** Side whose Phase-2 argument was attacked (the side that needs to
+   *  defend / attack-back in round 2). */
+  defendingSide: "A" | "B";
+}
 
 export interface RunPhase3Round2Opts {
   cfg: OrchestratorConfig;
   iso: IsonomiaClient;
   llm: AnthropicClient;
   deliberationId: string;
-  /** Path to PHASE_3_COMPLETE.json (round-1 finalize result). */
-  phase3CompletePath: string;
-  logger: RoundLogger;
+  framing: string;
+  evidenceCorpusPrompt: string;
+  allowedCitationTokens: Set<string>;
+  tokenToSourceId: Record<string, string>;
+  schemeCatalog: Array<{ id: string; key: string }>;
+  schemeIdByKey: ReadonlyMap<string, string>;
+  cqCatalogByScheme: ReadonlyMap<ExperimentSchemeKey, ReadonlySet<string>>;
+  registry: ClaimRegistry;
+  /** Round-1 results. All three must have outcome="ok" before calling. */
+  round1: {
+    a: RebuttalRunRecord;
+    b: RebuttalRunRecord;
+    methodologist: MethodologistRunRecord;
+  };
+  /** Phase-2 opposing-argument bindings for each side (reused from round 1). */
+  phase2OpponentBindings: {
+    a: ReadonlyMap<string, OpposingArgumentBinding>; // for A: B's args
+    b: ReadonlyMap<string, OpposingArgumentBinding>; // for B: A's args
+  };
+  /** Pre-rendered Phase-2 OPPONENT_ARGUMENTS prompt blocks (from round 1). */
+  phase2OpponentPrompts: { a: string; b: string };
+  /** Pre-rendered Phase-2 BOTH-SIDES prompt block for the methodologist. */
+  methodologistPhase2Prompt: string;
+  /** Methodologist's Phase-2 bindings (both sides). */
+  methodologistPhase2Bindings: ReadonlyMap<string, MethodologistOpposingArgumentBinding>;
+  /** Phase-2 premise/conclusion maps (one per side, indexed by Phase-2 argId). */
+  phase2PremiseMaps: { a: ReadonlyMap<string, readonly string[]>; b: ReadonlyMap<string, readonly string[]> };
+  phase2ConclusionMaps: { a: ReadonlyMap<string, string>; b: ReadonlyMap<string, string> };
+  methodologistPhase2PremiseMap: ReadonlyMap<string, readonly string[]>;
+  methodologistPhase2ConclusionMap: ReadonlyMap<string, string>;
+  /** Phase-2 advocate sides keyed by argumentId — used to determine which
+   *  Phase-2 args belong to A vs B for routing round-1 rebuttals. */
+  phase2ArgSideById: ReadonlyMap<string, "A" | "B">;
+  /** Optional EvidenceSourceLite[] for the round-2 evidence-fidelity
+   *  judge. When omitted, deterministic soft-checks still run; only the
+   *  LLM-judge call is skipped. */
+  sources?: EvidenceSourceLite[];
 }
 
-export interface RunPhase3Round2Result {
-  /** TODO: typed round-2 result records (rebuttals, methodologist). */
-  status: "not-implemented" | "ok";
-  notes: string[];
+export interface Phase3Round2PartialFile {
+  phase: 3;
+  subPhase: "round-2";
+  status: "partial";
+  generatedAt: string;
+  deliberationId: string;
+  modelTier: string;
+  actors: {
+    a?: RebuttalRunRecord;
+    b?: RebuttalRunRecord;
+    methodologist?: MethodologistRunRecord;
+  };
+  totals: {
+    rebuttalsCreated: number;
+    edgesCreated: number;
+    cqStatusesUpserted: number;
+    inputTokens: number;
+    outputTokens: number;
+  };
+  /** Iter-3 task #6: round-2 soft-check flags (deterministic +
+   *  optional LLM-judge). Empty array when no actor produced output. */
+  reviewFlags?: ReviewFlag[];
+  judgeUsage?: { calls: number; inputTokens: number; outputTokens: number };
+}
+
+// ─────────────────────────────────────────────────────────────────
+// Round-1 → Round1RebuttalRef extraction
+// ─────────────────────────────────────────────────────────────────
+
+/**
+ * Collect every round-1 rebuttal in the in-memory records, tagged with
+ * its author and the side it attacked. Source of truth: each record's
+ * `mintResult.rebuttals` (carries persisted DB ids) joined with
+ * `llmOutput.rebuttals` (carries text + premises).
+ */
+function collectRound1Rebuttals(
+  round1: RunPhase3Round2Opts["round1"],
+  phase2ArgSideById: ReadonlyMap<string, "A" | "B">,
+): Round1RebuttalRef[] {
+  const out: Round1RebuttalRef[] = [];
+
+  function collect(
+    rec: RebuttalRunRecord | MethodologistRunRecord,
+    authorRole: "advocate-a" | "advocate-b" | "methodologist",
+  ): void {
+    if (rec.outcome !== "ok" || !rec.mintResult || !rec.llmOutput) return;
+    const inputs = rec.llmOutput.rebuttals;
+    for (const m of rec.mintResult.rebuttals) {
+      const orig = inputs[m.inputIndex];
+      if (!orig) continue;
+      // Round-1 rebuttals only — defensive in case round-2 records ever
+      // get appended in the future.
+      const round = (orig as any).round ?? "1";
+      if (round !== "1") continue;
+      // Round-1 rebuttals only target Phase-2 args.
+      const targetKind = (orig as any).targetKind ?? "phase2-arg";
+      if (targetKind !== "phase2-arg") continue;
+      const defendingSide = phase2ArgSideById.get(m.targetArgumentId);
+      if (!defendingSide) continue; // unknown target — skip defensively
+      out.push({
+        rebuttalArgumentId: m.rebuttalArgumentId,
+        schemeKey: m.schemeKey,
+        premiseClaimIds: m.premiseClaimIds,
+        conclusionClaimId: m.conclusionClaimId,
+        conclusionText: orig.conclusionText,
+        premiseTexts: orig.premises.map((p: any) => p.text),
+        warrant: orig.warrant ?? null,
+        cqKey: m.cqKey ?? null,
+        targetPhase2ArgId: m.targetArgumentId,
+        attackType: m.attackType,
+        authorRole,
+        defendingSide,
+      });
+    }
+  }
+
+  collect(round1.a, "advocate-a");
+  collect(round1.b, "advocate-b");
+  collect(round1.methodologist, "methodologist");
+  return out;
+}
+
+// ─────────────────────────────────────────────────────────────────
+// Extended binding builders (Phase-2 args ∪ round-1 rebuttals)
+// ─────────────────────────────────────────────────────────────────
+
+function rebuttalBinding(rb: Round1RebuttalRef): OpposingArgumentBinding | null {
+  if (!isAllowedSchemeKey(rb.schemeKey)) return null;
+  return {
+    argumentId: rb.rebuttalArgumentId,
+    schemeKey: rb.schemeKey as ExperimentSchemeKey,
+    premiseCount: rb.premiseClaimIds.length,
+    // Round-1 rebuttal conclusions are free-form claims (no layer
+    // assignment). Default to "empirical" — the layer-plausibility
+    // rule then accepts any rebuttal scheme attacking them.
+    conclusionLayer: "empirical",
+  };
+}
+
+function buildAdvocateRound2Bindings(
+  side: "A" | "B",
+  phase2Bindings: ReadonlyMap<string, OpposingArgumentBinding>,
+  round1Refs: readonly Round1RebuttalRef[],
+): Map<string, OpposingArgumentBinding> {
+  const out = new Map<string, OpposingArgumentBinding>(phase2Bindings);
+  // Side A round-2 may attack round-1 rebuttals filed against A's args.
+  for (const rb of round1Refs) {
+    if (rb.defendingSide !== side) continue;
+    const b = rebuttalBinding(rb);
+    if (b) out.set(rb.rebuttalArgumentId, b);
+  }
+  return out;
+}
+
+function buildMethodologistRound2Bindings(
+  phase2Bindings: ReadonlyMap<string, MethodologistOpposingArgumentBinding>,
+  round1Refs: readonly Round1RebuttalRef[],
+): Map<string, MethodologistOpposingArgumentBinding> {
+  const out = new Map<string, MethodologistOpposingArgumentBinding>(phase2Bindings);
+  // Methodologist round-2 may attack ANY round-1 rebuttal.
+  for (const rb of round1Refs) {
+    const b = rebuttalBinding(rb);
+    if (!b) continue;
+    out.set(rb.rebuttalArgumentId, {
+      ...b,
+      // Route the methodologist's targetAdvocateRole to the side whose
+      // arg the round-1 rebuttal attacked. (Methodologist attacking a
+      // rebuttal-against-A is conceptually "supporting A", so route
+      // the criticism as targeting side A's defensive interest.)
+      advocateRole: rb.defendingSide,
+    });
+  }
+  return out;
+}
+
+function extendPremiseMap(
+  base: ReadonlyMap<string, readonly string[]>,
+  round1Refs: readonly Round1RebuttalRef[],
+  filter: (rb: Round1RebuttalRef) => boolean,
+): Map<string, readonly string[]> {
+  const out = new Map<string, readonly string[]>(base);
+  for (const rb of round1Refs) {
+    if (!filter(rb)) continue;
+    out.set(rb.rebuttalArgumentId, rb.premiseClaimIds);
+  }
+  return out;
+}
+
+function extendConclusionMap(
+  base: ReadonlyMap<string, string>,
+  round1Refs: readonly Round1RebuttalRef[],
+  filter: (rb: Round1RebuttalRef) => boolean,
+): Map<string, string> {
+  const out = new Map<string, string>(base);
+  for (const rb of round1Refs) {
+    if (!filter(rb)) continue;
+    out.set(rb.rebuttalArgumentId, rb.conclusionClaimId);
+  }
+  return out;
+}
+
+function extendSchemeMap(
+  base: ReadonlyMap<string, string>,
+  round1Refs: readonly Round1RebuttalRef[],
+  filter: (rb: Round1RebuttalRef) => boolean,
+): Map<string, string> {
+  const out = new Map<string, string>(base);
+  for (const rb of round1Refs) {
+    if (!filter(rb)) continue;
+    out.set(rb.rebuttalArgumentId, rb.schemeKey);
+  }
+  return out;
+}
+
+// ─────────────────────────────────────────────────────────────────
+// Renderers
+// ─────────────────────────────────────────────────────────────────
+
+/**
+ * Render the `## ROUND_1_ATTACKS_ON_YOU` block for an advocate
+ * recipient. Lists every round-1 rebuttal filed against the
+ * recipient's Phase-2 args by the opposing advocate or the
+ * methodologist. The `rebuttalArgumentId` is a legal
+ * `targetArgumentId` for round-2 attacks-on-attacks.
+ */
+function renderRound1AttacksForAdvocate(
+  side: "A" | "B",
+  round1Refs: readonly Round1RebuttalRef[],
+  cqCatalog: ReadonlyMap<ExperimentSchemeKey, ReadonlySet<string>>,
+): string {
+  const mine = round1Refs.filter((rb) => rb.defendingSide === side);
+  if (mine.length === 0) {
+    return [
+      "## ROUND_1_ATTACKS_ON_YOU",
+      "",
+      `(No round-1 attacks were filed against your Phase-2 arguments.)`,
+      "",
+    ].join("\n");
+  }
+  const lines: string[] = ["## ROUND_1_ATTACKS_ON_YOU", ""];
+  for (const rb of mine) {
+    lines.push(
+      `REB ${rb.rebuttalArgumentId}  attacker=${rb.authorRole}  ` +
+        `targets-your=${rb.targetPhase2ArgId}  attackType=${rb.attackType}  ` +
+        `scheme=${rb.schemeKey}` + (rb.cqKey ? `  cqKey=${rb.cqKey}` : ""),
+    );
+    lines.push(`  conclusion: "${rb.conclusionText}"`);
+    lines.push(`  premises (0-indexed):`);
+    for (let i = 0; i < rb.premiseTexts.length; i++) {
+      lines.push(`    [${i}] "${rb.premiseTexts[i]}"`);
+    }
+    lines.push(`  warrant: ${rb.warrant ? `"${rb.warrant}"` : "null"}`);
+    if (isAllowedSchemeKey(rb.schemeKey)) {
+      const cqs = cqCatalog.get(rb.schemeKey as ExperimentSchemeKey);
+      if (cqs && cqs.size > 0) {
+        lines.push(`  critical-questions for scheme=${rb.schemeKey}:`);
+        for (const cq of [...cqs].sort()) {
+          lines.push(`    ${cq}: (see CriticalQuestion catalog)`);
+        }
+      } else {
+        lines.push(`  critical-questions: (none registered for ${rb.schemeKey})`);
+      }
+    }
+    lines.push("");
+  }
+  return lines.join("\n");
 }
 
 /**
- * Read a round-2 addendum prompt by role. Returns the file content if
- * present, or empty string if absent (defensive — addendums are
- * scaffolding files in `experiments/polarization-1/prompts/`).
+ * Render `## ROUND_1_ATTACKS_ALL` for the methodologist (every
+ * round-1 rebuttal regardless of side).
  */
-export function readRound2Addendum(
+function renderRound1AttacksForMethodologist(
+  round1Refs: readonly Round1RebuttalRef[],
+  cqCatalog: ReadonlyMap<ExperimentSchemeKey, ReadonlySet<string>>,
+): string {
+  if (round1Refs.length === 0) {
+    return ["## ROUND_1_ATTACKS_ALL", "", "(No round-1 attacks were filed.)", ""].join("\n");
+  }
+  const lines: string[] = ["## ROUND_1_ATTACKS_ALL", ""];
+  for (const rb of round1Refs) {
+    lines.push(
+      `REB ${rb.rebuttalArgumentId}  side=${rb.defendingSide}-defender  ` +
+        `attacker=${rb.authorRole}  targets-arg=${rb.targetPhase2ArgId}  ` +
+        `attackType=${rb.attackType}  scheme=${rb.schemeKey}` +
+        (rb.cqKey ? `  cqKey=${rb.cqKey}` : ""),
+    );
+    lines.push(`  conclusion: "${rb.conclusionText}"`);
+    lines.push(`  premises (0-indexed):`);
+    for (let i = 0; i < rb.premiseTexts.length; i++) {
+      lines.push(`    [${i}] "${rb.premiseTexts[i]}"`);
+    }
+    lines.push(`  warrant: ${rb.warrant ? `"${rb.warrant}"` : "null"}`);
+    if (isAllowedSchemeKey(rb.schemeKey)) {
+      const cqs = cqCatalog.get(rb.schemeKey as ExperimentSchemeKey);
+      if (cqs && cqs.size > 0) {
+        lines.push(`  critical-questions for scheme=${rb.schemeKey}:`);
+        for (const cq of [...cqs].sort()) {
+          lines.push(`    ${cq}: (see CriticalQuestion catalog)`);
+        }
+      }
+    }
+    lines.push("");
+  }
+  return lines.join("\n");
+}
+
+// ─────────────────────────────────────────────────────────────────
+// Per-actor round-2 runners
+// ─────────────────────────────────────────────────────────────────
+
+const PHASE_3_ROUND_2 = 4 as const; // round 4 within Phase 3 logger (1=A,2=B,3=M; 4=A-r2,5=B-r2,6=M-r2)
+
+interface RunRound2AdvocateOpts {
+  side: "A" | "B";
+  role: RebuttalAgentRole;
+  cfg: OrchestratorConfig;
+  iso: IsonomiaClient;
+  llm: AnthropicClient;
+  deliberationId: string;
+  framing: string;
+  opponentArgumentsPrompt: string;
+  evidenceCorpusPrompt: string;
+  /** Extended bindings (Phase-2 ∪ round-1 rebuttals against this side). */
+  opposingArguments: ReadonlyMap<string, OpposingArgumentBinding>;
+  cqKeysByScheme: ReadonlyMap<ExperimentSchemeKey, ReadonlySet<string>>;
+  allowedCitationTokens: Set<string>;
+  tokenToSourceId: Record<string, string>;
+  registry: ClaimRegistry;
+  opposingArgumentSchemeByArgId: ReadonlyMap<string, string>;
+  opposingArgumentPremisesByArgId: ReadonlyMap<string, readonly string[]>;
+  opposingArgumentConclusionByArgId: ReadonlyMap<string, string>;
+  schemeCatalog: Array<{ id: string; key: string }>;
+  /** Round-2 addendum content + the rendered ROUND_1_ATTACKS_ON_YOU block. */
+  appendedSystemPrompt: string;
+  appendedUserBlock: string;
+}
+
+async function runRound2Advocate(opts: RunRound2AdvocateOpts): Promise<RebuttalRunRecord> {
+  const round = opts.role === "advocate-a" ? PHASE_3_ROUND_2 : PHASE_3_ROUND_2 + 1;
+  const logger = RoundLogger.forRound({
+    runtimeDir: opts.cfg.runtimeDir,
+    phase: 3,
+    round,
+    agentRole: opts.role,
+  });
+  const promptRel = opts.role === "advocate-a" ? "prompts/4-rebuttal-a.md" : "prompts/5-rebuttal-b.md";
+  const promptPath = path.join(opts.cfg.experimentRoot, promptRel);
+  const llmDir = path.join(opts.cfg.runtimeDir, PHASE_3_LLM_DIR);
+  const llmOutputPath = path.join(llmDir, `phase-3-round2-${opts.role}-output.json`);
+  const roundLogPath = path.join(
+    opts.cfg.runtimeDir,
+    "logs",
+    `round-3-${round}-${opts.role}.jsonl`,
+  );
+  const baseArtifacts = { promptPath, roundLogPath };
+
+  let turn;
+  try {
+    turn = await runRebuttalTurn({
+      role: opts.role,
+      promptPath,
+      framing: opts.framing,
+      opponentArgumentsPrompt: opts.opponentArgumentsPrompt,
+      evidenceCorpusPrompt: opts.evidenceCorpusPrompt,
+      appendedSystemPrompt: opts.appendedSystemPrompt,
+      appendedUserBlock: opts.appendedUserBlock,
+      schemaOpts: {
+        opposingArguments: opts.opposingArguments,
+        cqKeysByScheme: opts.cqKeysByScheme,
+        allowedCitationTokens: opts.allowedCitationTokens,
+      },
+      cfg: opts.cfg,
+      llm: opts.llm,
+      logger,
+    });
+  } catch (err) {
+    if (err instanceof RebuttalValidationError) {
+      logger.event("phase_complete", {
+        phase: 3,
+        round,
+        agent: opts.role,
+        outcome: "validation-error",
+        attempts: err.attempts,
+      });
+      return {
+        role: opts.role,
+        outcome: "validation-error",
+        attempts: err.attempts,
+        tokenUsage: { inputTokens: 0, outputTokens: 0 },
+        validationError: { message: err.message, rawResponsesCount: err.rawResponses.length },
+        artifacts: baseArtifacts,
+      };
+    }
+    throw err;
+  }
+
+  if (isRebuttalRefusal(turn.response)) {
+    const refusalPath = path.join(
+      opts.cfg.runtimeDir,
+      REFUSALS_DIR,
+      `phase-3-round2-${opts.role}-refusal.json`,
+    );
+    mkdirSync(path.dirname(refusalPath), { recursive: true });
+    writeFileSync(refusalPath, JSON.stringify(turn.response, null, 2));
+    logger.event("phase_complete", {
+      phase: 3,
+      round,
+      agent: opts.role,
+      outcome: "refused",
+      reason: turn.response.error,
+      refusalPath,
+    });
+    return {
+      role: opts.role,
+      outcome: "refused",
+      attempts: turn.attempts,
+      tokenUsage: turn.usage,
+      refusal: turn.response,
+      refusalPath,
+      artifacts: baseArtifacts,
+    };
+  }
+
+  mkdirSync(llmDir, { recursive: true });
+  writeFileSync(llmOutputPath, JSON.stringify(turn.response, null, 2));
+
+  const mintResult = await translateRebuttalOutput({
+    output: turn.response,
+    deliberationId: opts.deliberationId,
+    iso: opts.iso,
+    logger,
+    cfg: opts.cfg,
+    tokenToSourceId: opts.tokenToSourceId,
+    registry: opts.registry,
+    authorRole: opts.role,
+    round: "2",
+    opposingArgumentSchemeByArgId: opts.opposingArgumentSchemeByArgId,
+    opposingArgumentPremisesByArgId: opts.opposingArgumentPremisesByArgId,
+    opposingArgumentConclusionByArgId: opts.opposingArgumentConclusionByArgId,
+    schemeCatalog: opts.schemeCatalog,
+    stackId: opts.cfg.deliberation.evidenceStackId ?? null,
+  });
+
+  logger.event("phase_complete", {
+    phase: 3,
+    round,
+    agent: opts.role,
+    outcome: "ok",
+    rebuttalsCreated: mintResult.totals.rebuttalsCreated,
+    edgesCreated: mintResult.totals.edgesCreated,
+    cqStatusesUpserted: mintResult.totals.cqStatusesUpserted,
+  });
+
+  return {
+    role: opts.role,
+    outcome: "ok",
+    attempts: turn.attempts,
+    tokenUsage: turn.usage,
+    llmOutput: turn.response,
+    mintResult,
+    artifacts: { ...baseArtifacts, llmOutputPath },
+  };
+}
+
+interface RunRound2MethodologistOpts {
+  cfg: OrchestratorConfig;
+  iso: IsonomiaClient;
+  llm: AnthropicClient;
+  deliberationId: string;
+  framing: string;
+  phase2ArgumentsPrompt: string;
+  evidenceCorpusPrompt: string;
+  opposingArguments: ReadonlyMap<string, MethodologistOpposingArgumentBinding>;
+  cqKeysByScheme: ReadonlyMap<ExperimentSchemeKey, ReadonlySet<string>>;
+  allowedCitationTokens: Set<string>;
+  tokenToSourceId: Record<string, string>;
+  registry: ClaimRegistry;
+  opposingArgumentSchemeByArgId: ReadonlyMap<string, string>;
+  opposingArgumentPremisesByArgId: ReadonlyMap<string, readonly string[]>;
+  opposingArgumentConclusionByArgId: ReadonlyMap<string, string>;
+  schemeCatalog: Array<{ id: string; key: string }>;
+  appendedSystemPrompt: string;
+  appendedUserBlock: string;
+}
+
+async function runRound2Methodologist(
+  opts: RunRound2MethodologistOpts,
+): Promise<MethodologistRunRecord> {
+  const round = PHASE_3_ROUND_2 + 2;
+  const logger = RoundLogger.forRound({
+    runtimeDir: opts.cfg.runtimeDir,
+    phase: 3,
+    round,
+    agentRole: METHODOLOGIST_AGENT_ROLE,
+  });
+  const promptRel = "prompts/10-methodologist.md";
+  const promptPath = path.join(opts.cfg.experimentRoot, promptRel);
+  const llmDir = path.join(opts.cfg.runtimeDir, PHASE_3_LLM_DIR);
+  const llmOutputPath = path.join(llmDir, `phase-3-round2-methodologist-output.json`);
+  const roundLogPath = path.join(
+    opts.cfg.runtimeDir,
+    "logs",
+    `round-3-${round}-methodologist.jsonl`,
+  );
+  const baseArtifacts = { promptPath, roundLogPath };
+
+  let turn;
+  try {
+    turn = await runMethodologistTurn({
+      promptPath,
+      framing: opts.framing,
+      phase2ArgumentsPrompt: opts.phase2ArgumentsPrompt,
+      evidenceCorpusPrompt: opts.evidenceCorpusPrompt,
+      appendedSystemPrompt: opts.appendedSystemPrompt,
+      appendedUserBlock: opts.appendedUserBlock,
+      schemaOpts: {
+        opposingArguments: opts.opposingArguments,
+        cqKeysByScheme: opts.cqKeysByScheme,
+        allowedCitationTokens: opts.allowedCitationTokens,
+      },
+      cfg: opts.cfg,
+      llm: opts.llm,
+      logger,
+    });
+  } catch (err) {
+    if (err instanceof MethodologistValidationError) {
+      logger.event("phase_complete", {
+        phase: 3,
+        round,
+        agent: METHODOLOGIST_AGENT_ROLE,
+        outcome: "validation-error",
+        attempts: err.attempts,
+      });
+      return {
+        role: METHODOLOGIST_AGENT_ROLE,
+        outcome: "validation-error",
+        attempts: err.attempts,
+        tokenUsage: { inputTokens: 0, outputTokens: 0 },
+        validationError: { message: err.message, rawResponsesCount: err.rawResponses.length },
+        artifacts: baseArtifacts,
+      };
+    }
+    throw err;
+  }
+
+  if (isMethodologistRefusal(turn.response)) {
+    const refusalPath = path.join(
+      opts.cfg.runtimeDir,
+      REFUSALS_DIR,
+      `phase-3-round2-methodologist-refusal.json`,
+    );
+    mkdirSync(path.dirname(refusalPath), { recursive: true });
+    writeFileSync(refusalPath, JSON.stringify(turn.response, null, 2));
+    logger.event("phase_complete", {
+      phase: 3,
+      round,
+      agent: METHODOLOGIST_AGENT_ROLE,
+      outcome: "refused",
+      reason: turn.response.error,
+      refusalPath,
+    });
+    return {
+      role: METHODOLOGIST_AGENT_ROLE,
+      outcome: "refused",
+      attempts: turn.attempts,
+      tokenUsage: turn.usage,
+      refusal: turn.response,
+      refusalPath,
+      artifacts: baseArtifacts,
+    };
+  }
+
+  mkdirSync(llmDir, { recursive: true });
+  writeFileSync(llmOutputPath, JSON.stringify(turn.response, null, 2));
+
+  const mintResult = await translateRebuttalOutput({
+    output: turn.response as unknown as RebuttalOutput,
+    deliberationId: opts.deliberationId,
+    iso: opts.iso,
+    logger,
+    cfg: opts.cfg,
+    tokenToSourceId: opts.tokenToSourceId,
+    registry: opts.registry,
+    authorRole: METHODOLOGIST_AGENT_ROLE,
+    round: "2",
+    opposingArgumentSchemeByArgId: opts.opposingArgumentSchemeByArgId,
+    opposingArgumentPremisesByArgId: opts.opposingArgumentPremisesByArgId,
+    opposingArgumentConclusionByArgId: opts.opposingArgumentConclusionByArgId,
+    schemeCatalog: opts.schemeCatalog,
+    stackId: opts.cfg.deliberation.evidenceStackId ?? null,
+  });
+
+  logger.event("phase_complete", {
+    phase: 3,
+    round,
+    agent: METHODOLOGIST_AGENT_ROLE,
+    outcome: "ok",
+    rebuttalsCreated: mintResult.totals.rebuttalsCreated,
+    edgesCreated: mintResult.totals.edgesCreated,
+    cqStatusesUpserted: mintResult.totals.cqStatusesUpserted,
+  });
+
+  return {
+    role: METHODOLOGIST_AGENT_ROLE,
+    outcome: "ok",
+    attempts: turn.attempts,
+    tokenUsage: turn.usage,
+    llmOutput: turn.response,
+    mintResult,
+    artifacts: { ...baseArtifacts, llmOutputPath },
+  };
+}
+
+// ─────────────────────────────────────────────────────────────────
+// Entry point
+// ─────────────────────────────────────────────────────────────────
+
+export async function runPhase3Round2(
+  opts: RunPhase3Round2Opts,
+): Promise<Phase3Round2PartialFile> {
+  const phaseLogger = RoundLogger.forRound({
+    runtimeDir: opts.cfg.runtimeDir,
+    phase: 3,
+    round: PHASE_3_ROUND_2 - 1,
+  });
+  phaseLogger.event("round_summary", {
+    step: "round-2-start",
+    deliberationId: opts.deliberationId,
+  });
+
+  const partialPath = path.join(opts.cfg.runtimeDir, PHASE_3_ROUND2_PARTIAL_FILE);
+
+  // Resume support: if a prior round-2 partial exists for this delib,
+  // use its records and re-run only actors that aren't ok.
+  let prior: Phase3Round2PartialFile | null = null;
+  if (existsSync(partialPath)) {
+    try {
+      const raw = JSON.parse(readFileSync(partialPath, "utf8")) as Phase3Round2PartialFile;
+      if (raw.deliberationId === opts.deliberationId) prior = raw;
+    } catch {
+      // ignore corrupt
+    }
+  }
+  const actors: Phase3Round2PartialFile["actors"] = {
+    a: prior?.actors.a,
+    b: prior?.actors.b,
+    methodologist: prior?.actors.methodologist,
+  };
+
+  // 1. Collect round-1 rebuttals + extend cq catalog with rebuttal schemes.
+  const round1Refs = collectRound1Rebuttals(opts.round1, opts.phase2ArgSideById);
+  phaseLogger.event("round_summary", {
+    step: "round-1-collected",
+    rebuttalCount: round1Refs.length,
+    bySide: {
+      A: round1Refs.filter((r) => r.defendingSide === "A").length,
+      B: round1Refs.filter((r) => r.defendingSide === "B").length,
+    },
+  });
+
+  // Extend cq catalog with any rebuttal scheme keys not already present.
+  const newSchemeKeys = new Set<string>();
+  for (const rb of round1Refs) {
+    if (!opts.cqCatalogByScheme.has(rb.schemeKey as ExperimentSchemeKey)) {
+      newSchemeKeys.add(rb.schemeKey);
+    }
+  }
+  let cqCatalogExtended: ReadonlyMap<ExperimentSchemeKey, ReadonlySet<string>> =
+    opts.cqCatalogByScheme;
+  if (newSchemeKeys.size > 0) {
+    const fresh = await loadCqCatalog(newSchemeKeys, opts.schemeIdByKey);
+    const merged = new Map<ExperimentSchemeKey, Set<string>>();
+    for (const [k, v] of opts.cqCatalogByScheme) merged.set(k, new Set(v));
+    for (const [k, v] of fresh) merged.set(k, v);
+    cqCatalogExtended = merged;
+  }
+
+  // 2. Run actors (advocate-a, advocate-b, methodologist) sequentially.
+  const addendumA = readAddendum(opts.cfg, "advocate-a");
+  const addendumB = readAddendum(opts.cfg, "advocate-b");
+  const addendumM = readAddendum(opts.cfg, "methodologist");
+
+  // ── Advocate A ──
+  if (actors.a?.outcome !== "ok") {
+    const bindingsA = buildAdvocateRound2Bindings(
+      "A",
+      opts.phase2OpponentBindings.a,
+      round1Refs,
+    );
+    const premiseMapA = extendPremiseMap(
+      opts.phase2PremiseMaps.a,
+      round1Refs,
+      (rb) => rb.defendingSide === "A",
+    );
+    const conclusionMapA = extendConclusionMap(
+      opts.phase2ConclusionMaps.a,
+      round1Refs,
+      (rb) => rb.defendingSide === "A",
+    );
+    const schemeMapA = extendSchemeMap(
+      buildSchemeMap(opts.phase2OpponentBindings.a),
+      round1Refs,
+      (rb) => rb.defendingSide === "A",
+    );
+    const userBlockA = renderRound1AttacksForAdvocate("A", round1Refs, cqCatalogExtended);
+    try {
+      actors.a = await runRound2Advocate({
+        side: "A",
+        role: "advocate-a",
+        cfg: opts.cfg,
+        iso: opts.iso,
+        llm: opts.llm,
+        deliberationId: opts.deliberationId,
+        framing: opts.framing,
+        opponentArgumentsPrompt: opts.phase2OpponentPrompts.a,
+        evidenceCorpusPrompt: opts.evidenceCorpusPrompt,
+        opposingArguments: bindingsA,
+        cqKeysByScheme: cqCatalogExtended,
+        allowedCitationTokens: opts.allowedCitationTokens,
+        tokenToSourceId: opts.tokenToSourceId,
+        registry: opts.registry,
+        opposingArgumentSchemeByArgId: schemeMapA,
+        opposingArgumentPremisesByArgId: premiseMapA,
+        opposingArgumentConclusionByArgId: conclusionMapA,
+        schemeCatalog: opts.schemeCatalog,
+        appendedSystemPrompt: addendumA,
+        appendedUserBlock: userBlockA,
+      });
+    } catch (err) {
+      phaseLogger.event("round_summary", {
+        step: "round-2-actor-error",
+        actor: "advocate-a",
+        error: err instanceof Error ? err.message : String(err),
+      });
+      // Leave actors.a as-is (null or prior failed record) so resume retries.
+    }
+    writeRound2Partial(partialPath, opts, actors);
+  }
+
+  // ── Advocate B ──
+  if (actors.b?.outcome !== "ok") {
+    const bindingsB = buildAdvocateRound2Bindings(
+      "B",
+      opts.phase2OpponentBindings.b,
+      round1Refs,
+    );
+    const premiseMapB = extendPremiseMap(
+      opts.phase2PremiseMaps.b,
+      round1Refs,
+      (rb) => rb.defendingSide === "B",
+    );
+    const conclusionMapB = extendConclusionMap(
+      opts.phase2ConclusionMaps.b,
+      round1Refs,
+      (rb) => rb.defendingSide === "B",
+    );
+    const schemeMapB = extendSchemeMap(
+      buildSchemeMap(opts.phase2OpponentBindings.b),
+      round1Refs,
+      (rb) => rb.defendingSide === "B",
+    );
+    const userBlockB = renderRound1AttacksForAdvocate("B", round1Refs, cqCatalogExtended);
+    try {
+      actors.b = await runRound2Advocate({
+        side: "B",
+        role: "advocate-b",
+        cfg: opts.cfg,
+        iso: opts.iso,
+        llm: opts.llm,
+        deliberationId: opts.deliberationId,
+        framing: opts.framing,
+        opponentArgumentsPrompt: opts.phase2OpponentPrompts.b,
+        evidenceCorpusPrompt: opts.evidenceCorpusPrompt,
+        opposingArguments: bindingsB,
+        cqKeysByScheme: cqCatalogExtended,
+        allowedCitationTokens: opts.allowedCitationTokens,
+        tokenToSourceId: opts.tokenToSourceId,
+        registry: opts.registry,
+        opposingArgumentSchemeByArgId: schemeMapB,
+        opposingArgumentPremisesByArgId: premiseMapB,
+        opposingArgumentConclusionByArgId: conclusionMapB,
+        schemeCatalog: opts.schemeCatalog,
+        appendedSystemPrompt: addendumB,
+        appendedUserBlock: userBlockB,
+      });
+    } catch (err) {
+      phaseLogger.event("round_summary", {
+        step: "round-2-actor-error",
+        actor: "advocate-b",
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+    writeRound2Partial(partialPath, opts, actors);
+  }
+
+  // ── Methodologist ──
+  if (actors.methodologist?.outcome !== "ok") {
+    const bindingsM = buildMethodologistRound2Bindings(
+      opts.methodologistPhase2Bindings,
+      round1Refs,
+    );
+    const premiseMapM = extendPremiseMap(
+      opts.methodologistPhase2PremiseMap,
+      round1Refs,
+      () => true,
+    );
+    const conclusionMapM = extendConclusionMap(
+      opts.methodologistPhase2ConclusionMap,
+      round1Refs,
+      () => true,
+    );
+    const schemeMapM = extendSchemeMap(
+      (() => {
+        const m = new Map<string, string>();
+        for (const [argId, b] of opts.methodologistPhase2Bindings) m.set(argId, b.schemeKey);
+        return m;
+      })(),
+      round1Refs,
+      () => true,
+    );
+    const userBlockM = renderRound1AttacksForMethodologist(round1Refs, cqCatalogExtended);
+    try {
+      actors.methodologist = await runRound2Methodologist({
+        cfg: opts.cfg,
+        iso: opts.iso,
+        llm: opts.llm,
+        deliberationId: opts.deliberationId,
+        framing: opts.framing,
+        phase2ArgumentsPrompt: opts.methodologistPhase2Prompt,
+        evidenceCorpusPrompt: opts.evidenceCorpusPrompt,
+        opposingArguments: bindingsM,
+        cqKeysByScheme: cqCatalogExtended,
+        allowedCitationTokens: opts.allowedCitationTokens,
+        tokenToSourceId: opts.tokenToSourceId,
+        registry: opts.registry,
+        opposingArgumentSchemeByArgId: schemeMapM,
+        opposingArgumentPremisesByArgId: premiseMapM,
+        opposingArgumentConclusionByArgId: conclusionMapM,
+        schemeCatalog: opts.schemeCatalog,
+        appendedSystemPrompt: addendumM,
+        appendedUserBlock: userBlockM,
+      });
+    } catch (err) {
+      phaseLogger.event("round_summary", {
+        step: "round-2-actor-error",
+        actor: "methodologist",
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+    writeRound2Partial(partialPath, opts, actors);
+  }
+
+  // ── Soft-check review (Iter-3 task #6) ──
+  // Build per-actor opponent meta sets and run round-2 soft-checks.
+  // mutual_rebut + hinge_attack_concentration are skipped per design;
+  // remaining checks (attack_targeting, scheme_cq_validity,
+  // scheme_appropriateness, evidence_fidelity) run per-actor.
+  const review = await runRound2SoftChecks({
+    opts,
+    actors,
+    round1Refs,
+    logger: phaseLogger,
+  });
+  phaseLogger.event("round_summary", {
+    step: "round-2-soft-review",
+    flagCount: review.flags.length,
+    judgeCalls: review.judgeUsage.calls,
+  });
+
+  const partial = writeRound2Partial(
+    partialPath,
+    opts,
+    actors,
+    review.flags,
+    review.judgeUsage.calls > 0 ? review.judgeUsage : undefined,
+  );
+  phaseLogger.event("round_summary", {
+    step: "round-2-complete",
+    okCount:
+      Number(actors.a?.outcome === "ok") +
+      Number(actors.b?.outcome === "ok") +
+      Number(actors.methodologist?.outcome === "ok"),
+    totals: partial.totals,
+    reviewFlagCount: review.flags.length,
+    judgeCalls: review.judgeUsage.calls,
+  });
+  return partial;
+}
+
+// ─────────────────────────────────────────────────────────────────
+// Helpers
+// ─────────────────────────────────────────────────────────────────
+
+function readAddendum(
   cfg: OrchestratorConfig,
   role: "advocate-a" | "advocate-b" | "methodologist",
 ): string {
@@ -73,70 +1016,169 @@ export function readRound2Addendum(
         ? "5b-rebuttal-b-round2-addendum.md"
         : "10b-methodologist-round2-addendum.md";
   const p = path.join(cfg.experimentRoot, "prompts", filename);
-  if (!existsSync(p)) {
-    return "";
-  }
+  if (!existsSync(p)) return "";
   return readFileSync(p, "utf8");
 }
 
-/**
- * TODO(Iter-3): Build the `## ROUND_1_ATTACKS_ON_YOU` Markdown block
- * for a recipient advocate. Lists every round-1 rebuttal filed against
- * the recipient's Phase-2 arguments by the opponent and Methodologist,
- * with their `rebuttalArgumentId` (legal `targetArgumentId` for round-2
- * attacks-on-attacks), conclusion text, premises, and `cqKey` (if any).
- *
- * Spec (from locked design memo):
- *   - For Advocate A, list B's + Methodologist's round-1 rebuttals
- *     against A's Phase-2 args.
- *   - For Advocate B, list A's + Methodologist's round-1 rebuttals
- *     against B's Phase-2 args.
- *   - For Methodologist, list ALL round-1 rebuttals (A's + B's + own)
- *     in `## ROUND_1_ATTACKS_ALL`.
- */
-export function renderRound1AttacksOnYou(
-  _recipientRole: "advocate-a" | "advocate-b" | "methodologist",
-  _phase3Complete: unknown,
-): string {
-  return "## ROUND_1_ATTACKS_ON_YOU\n\n_(TODO: implement renderer in phase-3-round2.ts)_\n";
+function writeRound2Partial(
+  partialPath: string,
+  opts: RunPhase3Round2Opts,
+  actors: Phase3Round2PartialFile["actors"],
+  reviewFlags?: ReviewFlag[],
+  judgeUsage?: { calls: number; inputTokens: number; outputTokens: number },
+): Phase3Round2PartialFile {
+  const partial: Phase3Round2PartialFile = {
+    phase: 3,
+    subPhase: "round-2",
+    status: "partial",
+    generatedAt: new Date().toISOString(),
+    deliberationId: opts.deliberationId,
+    modelTier: opts.cfg.modelTier,
+    actors,
+    totals: aggregateRound2Totals(actors),
+    reviewFlags: reviewFlags ?? [],
+    judgeUsage,
+  };
+  writeFileSync(partialPath, JSON.stringify(partial, null, 2));
+  return partial;
 }
 
+function aggregateRound2Totals(
+  actors: Phase3Round2PartialFile["actors"],
+): Phase3Round2PartialFile["totals"] {
+  let rebuttalsCreated = 0,
+    edgesCreated = 0,
+    cqStatusesUpserted = 0,
+    inputTokens = 0,
+    outputTokens = 0;
+  for (const rec of [actors.a, actors.b, actors.methodologist]) {
+    if (!rec) continue;
+    inputTokens += rec.tokenUsage.inputTokens;
+    outputTokens += rec.tokenUsage.outputTokens;
+    if (rec.outcome === "ok" && rec.mintResult) {
+      rebuttalsCreated += rec.mintResult.totals.rebuttalsCreated;
+      edgesCreated += rec.mintResult.totals.edgesCreated;
+      cqStatusesUpserted += rec.mintResult.totals.cqStatusesUpserted;
+    }
+  }
+  return { rebuttalsCreated, edgesCreated, cqStatusesUpserted, inputTokens, outputTokens };
+}
+
+// Keep imports referenced (silences "imported but unused" in tsc when
+// the types are only used for documentation in this module).
+type _KeepImports = Phase3PartialFile | Phase3CompleteRebuttal | Phase3CompleteMethodologistRebuttal;
+
+// ─────────────────────────────────────────────────────────────────
+// Iter-3 task #6: round-2 soft-check execution
+// ─────────────────────────────────────────────────────────────────
+
 /**
- * Main entry point — called from `runPhase` (phase-3-attacks.ts) after
- * round-1 finalizes successfully and ONLY when `cfg.iter3MultiRound`
- * is true.
+ * Build the per-actor opponent meta map (the set of every argumentId
+ * the actor was permitted to target in round 2 — opponent's Phase-2
+ * args + round-1 rebuttals filed against own args; methodologist sees
+ * BOTH sides + ALL round-1 rebuttals) and dispatch the round-2 soft
+ * checks.
+ *
+ * Phase-2 arg meta uses schemeKey lookup from `phase2OpponentBindings`
+ * (advocates) / `methodologistPhase2Bindings`. Round-1 rebuttal meta
+ * uses `Round1RebuttalRef.schemeKey` + `conclusionText`.
+ *
+ * `conclusionClaimIndex` is set to a sentinel `-1` since round-2 skips
+ * the hinge-attack-concentration check (which would consume that field).
  */
-export async function runPhase3Round2(
-  opts: RunPhase3Round2Opts,
-): Promise<RunPhase3Round2Result> {
-  opts.logger.event("phase_round2_start", {
-    phase: 3,
-    round: 2,
-    deliberationId: opts.deliberationId,
-  });
+async function runRound2SoftChecks(args: {
+  opts: RunPhase3Round2Opts;
+  actors: Phase3Round2PartialFile["actors"];
+  round1Refs: readonly Round1RebuttalRef[];
+  logger: RoundLogger;
+}): Promise<{ flags: ReviewFlag[]; judgeUsage: { calls: number; inputTokens: number; outputTokens: number } }> {
+  const { opts, actors, round1Refs, logger } = args;
 
-  // TODO(Iter-3):
-  //   1. Load PHASE_3_COMPLETE.json from `opts.phase3CompletePath`.
-  //   2. Build extended `opposingArgumentSchemeByArgId` /
-  //      `opposingArgumentPremisesByArgId` /
-  //      `opposingArgumentConclusionByArgId` maps including round-1
-  //      rebuttal ids (with their `schemeKey`, premise claims, and
-  //      conclusion claim from the persisted complete record).
-  //   3. Render `## ROUND_1_ATTACKS_ON_YOU` per recipient.
-  //   4. For each of advocate-a, advocate-b, methodologist:
-  //      a. Load base prompt; append round-2 addendum via
-  //         `runRebuttalTurn({ appendedSystemPrompt, appendedUserBlock })`
-  //         or `runMethodologistTurn({ ... })`.
-  //      b. On ok, call `translateRebuttalOutput({ ..., round: "2" })`
-  //         (translator skips orphan-guard automatically).
-  //   5. Write PHASE_3_ROUND2_PARTIAL.json (same shape as round-1
-  //      partial) and let finalize merge.
+  // Build per-actor opponent meta sets.
+  function buildMeta(
+    phase2Bindings: ReadonlyMap<string, OpposingArgumentBinding>,
+    phase2ConclusionTexts: ReadonlyMap<string, string>,
+    round1Visible: readonly Round1RebuttalRef[],
+  ): ReadonlyMap<string, OpposingArgumentMeta> {
+    const out = new Map<string, OpposingArgumentMeta>();
+    for (const [argId, b] of phase2Bindings) {
+      out.set(argId, {
+        argumentId: argId,
+        conclusionClaimIndex: -1, // sentinel — hinge check skipped in round 2
+        conclusionText: phase2ConclusionTexts.get(argId) ?? "",
+        schemeKey: b.schemeKey,
+      });
+    }
+    for (const rb of round1Visible) {
+      out.set(rb.rebuttalArgumentId, {
+        argumentId: rb.rebuttalArgumentId,
+        conclusionClaimIndex: -1,
+        conclusionText: rb.conclusionText,
+        schemeKey: rb.schemeKey,
+      });
+    }
+    return out;
+  }
 
-  return {
-    status: "not-implemented",
-    notes: [
-      "round-2 driver is scaffold-only; complete the TODOs in phase-3-round2.ts.",
-      "schemas, translator, prompts, and finalize already accept round-2 inputs.",
-    ],
+  // For Phase-2 conclusion text lookup we don't have full text in the
+  // bindings; the round-1 driver doesn't surface this map either. Use
+  // an empty map (conclusion text is only consumed by mutual-rebut,
+  // which we skip). The judge prompt does not need it.
+  const emptyText: ReadonlyMap<string, string> = new Map();
+
+  const metaA = buildMeta(
+    opts.phase2OpponentBindings.a,
+    emptyText,
+    round1Refs.filter((rb) => rb.defendingSide === "A"),
+  );
+  const metaB = buildMeta(
+    opts.phase2OpponentBindings.b,
+    emptyText,
+    round1Refs.filter((rb) => rb.defendingSide === "B"),
+  );
+  // Methodologist sees both sides' Phase-2 args + ALL round-1 rebuttals.
+  const metaM = new Map<string, OpposingArgumentMeta>();
+  for (const [argId, b] of opts.methodologistPhase2Bindings) {
+    metaM.set(argId, {
+      argumentId: argId,
+      conclusionClaimIndex: -1,
+      conclusionText: "",
+      schemeKey: b.schemeKey,
+    });
+  }
+  for (const rb of round1Refs) {
+    metaM.set(rb.rebuttalArgumentId, {
+      argumentId: rb.rebuttalArgumentId,
+      conclusionClaimIndex: -1,
+      conclusionText: rb.conclusionText,
+      schemeKey: rb.schemeKey,
+    });
+  }
+
+  // Methodologist output is structurally compatible with RebuttalOutput
+  // for the fields the soft-checks read (rebuttals[].targetArgumentId/
+  // attackType/targetPremiseIndex/schemeKey/premises/conclusionText/cqKey
+  // and cqResponses[].targetArgumentId). Cast at the boundary.
+  const outputs = {
+    a: actors.a?.outcome === "ok" ? actors.a.llmOutput : undefined,
+    b: actors.b?.outcome === "ok" ? actors.b.llmOutput : undefined,
+    methodologist:
+      actors.methodologist?.outcome === "ok"
+        ? (actors.methodologist.llmOutput as unknown as RebuttalOutput | undefined)
+        : undefined,
   };
+
+  const anyOk = Boolean(outputs.a || outputs.b || outputs.methodologist);
+  if (!anyOk) {
+    return { flags: [], judgeUsage: { calls: 0, inputTokens: 0, outputTokens: 0 } };
+  }
+
+  return runPhase3Round2SoftChecks({
+    outputs,
+    opponentByActor: { a: metaA, b: metaB, methodologist: metaM },
+    sources: opts.sources ?? [],
+    llm: opts.sources && opts.sources.length > 0 ? opts.llm : undefined,
+    cfg: opts.sources && opts.sources.length > 0 ? opts.cfg : undefined,
+    logger,
+  });
 }

--- a/experiments/polarization-1/orchestrator/phases/phase-4-defenses.ts
+++ b/experiments/polarization-1/orchestrator/phases/phase-4-defenses.ts
@@ -107,6 +107,17 @@ export interface RunPhase4Opts {
   /** If set, skip the tracker run (e.g. for fast iteration on advocates). */
   skipTracker?: boolean;
   resume?: boolean;
+  /**
+   * Iter-3 sub-round filter for resume granularity.
+   * - undefined: default behavior (sub-round-a then iter3 sub-round-b
+   *   hook if flag set, then tracker).
+   * - "a": run only sub-round-a; skip the iter3 sub-round-b hook AND
+   *   skip the tracker (re-run `--phase 4` later to get the tracker).
+   * - "b": skip sub-round-a actor loop (must be ok in PHASE_4_PARTIAL.json);
+   *   run only the sub-round-b hook AND skip the tracker. Requires
+   *   `cfg.iter3MultiRound`.
+   */
+  roundFilter?: "a" | "b";
 }
 
 export interface DefenseRunRecord {
@@ -271,7 +282,26 @@ export async function runPhase(opts: RunPhase4Opts): Promise<Phase4PartialFile> 
   }
 
   // 6. Decide which advocates to run.
+  //    Iter-3 `--round b` short-circuits the sub-round-a actor loop entirely:
+  //    sub-round-a must already be complete in PHASE_4_PARTIAL.json.
+  if (opts.roundFilter === "b") {
+    if (!opts.cfg.iter3MultiRound) {
+      throw new Error(
+        "--round b requires ITER3_MULTI_ROUND=1 (set the env var or `iter3MultiRound: true` in agents.json).",
+      );
+    }
+    if (
+      !priorPartial ||
+      priorPartial.advocates.a?.outcome !== "ok" ||
+      priorPartial.advocates.b?.outcome !== "ok"
+    ) {
+      throw new Error(
+        "--round b requires PHASE_4_PARTIAL.json with both sub-round-a advocates `outcome=ok`. Run `--phase 4 --round a` (or `--phase 4`) first.",
+      );
+    }
+  }
   const advocatesToRun: DefenseAgentRole[] = (() => {
+    if (opts.roundFilter === "b") return [];
     if (opts.onlyAdvocate) return [opts.onlyAdvocate];
     const all: DefenseAgentRole[] = ["advocate-a", "advocate-b"];
     if (!priorPartial) return all;
@@ -306,7 +336,7 @@ export async function runPhase(opts: RunPhase4Opts): Promise<Phase4PartialFile> 
         outcome: "ok",
         attempts: 0,
         tokenUsage: { inputTokens: 0, outputTokens: 0 },
-        llmOutput: { phase: "4", advocateRole: role === "advocate-a" ? "A" : "B", responses: [], cqAnswers: [] },
+        llmOutput: { phase: "4", advocateRole: role === "advocate-a" ? "A" : "B", subRound: "a", responses: [], cqAnswers: [], webCitations: [] },
         artifacts: {
           promptPath: defensePromptPath(opts.cfg, role),
           roundLogPath: roundLogPath(opts.cfg, role),
@@ -351,13 +381,63 @@ export async function runPhase(opts: RunPhase4Opts): Promise<Phase4PartialFile> 
     );
   }
 
+  // 8c. Iter-3 multi-round: run sub-round-b after both sub-round-a
+  //     defenders are ok and the gate flag is set. Sub-round-b mints to
+  //     the DB (translator preserves sub-round-a narrows via subRound:"b")
+  //     and writes its own PHASE_4_SUBROUNDB_PARTIAL.json. Sub-round-a
+  //     partial is untouched.
+  if (
+    opts.cfg.iter3MultiRound &&
+    opts.roundFilter !== "a" &&
+    !opts.onlyAdvocate &&
+    results.a?.outcome === "ok" &&
+    results.b?.outcome === "ok"
+  ) {
+    const phase2ArgSideById = new Map<string, "A" | "B">();
+    for (const arg of phase2.advocates.a.arguments) phase2ArgSideById.set(arg.argumentId, "A");
+    for (const arg of phase2.advocates.b.arguments) phase2ArgSideById.set(arg.argumentId, "B");
+    const schemeIdByKey = new Map<string, string>();
+    for (const s of schemeCatalog) schemeIdByKey.set(s.key, s.id);
+    try {
+      const { runPhase4SubRoundB } = await import("./phase-4-subround-b");
+      await runPhase4SubRoundB({
+        cfg: opts.cfg,
+        iso: opts.iso,
+        llm: opts.llm,
+        deliberationId: opts.deliberationId,
+        framing: framing.full,
+        evidenceCorpusPrompt,
+        allowedCitationTokens,
+        tokenToSourceId,
+        schemeCatalog,
+        registry,
+        subRoundA: { a: results.a!, b: results.b! },
+        phase3,
+        ownArgsByRole,
+        phase2ArgSideById,
+        yourPhase2PromptByRole,
+        schemeIdByKey,
+      });
+    } catch (err) {
+      // Sub-round-b failure must NOT poison sub-round-a partial. Log
+      // and continue to tracker on sub-round-a results.
+      phaseLogger.event("round_summary", {
+        step: "sub-round-b-error",
+        error: (err as Error).message,
+      });
+    }
+  }
+
   // 9. Concession Tracker.
+  //    Iter-3 `--round a|b` skips the tracker so the user can iterate on
+  //    one sub-round at a time; re-running `--phase 4` (no `--round`)
+  //    runs the tracker against whatever sub-round records exist.
   const tracker = await maybeRunTracker({
     cfg: opts.cfg,
     iso: opts.iso,
     llm: opts.llm,
     deliberationId: opts.deliberationId,
-    skipTracker: opts.skipTracker,
+    skipTracker: opts.skipTracker || opts.roundFilter === "a" || opts.roundFilter === "b",
     framing: framing.full,
     subClaimTextByIndex,
     phase2,
@@ -806,6 +886,28 @@ async function maybeRunTracker(opts: MaybeRunTrackerOpts): Promise<TrackerRunRec
     }
   }
 
+  // Iter-3: when the multi-round flag is set AND partial files exist,
+  // augment the tracker inputs with round-2 attacks + sub-round-b
+  // responses. No-op when flag is off or partials missing.
+  let appendedUserBlock: string | undefined;
+  if (opts.cfg.iter3MultiRound) {
+    const { loadIter3Augmentation } = await import("../util/iter3-augment");
+    const aug = loadIter3Augmentation({
+      runtimeDir: opts.cfg.runtimeDir,
+      deliberationId: opts.deliberationId,
+    });
+    if (aug.anyData) {
+      for (const id of aug.round2AttackIds) knownAttackIds.add(id);
+      for (const id of aug.subRoundBResponseIds) knownPhase4ResponseIds.add(id);
+      appendedUserBlock = aug.appendedUserBlock;
+      logger.event("round_summary", {
+        step: "tracker-iter3-augmented",
+        round2AttackIds: aug.round2AttackIds.size,
+        subRoundBResponseIds: aug.subRoundBResponseIds.size,
+      });
+    }
+  }
+
   let turn;
   try {
     turn = await runTrackerTurn({
@@ -820,6 +922,7 @@ async function maybeRunTracker(opts: MaybeRunTrackerOpts): Promise<TrackerRunRec
       advocateAPhase4Prompt: aPhase4Prompt,
       advocateBPhase4Prompt: bPhase4Prompt,
       evidenceCorpusPrompt: opts.evidenceCorpusPrompt,
+      appendedUserBlock,
       schemaOpts: { knownArguments, knownAttackIds, knownPhase4ResponseIds },
       cfg: opts.cfg,
       llm: opts.llm,
@@ -875,7 +978,7 @@ async function maybeRunTracker(opts: MaybeRunTrackerOpts): Promise<TrackerRunRec
 // Loaders
 // ─────────────────────────────────────────────────────────────────
 
-function loadPhase2Complete(runtimeDir: string, deliberationId: string): Phase2CompleteFile {
+export function loadPhase2Complete(runtimeDir: string, deliberationId: string): Phase2CompleteFile {
   const p = path.join(runtimeDir, "PHASE_2_COMPLETE.json");
   if (!existsSync(p)) {
     throw new Error(`Phase 4 prereq missing: ${p}. Run phase 2 + finalize.`);
@@ -892,7 +995,7 @@ function loadPhase2Complete(runtimeDir: string, deliberationId: string): Phase2C
   return raw;
 }
 
-function loadPhase3Complete(runtimeDir: string, deliberationId: string): Phase3CompleteFile {
+export function loadPhase3Complete(runtimeDir: string, deliberationId: string): Phase3CompleteFile {
   const p = path.join(runtimeDir, "PHASE_3_COMPLETE.json");
   if (!existsSync(p)) {
     throw new Error(`Phase 4 prereq missing: ${p}. Run phase 3 + finalize.`);
@@ -909,7 +1012,7 @@ function loadPhase3Complete(runtimeDir: string, deliberationId: string): Phase3C
   return raw;
 }
 
-function loadSubClaimTextByIndex(runtimeDir: string): Record<number, string> {
+export function loadSubClaimTextByIndex(runtimeDir: string): Record<number, string> {
   const p = path.join(runtimeDir, "PHASE_1_COMPLETE.json");
   const out: Record<number, string> = {};
   if (!existsSync(p)) return out;
@@ -928,7 +1031,7 @@ function loadSubClaimTextByIndex(runtimeDir: string): Record<number, string> {
 // Binding builders
 // ─────────────────────────────────────────────────────────────────
 
-function buildOwnArgumentBindings(
+export function buildOwnArgumentBindings(
   own: Phase2CompleteAdvocate,
   schemeCatalog: Array<{ id: string; key: string }>,
   subClaimTextByIndex: Record<number, string>,

--- a/experiments/polarization-1/orchestrator/phases/phase-4-subround-b.ts
+++ b/experiments/polarization-1/orchestrator/phases/phase-4-subround-b.ts
@@ -1,0 +1,960 @@
+/**
+ * phases/phase-4-subround-b.ts
+ *
+ * Iter-3 multi-round Phase 4 — sub-round-b driver. Symmetric to
+ * `phase-3-round2.ts`. Gated behind `cfg.iter3MultiRound` and invoked
+ * from `phase-4-defenses.ts#runPhase` AFTER sub-round-a has produced
+ * outcome="ok" for both advocates.
+ *
+ * Sub-round-b semantics (per locked design memo):
+ *   - Actors: advocate-a, advocate-b (no methodologist defenses).
+ *   - Each defender now responds to ROUND-2 attacks targeting either:
+ *       (a) their Phase-2 own arguments (NEW direct round-2 attacks), OR
+ *       (b) their own ROUND-1 rebuttals (round-2 attacks-on-attacks).
+ *   - Defense schema is unchanged; the LLM emits `subRound: "b"`.
+ *
+ * Outputs:
+ *   - DB: argument + edge rows for sub-round-b defenses (translator
+ *     skips the narrow-variant orphan-cleanup branch when
+ *     `subRound: "b"` is passed so sub-round-a narrows are preserved).
+ *   - File: `PHASE_4_SUBROUNDB_PARTIAL.json` next to PHASE_4_PARTIAL.json
+ *     (separate file — finalize-merge into PHASE_4_COMPLETE is a
+ *     follow-up task; tracker reads moves from DB regardless).
+ *
+ * Failure mode: if any actor refuses or validation-errors, sub-round-b
+ * partial still records the failure record; sub-round-a results are
+ * untouched. User can re-resume with the same gate flag.
+ */
+
+import path from "path";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "fs";
+
+import type { OrchestratorConfig } from "../config";
+import type { IsonomiaClient } from "../isonomia-client";
+import type { AnthropicClient } from "../anthropic-client";
+import { RoundLogger } from "../log/round-logger";
+import { ClaimRegistry } from "../translators/claim-mint";
+
+import {
+  runDefenseTurn,
+  isDefenseRefusal,
+  DefenseValidationError,
+  type DefenseAgentRole,
+} from "../agents/defense";
+import type { DefenseRefusal } from "../agents/defense-schema";
+
+import {
+  translateDefenseOutput,
+  type OwnArgumentBinding,
+  type OpposingRebuttalBinding,
+  type OpposingCqRaiseBinding,
+} from "../translators/defense-mint";
+
+import type {
+  RebuttalRunRecord,
+  MethodologistRunRecord,
+} from "./phase-3-attacks";
+import type { Phase3Round2PartialFile } from "./phase-3-round2";
+
+import type {
+  Phase3CompleteFile,
+  Phase3CompleteAdvocate,
+  Phase3CompleteMethodologist,
+  Phase3CompleteRebuttal,
+  Phase3CompleteMethodologistRebuttal,
+} from "../finalize/phase-3-finalize";
+
+import type { DefenseRunRecord } from "./phase-4-defenses";
+
+// ─────────────────────────────────────────────────────────────────
+// Constants
+// ─────────────────────────────────────────────────────────────────
+
+const PHASE_4_LLM_DIR = "llm";
+const PHASE_4_SUBROUND_B_PARTIAL_FILE = "PHASE_4_SUBROUNDB_PARTIAL.json";
+const PHASE_3_ROUND2_PARTIAL_FILE = "PHASE_3_ROUND2_PARTIAL.json";
+const REFUSALS_DIR = "refusals";
+
+// Round numbering inside the Phase-4 logger:
+//   1 = sub-round-a advocate-a
+//   2 = sub-round-a advocate-b
+//   3 = sub-round-b advocate-a
+//   4 = sub-round-b advocate-b
+const PHASE_4_SUB_ROUND_B_BASE = 3 as const;
+
+// ─────────────────────────────────────────────────────────────────
+// Public types
+// ─────────────────────────────────────────────────────────────────
+
+export interface RunPhase4SubRoundBOpts {
+  cfg: OrchestratorConfig;
+  iso: IsonomiaClient;
+  llm: AnthropicClient;
+  deliberationId: string;
+  framing: string;
+  evidenceCorpusPrompt: string;
+  allowedCitationTokens: Set<string>;
+  tokenToSourceId: Record<string, string>;
+  schemeCatalog: Array<{ id: string; key: string }>;
+  registry: ClaimRegistry;
+  /** Sub-round-a defense results (both advocates must be ok before calling). */
+  subRoundA: { a: DefenseRunRecord; b: DefenseRunRecord };
+  /** Phase-3 finalized data (used to extract own round-1 rebuttals). */
+  phase3: Phase3CompleteFile;
+  /** Pre-built Phase-2 ownArguments per advocate (extended in this driver with own round-1 rebuttals). */
+  ownArgsByRole: {
+    "advocate-a": ReadonlyMap<string, OwnArgumentBinding>;
+    "advocate-b": ReadonlyMap<string, OwnArgumentBinding>;
+  };
+  /** Side index of every Phase-2 argument (used to route round-2 attacks). */
+  phase2ArgSideById: ReadonlyMap<string, "A" | "B">;
+  /** Pre-rendered YOUR_PHASE_2 prompts per defender (reused from sub-round-a). */
+  yourPhase2PromptByRole: { "advocate-a": string; "advocate-b": string };
+  /** scheme-key → scheme-id (resolved schemeId for OwnArgumentBinding extension). */
+  schemeIdByKey: ReadonlyMap<string, string>;
+}
+
+export interface Phase4SubRoundBPartialFile {
+  phase: 4;
+  subPhase: "sub-round-b";
+  status: "partial";
+  generatedAt: string;
+  deliberationId: string;
+  modelTier: string;
+  advocates: {
+    a?: DefenseRunRecord;
+    b?: DefenseRunRecord;
+  };
+  totals: {
+    defensesCreated: number;
+    edgesCreated: number;
+    narrowsCreated: number;
+    cqStatusesUpserted: number;
+    inputTokens: number;
+    outputTokens: number;
+  };
+}
+
+// ─────────────────────────────────────────────────────────────────
+// Round-2 attack collection (across both advocates + methodologist)
+// ─────────────────────────────────────────────────────────────────
+
+/** A round-2 rebuttal viewed as a sub-round-b attack. */
+interface Round2AttackRef {
+  /** DB id of the round-2 rebuttal Argument (used as `targetAttackId` in defense schema). */
+  rebuttalArgumentId: string;
+  /** What this round-2 attack targets. */
+  targetArgumentId: string;
+  /** Phase-2 own arg vs round-1 rebuttal (from round-2 LLM output). */
+  targetKind: "phase2-arg" | "round1-rebuttal";
+  /** Author role of the round-2 attack (the OPPONENT of the defender). */
+  authorRole: "advocate-a" | "advocate-b" | "methodologist";
+  /** Side that needs to defend in sub-round-b ("A" or "B"). */
+  defendingSide: "A" | "B";
+  attackType: "REBUT" | "UNDERMINE" | "UNDERCUT";
+  rebuttalPremiseCount: number;
+  rebuttalPremiseClaimIds: readonly string[];
+  rebuttalTargetPremiseIndex: number | null;
+  rebuttalConclusionClaimId: string;
+  conclusionText: string;
+  premiseTexts: readonly string[];
+  premiseCitationTokens: ReadonlyArray<string | null>;
+  warrant: string | null;
+  schemeKey: string;
+  cqKey: string | null;
+}
+
+/** A round-2 CQ raise viewed as a sub-round-b attack. */
+interface Round2CqRaiseRef {
+  /** Synthesized stable id (no first-class CQResponse id is exposed). */
+  cqResponseId: string;
+  targetArgumentId: string;
+  targetKind: "phase2-arg" | "round1-rebuttal";
+  authorRole: "advocate-a" | "advocate-b" | "methodologist";
+  defendingSide: "A" | "B";
+  cqKey: string;
+  rationale: string;
+}
+
+interface OwnRebuttalRef {
+  /** This bot's round-1 rebuttal Argument id (treated as an "own argument" in sub-round-b). */
+  rebuttalArgumentId: string;
+  schemeKey: string;
+  schemeId: string;
+  conclusionClaimId: string;
+  conclusionText: string;
+  premiseClaimIds: readonly string[];
+  premiseTexts: readonly string[];
+  /** The Phase-2 argId this rebuttal originally attacked (carries side info). */
+  targetPhase2ArgId: string;
+  authorRole: "advocate-a" | "advocate-b" | "methodologist";
+}
+
+function collectOwnRebuttals(
+  phase3: Phase3CompleteFile,
+  schemeIdByKey: ReadonlyMap<string, string>,
+): OwnRebuttalRef[] {
+  const out: OwnRebuttalRef[] = [];
+
+  function pushAdvocate(adv: Phase3CompleteAdvocate, authorRole: "advocate-a" | "advocate-b"): void {
+    for (const r of adv.rebuttals) {
+      const targetKind = (r as any).targetKind ?? "phase2-arg";
+      if (targetKind !== "phase2-arg") continue;
+      const round = (r as any).round ?? "1";
+      if (round !== "1") continue;
+      out.push({
+        rebuttalArgumentId: r.rebuttalArgumentId,
+        schemeKey: r.schemeKey,
+        schemeId: schemeIdByKey.get(r.schemeKey) ?? "",
+        conclusionClaimId: r.conclusionClaimId,
+        conclusionText: r.conclusionText,
+        premiseClaimIds: r.premiseClaimIds,
+        premiseTexts: r.premiseTexts,
+        targetPhase2ArgId: r.targetArgumentId,
+        authorRole,
+      });
+    }
+  }
+
+  pushAdvocate(phase3.advocates.a, "advocate-a");
+  pushAdvocate(phase3.advocates.b, "advocate-b");
+
+  const meth = phase3.methodologist;
+  if (meth) {
+    for (const r of meth.rebuttals) {
+      const targetKind = (r as any).targetKind ?? "phase2-arg";
+      if (targetKind !== "phase2-arg") continue;
+      const round = (r as any).round ?? "1";
+      if (round !== "1") continue;
+      out.push({
+        rebuttalArgumentId: r.rebuttalArgumentId,
+        schemeKey: r.schemeKey,
+        schemeId: schemeIdByKey.get(r.schemeKey) ?? "",
+        conclusionClaimId: r.conclusionClaimId,
+        conclusionText: r.conclusionText,
+        premiseClaimIds: r.premiseClaimIds,
+        premiseTexts: r.premiseTexts,
+        targetPhase2ArgId: r.targetArgumentId,
+        authorRole: "methodologist",
+      });
+    }
+  }
+
+  return out;
+}
+
+function collectRound2Attacks(
+  round2Actors: Phase3Round2PartialFile["actors"],
+  phase2ArgSideById: ReadonlyMap<string, "A" | "B">,
+  ownRebuttalsById: ReadonlyMap<string, OwnRebuttalRef>,
+): { rebuttals: Round2AttackRef[]; cqRaises: Round2CqRaiseRef[] } {
+  const rebuttals: Round2AttackRef[] = [];
+  const cqRaises: Round2CqRaiseRef[] = [];
+
+  function defendingSideFor(
+    targetArgumentId: string,
+    targetKind: "phase2-arg" | "round1-rebuttal",
+  ): "A" | "B" | null {
+    if (targetKind === "phase2-arg") {
+      return phase2ArgSideById.get(targetArgumentId) ?? null;
+    }
+    // round1-rebuttal: defender is the actor who AUTHORED the
+    // round-1 rebuttal that's now under attack.
+    const own = ownRebuttalsById.get(targetArgumentId);
+    if (!own) return null;
+    if (own.authorRole === "advocate-a") return "A";
+    if (own.authorRole === "advocate-b") return "B";
+    // methodologist: round-2 attacks targeting the methodologist's
+    // round-1 rebuttals don't get defended by an advocate. Skip.
+    return null;
+  }
+
+  function collect(
+    rec: RebuttalRunRecord | MethodologistRunRecord | undefined,
+    authorRole: "advocate-a" | "advocate-b" | "methodologist",
+  ): void {
+    if (!rec || rec.outcome !== "ok" || !rec.mintResult || !rec.llmOutput) return;
+    const inputs = rec.llmOutput.rebuttals;
+    for (const m of rec.mintResult.rebuttals) {
+      const orig = inputs[m.inputIndex];
+      if (!orig) continue;
+      const round = (orig as any).round ?? "1";
+      if (round !== "2") continue;
+      const targetKind: "phase2-arg" | "round1-rebuttal" =
+        (orig as any).targetKind ?? "phase2-arg";
+      const side = defendingSideFor(m.targetArgumentId, targetKind);
+      if (!side) continue;
+      // Reconstruct minimal binding fields. premiseCitationTokens are
+      // present on the LLM output; map them to the same length as premises.
+      const premiseCitationTokens: Array<string | null> = orig.premises.map(
+        (p: any) => (p.citationToken ?? null) as string | null,
+      );
+      rebuttals.push({
+        rebuttalArgumentId: m.rebuttalArgumentId,
+        targetArgumentId: m.targetArgumentId,
+        targetKind,
+        authorRole,
+        defendingSide: side,
+        attackType: m.attackType,
+        rebuttalPremiseCount: m.premiseClaimIds.length,
+        rebuttalPremiseClaimIds: m.premiseClaimIds,
+        rebuttalTargetPremiseIndex: m.targetPremiseIndex,
+        rebuttalConclusionClaimId: m.conclusionClaimId,
+        conclusionText: orig.conclusionText,
+        premiseTexts: orig.premises.map((p: any) => p.text),
+        premiseCitationTokens,
+        warrant: orig.warrant ?? null,
+        schemeKey: m.schemeKey,
+        cqKey: m.cqKey ?? null,
+      });
+    }
+    // CQ raises in round 2.
+    const cqs = (rec.llmOutput as any).cqResponses ?? [];
+    for (let i = 0; i < cqs.length; i++) {
+      const c = cqs[i];
+      if (c.action !== "raise") continue;
+      // round-2 CQ raise must mirror the rebuttal `targetKind`.
+      const targetKind: "phase2-arg" | "round1-rebuttal" = c.targetKind ?? "phase2-arg";
+      const side = defendingSideFor(c.targetArgumentId, targetKind);
+      if (!side) continue;
+      // De-dup against rebuttal cqKey embedding handled by attack-mint;
+      // we surface raw raises here and rely on schema validation downstream.
+      const cqResponseId = `cqraise-r2-${authorRole}:${c.targetArgumentId}:${c.cqKey}`;
+      cqRaises.push({
+        cqResponseId,
+        targetArgumentId: c.targetArgumentId,
+        targetKind,
+        authorRole,
+        defendingSide: side,
+        cqKey: c.cqKey,
+        rationale: c.rationale ?? "",
+      });
+    }
+  }
+
+  collect(round2Actors.a, "advocate-a");
+  collect(round2Actors.b, "advocate-b");
+  collect(round2Actors.methodologist, "methodologist");
+  return { rebuttals, cqRaises };
+}
+
+// ─────────────────────────────────────────────────────────────────
+// Binding builders
+// ─────────────────────────────────────────────────────────────────
+
+function buildExtendedOwnArgs(
+  basePhase2: ReadonlyMap<string, OwnArgumentBinding>,
+  defenderRole: "advocate-a" | "advocate-b",
+  ownRebuttals: readonly OwnRebuttalRef[],
+): Map<string, OwnArgumentBinding> {
+  const out = new Map<string, OwnArgumentBinding>(basePhase2);
+  for (const r of ownRebuttals) {
+    if (r.authorRole !== defenderRole) continue;
+    out.set(r.rebuttalArgumentId, {
+      argumentId: r.rebuttalArgumentId,
+      schemeKey: r.schemeKey,
+      schemeId: r.schemeId,
+      conclusionClaimId: r.conclusionClaimId,
+      conclusionText: r.conclusionText,
+      premiseClaimIds: r.premiseClaimIds,
+      premiseTexts: r.premiseTexts,
+    });
+  }
+  return out;
+}
+
+function buildOpposingRebuttalBindingsFromRound2(
+  side: "A" | "B",
+  rebuttals: readonly Round2AttackRef[],
+  ownArgs: ReadonlyMap<string, OwnArgumentBinding>,
+): Map<string, OpposingRebuttalBinding> {
+  const out = new Map<string, OpposingRebuttalBinding>();
+  for (const r of rebuttals) {
+    if (r.defendingSide !== side) continue;
+    if (!ownArgs.has(r.targetArgumentId)) continue;
+    out.set(r.rebuttalArgumentId, {
+      rebuttalArgumentId: r.rebuttalArgumentId,
+      targetArgumentId: r.targetArgumentId,
+      rebuttalPremiseCount: r.rebuttalPremiseCount,
+      rebuttalPremiseClaimIds: r.rebuttalPremiseClaimIds,
+      rebuttalAttackType: r.attackType,
+      rebuttalTargetPremiseIndex: r.rebuttalTargetPremiseIndex,
+      rebuttalConclusionClaimId: r.rebuttalConclusionClaimId,
+      cqKey: r.cqKey,
+    });
+  }
+  return out;
+}
+
+function buildOpposingCqRaiseBindingsFromRound2(
+  side: "A" | "B",
+  cqRaises: readonly Round2CqRaiseRef[],
+  ownArgs: ReadonlyMap<string, OwnArgumentBinding>,
+): Map<string, OpposingCqRaiseBinding> {
+  const out = new Map<string, OpposingCqRaiseBinding>();
+  for (const c of cqRaises) {
+    if (c.defendingSide !== side) continue;
+    if (!ownArgs.has(c.targetArgumentId)) continue;
+    out.set(c.cqResponseId, {
+      cqResponseId: c.cqResponseId,
+      targetArgumentId: c.targetArgumentId,
+      cqKey: c.cqKey,
+    });
+  }
+  return out;
+}
+
+// ─────────────────────────────────────────────────────────────────
+// Prompt block renderer (## ROUND_2_ATTACKS_AGAINST_YOU)
+// ─────────────────────────────────────────────────────────────────
+
+function renderRound2AttacksForDefender(
+  side: "A" | "B",
+  rebuttals: readonly Round2AttackRef[],
+  cqRaises: readonly Round2CqRaiseRef[],
+  ownRebuttalsById: ReadonlyMap<string, OwnRebuttalRef>,
+): string {
+  const lines: string[] = [];
+  lines.push(`## ROUND_2_ATTACKS_AGAINST_YOU`);
+  lines.push(``);
+  lines.push(
+    `Round-2 attacks below target either your Phase-2 own arguments OR your own ` +
+      `round-1 rebuttals. Treat the listed \`targets:\` ARG id as the entity you ` +
+      `must defend (or concede / narrow) in your sub-round-b response.`,
+  );
+  lines.push(``);
+
+  let any = false;
+  for (const r of rebuttals) {
+    if (r.defendingSide !== side) continue;
+    any = true;
+    const targetLabel =
+      r.targetKind === "round1-rebuttal" ? "ROUND_1_REBUTTAL" : "PHASE_2_ARG";
+    lines.push(
+      `ATTACK ${r.rebuttalArgumentId}  attackType=${r.attackType}  from=${r.authorRole}  round=2`,
+    );
+    lines.push(
+      `  targets: ${targetLabel} ${r.targetArgumentId}  premise=${r.rebuttalTargetPremiseIndex ?? "null"}  cqKey=${r.cqKey ?? "null"}`,
+    );
+    if (r.targetKind === "round1-rebuttal") {
+      const own = ownRebuttalsById.get(r.targetArgumentId);
+      if (own) {
+        lines.push(
+          `  your round-1 rebuttal originally attacked your own Phase-2 ARG ${own.targetPhase2ArgId}`,
+        );
+      }
+    }
+    lines.push(`  concludes: "${r.conclusionText}"`);
+    lines.push(`  premises (0-indexed):`);
+    for (let i = 0; i < r.premiseTexts.length; i++) {
+      const tok = r.premiseCitationTokens[i] ?? null;
+      lines.push(`    [${i}] "${r.premiseTexts[i]}"  cite=${tok ?? "null"}`);
+    }
+    lines.push(`  warrant: ${r.warrant ? `"${r.warrant}"` : "null"}`);
+    lines.push(`  scheme: ${r.schemeKey}`);
+    lines.push(``);
+  }
+  for (const c of cqRaises) {
+    if (c.defendingSide !== side) continue;
+    any = true;
+    const targetLabel =
+      c.targetKind === "round1-rebuttal" ? "ROUND_1_REBUTTAL" : "PHASE_2_ARG";
+    lines.push(`CQ_RAISE ${c.cqResponseId}  action=raise  from=${c.authorRole}  round=2`);
+    lines.push(`  targets: ${targetLabel} ${c.targetArgumentId}  cqKey=${c.cqKey}`);
+    lines.push(`  rationale: "${c.rationale}"`);
+    lines.push(``);
+  }
+  if (!any) {
+    lines.push(`(No round-2 attacks were filed against your arguments or rebuttals.)`);
+  }
+  return lines.join("\n");
+}
+
+function renderSubRoundADefensesForDefender(rec: DefenseRunRecord): string {
+  if (rec.outcome !== "ok" || !rec.llmOutput) {
+    return `## YOUR_SUB_ROUND_A_DEFENSES\n\n(No sub-round-a defense output to summarize.)\n`;
+  }
+  const lines: string[] = [];
+  lines.push(`## YOUR_SUB_ROUND_A_DEFENSES`);
+  lines.push(``);
+  lines.push(
+    `Below is your own sub-round-a output (responses + cqAnswers). Use it as ` +
+      `context — do NOT re-emit these responses; sub-round-b only handles ` +
+      `the round-2 attacks listed in ROUND_2_ATTACKS_AGAINST_YOU.`,
+  );
+  lines.push(``);
+  for (let i = 0; i < rec.llmOutput.responses.length; i++) {
+    const r: any = rec.llmOutput.responses[i];
+    lines.push(`RESPONSE [${i}] kind=${r.kind}  targetAttackId=${r.targetAttackId}`);
+    if (r.defense) {
+      lines.push(
+        `  defense: attackType=${r.defense.attackType}  scheme=${r.defense.schemeKey}  premises=${r.defense.premises.length}`,
+      );
+      lines.push(`  defense.concludes: "${r.defense.conclusionText}"`);
+    }
+    if (r.kind === "narrow" && r.narrowedConclusionText) {
+      lines.push(`  narrowedConclusionText: "${r.narrowedConclusionText}"`);
+    }
+    if (r.rationale) lines.push(`  rationale: "${r.rationale}"`);
+    lines.push(``);
+  }
+  for (let i = 0; i < rec.llmOutput.cqAnswers.length; i++) {
+    const c: any = rec.llmOutput.cqAnswers[i];
+    lines.push(`CQ_ANSWER [${i}] kind=${c.kind}  targetCqRaiseId=${c.targetCqRaiseId}`);
+    if (c.rationale) lines.push(`  rationale: "${c.rationale}"`);
+    lines.push(``);
+  }
+  return lines.join("\n");
+}
+
+// ─────────────────────────────────────────────────────────────────
+// Per-defender runner
+// ─────────────────────────────────────────────────────────────────
+
+interface RunSubRoundBDefenderOpts {
+  role: DefenseAgentRole;
+  cfg: OrchestratorConfig;
+  iso: IsonomiaClient;
+  llm: AnthropicClient;
+  deliberationId: string;
+  framing: string;
+  yourPhase2ArgumentsPrompt: string;
+  /** Empty here — sub-round-b folds opponent attacks into appendedUserBlock. */
+  opponentAttacksPrompt: string;
+  evidenceCorpusPrompt: string;
+  ownArguments: ReadonlyMap<string, OwnArgumentBinding>;
+  opposingRebuttals: ReadonlyMap<string, OpposingRebuttalBinding>;
+  opposingCqRaises: ReadonlyMap<string, OpposingCqRaiseBinding>;
+  tokenToSourceId: Record<string, string>;
+  allowedCitationTokens: Set<string>;
+  registry: ClaimRegistry;
+  schemeCatalog: Array<{ id: string; key: string }>;
+  appendedSystemPrompt: string;
+  appendedUserBlock: string;
+}
+
+async function runSubRoundBDefender(
+  opts: RunSubRoundBDefenderOpts,
+): Promise<DefenseRunRecord> {
+  const round =
+    opts.role === "advocate-a"
+      ? PHASE_4_SUB_ROUND_B_BASE
+      : PHASE_4_SUB_ROUND_B_BASE + 1;
+  const logger = RoundLogger.forRound({
+    runtimeDir: opts.cfg.runtimeDir,
+    phase: 4,
+    round,
+    agentRole: opts.role,
+  });
+  const promptRel =
+    opts.role === "advocate-a" ? "prompts/6-defense-a.md" : "prompts/7-defense-b.md";
+  const promptPath = path.join(opts.cfg.experimentRoot, promptRel);
+  const llmDir = path.join(opts.cfg.runtimeDir, PHASE_4_LLM_DIR);
+  const llmOutputPath = path.join(llmDir, `phase-4-subroundb-${opts.role}-output.json`);
+  const roundLogPath = path.join(
+    opts.cfg.runtimeDir,
+    "logs",
+    `round-4-${round}-${opts.role}.jsonl`,
+  );
+  const baseArtifacts = { promptPath, roundLogPath };
+
+  let turn;
+  try {
+    turn = await runDefenseTurn({
+      role: opts.role,
+      promptPath,
+      framing: opts.framing,
+      yourPhase2ArgumentsPrompt: opts.yourPhase2ArgumentsPrompt,
+      opponentAttacksPrompt: opts.opponentAttacksPrompt,
+      methodologistAttacksPrompt: "",
+      evidenceCorpusPrompt: opts.evidenceCorpusPrompt,
+      appendedSystemPrompt: opts.appendedSystemPrompt,
+      appendedUserBlock: opts.appendedUserBlock,
+      schemaOpts: {
+        opposingRebuttals: new Map(
+          Array.from(opts.opposingRebuttals.entries()).map(([id, b]) => [
+            id,
+            {
+              rebuttalArgumentId: b.rebuttalArgumentId,
+              targetArgumentId: b.targetArgumentId,
+              rebuttalPremiseCount: b.rebuttalPremiseCount,
+              rebuttalAttackType: b.rebuttalAttackType,
+              rebuttalTargetPremiseIndex: b.rebuttalTargetPremiseIndex,
+              cqKey: b.cqKey,
+            },
+          ]),
+        ),
+        opposingCqRaises: new Map(
+          Array.from(opts.opposingCqRaises.entries()).map(([id, b]) => [
+            id,
+            {
+              cqResponseId: b.cqResponseId,
+              targetArgumentId: b.targetArgumentId,
+              cqKey: b.cqKey,
+            },
+          ]),
+        ),
+        allowedCitationTokens: opts.allowedCitationTokens,
+      },
+      cfg: opts.cfg,
+      llm: opts.llm,
+      logger,
+    });
+  } catch (err) {
+    if (err instanceof DefenseValidationError) {
+      logger.event("phase_complete", {
+        phase: 4,
+        round,
+        agent: opts.role,
+        outcome: "validation-error",
+        attempts: err.attempts,
+      });
+      return {
+        role: opts.role,
+        outcome: "validation-error",
+        attempts: err.attempts,
+        tokenUsage: { inputTokens: 0, outputTokens: 0 },
+        validationError: { message: err.message, rawResponsesCount: err.rawResponses.length },
+        artifacts: baseArtifacts,
+      };
+    }
+    throw err;
+  }
+
+  if (isDefenseRefusal(turn.response)) {
+    const refusalPath = path.join(
+      opts.cfg.runtimeDir,
+      REFUSALS_DIR,
+      `phase-4-subroundb-${opts.role}-refusal.json`,
+    );
+    mkdirSync(path.dirname(refusalPath), { recursive: true });
+    writeFileSync(refusalPath, JSON.stringify(turn.response, null, 2));
+    logger.event("phase_complete", {
+      phase: 4,
+      round,
+      agent: opts.role,
+      outcome: "refused",
+      reason: (turn.response as DefenseRefusal).error,
+      refusalPath,
+    });
+    return {
+      role: opts.role,
+      outcome: "refused",
+      attempts: turn.attempts,
+      tokenUsage: turn.usage,
+      refusal: turn.response,
+      refusalPath,
+      artifacts: baseArtifacts,
+    };
+  }
+
+  mkdirSync(llmDir, { recursive: true });
+  writeFileSync(llmOutputPath, JSON.stringify(turn.response, null, 2));
+
+  const mintResult = await translateDefenseOutput({
+    output: turn.response,
+    deliberationId: opts.deliberationId,
+    iso: opts.iso,
+    logger,
+    cfg: opts.cfg,
+    tokenToSourceId: opts.tokenToSourceId,
+    registry: opts.registry,
+    authorRole: opts.role,
+    ownArguments: opts.ownArguments,
+    opposingRebuttals: opts.opposingRebuttals,
+    opposingCqRaises: opts.opposingCqRaises,
+    schemeCatalog: opts.schemeCatalog,
+    stackId: opts.cfg.deliberation.evidenceStackId ?? null,
+    subRound: "b",
+  });
+
+  logger.event("phase_complete", {
+    phase: 4,
+    round,
+    agent: opts.role,
+    outcome: "ok",
+    ...mintResult.totals,
+  });
+
+  return {
+    role: opts.role,
+    outcome: "ok",
+    attempts: turn.attempts,
+    tokenUsage: turn.usage,
+    llmOutput: turn.response,
+    mintResult,
+    artifacts: { ...baseArtifacts, llmOutputPath },
+  };
+}
+
+// ─────────────────────────────────────────────────────────────────
+// Entry point
+// ─────────────────────────────────────────────────────────────────
+
+export async function runPhase4SubRoundB(
+  opts: RunPhase4SubRoundBOpts,
+): Promise<Phase4SubRoundBPartialFile> {
+  const phaseLogger = RoundLogger.forRound({
+    runtimeDir: opts.cfg.runtimeDir,
+    phase: 4,
+    round: PHASE_4_SUB_ROUND_B_BASE - 1,
+  });
+  phaseLogger.event("round_summary", {
+    step: "sub-round-b-start",
+    deliberationId: opts.deliberationId,
+  });
+
+  const partialPath = path.join(opts.cfg.runtimeDir, PHASE_4_SUBROUND_B_PARTIAL_FILE);
+
+  // Resume support.
+  let prior: Phase4SubRoundBPartialFile | null = null;
+  if (existsSync(partialPath)) {
+    try {
+      const raw = JSON.parse(readFileSync(partialPath, "utf8")) as Phase4SubRoundBPartialFile;
+      if (raw.deliberationId === opts.deliberationId) prior = raw;
+    } catch {
+      // ignore corrupt
+    }
+  }
+  const advocates: Phase4SubRoundBPartialFile["advocates"] = {
+    a: prior?.advocates.a,
+    b: prior?.advocates.b,
+  };
+
+  // 1. Load PHASE_3_ROUND2_PARTIAL.json (required — sub-round-b is
+  //    only invoked when round-2 ran).
+  const round2PartialPath = path.join(opts.cfg.runtimeDir, PHASE_3_ROUND2_PARTIAL_FILE);
+  if (!existsSync(round2PartialPath)) {
+    phaseLogger.event("round_summary", {
+      step: "sub-round-b-skip",
+      reason: "PHASE_3_ROUND2_PARTIAL.json not present",
+    });
+    return writeSubRoundBPartial(partialPath, opts, advocates);
+  }
+  let round2Partial: Phase3Round2PartialFile;
+  try {
+    round2Partial = JSON.parse(readFileSync(round2PartialPath, "utf8")) as Phase3Round2PartialFile;
+  } catch (err) {
+    phaseLogger.event("round_summary", {
+      step: "sub-round-b-skip",
+      reason: `failed to read PHASE_3_ROUND2_PARTIAL.json: ${(err as Error).message}`,
+    });
+    return writeSubRoundBPartial(partialPath, opts, advocates);
+  }
+
+  // 2. Collect own round-1 rebuttals + round-2 attacks.
+  const ownRebuttals = collectOwnRebuttals(opts.phase3, opts.schemeIdByKey);
+  const ownRebuttalsById = new Map(ownRebuttals.map((r) => [r.rebuttalArgumentId, r] as const));
+  const { rebuttals: round2Rebuttals, cqRaises: round2CqRaises } = collectRound2Attacks(
+    round2Partial.actors,
+    opts.phase2ArgSideById,
+    ownRebuttalsById,
+  );
+  phaseLogger.event("round_summary", {
+    step: "round-2-attacks-collected",
+    rebuttalCount: round2Rebuttals.length,
+    cqRaiseCount: round2CqRaises.length,
+    bySide: {
+      A: {
+        rebuttals: round2Rebuttals.filter((r) => r.defendingSide === "A").length,
+        cqRaises: round2CqRaises.filter((c) => c.defendingSide === "A").length,
+      },
+      B: {
+        rebuttals: round2Rebuttals.filter((r) => r.defendingSide === "B").length,
+        cqRaises: round2CqRaises.filter((c) => c.defendingSide === "B").length,
+      },
+    },
+  });
+
+  // 3. Read addendums.
+  const addendumA = readAddendum(opts.cfg, "advocate-a");
+  const addendumB = readAddendum(opts.cfg, "advocate-b");
+
+  // 4. Run advocate-a then advocate-b.
+  const defenders: Array<{
+    role: DefenseAgentRole;
+    side: "A" | "B";
+    addendum: string;
+    subRoundARecord: DefenseRunRecord;
+  }> = [
+    {
+      role: "advocate-a",
+      side: "A",
+      addendum: addendumA,
+      subRoundARecord: opts.subRoundA.a,
+    },
+    {
+      role: "advocate-b",
+      side: "B",
+      addendum: addendumB,
+      subRoundARecord: opts.subRoundA.b,
+    },
+  ];
+
+  for (const def of defenders) {
+    const slot = def.role === "advocate-a" ? "a" : "b";
+    if (advocates[slot]?.outcome === "ok") continue;
+    const ownArgs = buildExtendedOwnArgs(
+      opts.ownArgsByRole[def.role],
+      def.role,
+      ownRebuttals,
+    );
+    const opposingRebuttals = buildOpposingRebuttalBindingsFromRound2(
+      def.side,
+      round2Rebuttals,
+      ownArgs,
+    );
+    const opposingCqRaises = buildOpposingCqRaiseBindingsFromRound2(
+      def.side,
+      round2CqRaises,
+      ownArgs,
+    );
+
+    if (opposingRebuttals.size === 0 && opposingCqRaises.size === 0) {
+      phaseLogger.event("phase_skip_advocate", {
+        phase: 4,
+        subPhase: "sub-round-b",
+        agent: def.role,
+        reason: "no round-2 attacks against this defender",
+      });
+      const empty: DefenseRunRecord = {
+        role: def.role,
+        outcome: "ok",
+        attempts: 0,
+        tokenUsage: { inputTokens: 0, outputTokens: 0 },
+        llmOutput: {
+          phase: "4",
+          advocateRole: def.side,
+          subRound: "b",
+          responses: [],
+          cqAnswers: [],
+        } as any,
+        artifacts: {
+          promptPath: path.join(
+            opts.cfg.experimentRoot,
+            def.role === "advocate-a" ? "prompts/6-defense-a.md" : "prompts/7-defense-b.md",
+          ),
+          roundLogPath: path.join(
+            opts.cfg.runtimeDir,
+            "logs",
+            `round-4-${def.role === "advocate-a" ? PHASE_4_SUB_ROUND_B_BASE : PHASE_4_SUB_ROUND_B_BASE + 1}-${def.role}.jsonl`,
+          ),
+        },
+      };
+      advocates[slot] = empty;
+      writeSubRoundBPartial(partialPath, opts, advocates);
+      continue;
+    }
+
+    const userBlock = [
+      renderRound2AttacksForDefender(
+        def.side,
+        round2Rebuttals,
+        round2CqRaises,
+        ownRebuttalsById,
+      ),
+      "",
+      renderSubRoundADefensesForDefender(def.subRoundARecord),
+    ].join("\n");
+
+    const rec = await runSubRoundBDefender({
+      role: def.role,
+      cfg: opts.cfg,
+      iso: opts.iso,
+      llm: opts.llm,
+      deliberationId: opts.deliberationId,
+      framing: opts.framing,
+      yourPhase2ArgumentsPrompt: opts.yourPhase2PromptByRole[def.role],
+      // Sub-round-b folds all "opponent" inputs into appendedUserBlock,
+      // but the schema requires a non-empty block for the existing
+      // `## OPPONENT_ATTACKS_AGAINST_YOU` section. Provide a stub
+      // pointing the LLM at the sub-round-b block.
+      opponentAttacksPrompt:
+        "(Sub-round-b: see ## ROUND_2_ATTACKS_AGAINST_YOU below for all attacks to address.)",
+      evidenceCorpusPrompt: opts.evidenceCorpusPrompt,
+      ownArguments: ownArgs,
+      opposingRebuttals,
+      opposingCqRaises,
+      tokenToSourceId: opts.tokenToSourceId,
+      allowedCitationTokens: opts.allowedCitationTokens,
+      registry: opts.registry,
+      schemeCatalog: opts.schemeCatalog,
+      appendedSystemPrompt: def.addendum,
+      appendedUserBlock: userBlock,
+    });
+    advocates[slot] = rec;
+    writeSubRoundBPartial(partialPath, opts, advocates);
+  }
+
+  const partial = writeSubRoundBPartial(partialPath, opts, advocates);
+  phaseLogger.event("round_summary", {
+    step: "sub-round-b-complete",
+    okCount:
+      Number(advocates.a?.outcome === "ok") + Number(advocates.b?.outcome === "ok"),
+    totals: partial.totals,
+  });
+  return partial;
+}
+
+// ─────────────────────────────────────────────────────────────────
+// Helpers
+// ─────────────────────────────────────────────────────────────────
+
+function readAddendum(
+  cfg: OrchestratorConfig,
+  role: "advocate-a" | "advocate-b",
+): string {
+  const filename =
+    role === "advocate-a"
+      ? "6b-defense-a-subroundb-addendum.md"
+      : "7b-defense-b-subroundb-addendum.md";
+  const p = path.join(cfg.experimentRoot, "prompts", filename);
+  if (!existsSync(p)) return "";
+  return readFileSync(p, "utf8");
+}
+
+function writeSubRoundBPartial(
+  partialPath: string,
+  opts: { cfg: OrchestratorConfig; deliberationId: string },
+  advocates: Phase4SubRoundBPartialFile["advocates"],
+): Phase4SubRoundBPartialFile {
+  const totals = computeTotals(advocates);
+  const partial: Phase4SubRoundBPartialFile = {
+    phase: 4,
+    subPhase: "sub-round-b",
+    status: "partial",
+    generatedAt: new Date().toISOString(),
+    deliberationId: opts.deliberationId,
+    modelTier: opts.cfg.modelTier,
+    advocates,
+    totals,
+  };
+  mkdirSync(path.dirname(partialPath), { recursive: true });
+  writeFileSync(partialPath, JSON.stringify(partial, null, 2));
+  return partial;
+}
+
+function computeTotals(
+  advocates: Phase4SubRoundBPartialFile["advocates"],
+): Phase4SubRoundBPartialFile["totals"] {
+  const totals = {
+    defensesCreated: 0,
+    edgesCreated: 0,
+    narrowsCreated: 0,
+    cqStatusesUpserted: 0,
+    inputTokens: 0,
+    outputTokens: 0,
+  };
+  for (const slot of ["a", "b"] as const) {
+    const r = advocates[slot];
+    if (!r) continue;
+    totals.inputTokens += r.tokenUsage.inputTokens;
+    totals.outputTokens += r.tokenUsage.outputTokens;
+    if (r.outcome !== "ok" || !r.mintResult) continue;
+    totals.defensesCreated += r.mintResult.totals.defensesCreated;
+    totals.edgesCreated += r.mintResult.totals.edgesCreated;
+    totals.narrowsCreated += r.mintResult.totals.narrowsCreated;
+    totals.cqStatusesUpserted += r.mintResult.totals.cqStatusesUpserted;
+  }
+  return totals;
+}

--- a/experiments/polarization-1/orchestrator/phases/phase-5-synthesis.ts
+++ b/experiments/polarization-1/orchestrator/phases/phase-5-synthesis.ts
@@ -221,6 +221,23 @@ export async function runPhase(opts: RunPhase5Opts): Promise<Phase5PartialFile> 
     knownPhase4ResponseIds.add(`phase4-B-cq${i}`);
   }
 
+  // Iter-3: when the multi-round flag is set AND partial files exist,
+  // augment the synthesist inputs with round-2 attacks + sub-round-b
+  // responses. No-op when flag is off or partials missing.
+  let appendedUserBlock: string | undefined;
+  if (opts.cfg.iter3MultiRound) {
+    const { loadIter3Augmentation } = await import("../util/iter3-augment");
+    const aug = loadIter3Augmentation({
+      runtimeDir: opts.cfg.runtimeDir,
+      deliberationId: opts.deliberationId,
+    });
+    if (aug.anyData) {
+      for (const id of aug.round2AttackIds) knownAttackIds.add(id);
+      for (const id of aug.subRoundBResponseIds) knownPhase4ResponseIds.add(id);
+      appendedUserBlock = aug.appendedUserBlock;
+    }
+  }
+
   // 7. Run the synthesist.
   const round = 0;
   const logger = RoundLogger.forRound({
@@ -251,6 +268,7 @@ export async function runPhase(opts: RunPhase5Opts): Promise<Phase5PartialFile> 
       advocateBPhase4Prompt: bPhase4Prompt,
       trackerVerdictPrompt,
       evidenceCorpusPrompt,
+      appendedUserBlock,
       schemaOpts: {
         knownArgumentIds,
         knownAttackIds,

--- a/experiments/polarization-1/orchestrator/review/phase-3-checks.ts
+++ b/experiments/polarization-1/orchestrator/review/phase-3-checks.ts
@@ -60,6 +60,10 @@ import type { ReviewFlag, EvidenceSourceLite } from "./phase-2-checks";
 
 export type { ReviewFlag, EvidenceSourceLite };
 
+/** Role keys for soft-check iteration. Round 1 uses {"a","b"}; Iter-3
+ *  round 2 adds "methodologist" as a third actor. */
+export type SoftCheckRole = "a" | "b" | "methodologist";
+
 export interface OpposingArgumentMeta {
   argumentId: string;
   /** Sub-claim index this argument concludes to. */
@@ -176,11 +180,108 @@ export async function runPhase3SoftChecks(opts: Phase3SoftCheckOpts): Promise<Ph
 }
 
 // ─────────────────────────────────────────────────────────────────
+// Iter-3 round-2 entry
+// ─────────────────────────────────────────────────────────────────
+
+/**
+ * Iter-3 round-2 soft-check options. Round 2 has THREE actors (A, B,
+ * methodologist) and a wider opponent set per actor (Phase-2 args ∪
+ * round-1 rebuttals filed against own args). We deliberately SKIP two
+ * round-1 checks here:
+ *
+ *   - `mutual_rebut`: round-2 attacks frequently target round-1 rebuttals,
+ *     not the symmetric a-vs-b Phase-2 args; the same-hinge factual-
+ *     disagreement semantics don't apply cleanly.
+ *   - `hinge_attack_concentration`: targets are a mix of Phase-2 args
+ *     (with conclusionClaimIndex) and round-1 rebuttals (free-form
+ *     conclusions — `conclusionClaimIndex` is a sentinel `-1`); the
+ *     hinge-share denominator is no longer meaningful.
+ *
+ * The remaining checks (`attack_targeting`, `scheme_cq_validity`,
+ * `scheme_appropriateness`, `evidence_fidelity`) all run per-actor.
+ *
+ * Methodologist outputs are structurally compatible with `RebuttalOutput`
+ * (rebuttals[] + cqResponses[] with the same field names the checks
+ * read); call sites cast at the boundary.
+ */
+export interface Phase3Round2SoftCheckOpts {
+  /** Per-actor round-2 outputs. Any may be undefined (refusal/error). */
+  outputs: {
+    a?: RebuttalOutput;
+    b?: RebuttalOutput;
+    methodologist?: RebuttalOutput;
+  };
+
+  /**
+   * Per-actor opponent maps. For each actor, the keys are every
+   * `argumentId` that the actor was permitted to target in round 2:
+   * opponent's Phase-2 args + round-1 rebuttals filed against own args
+   * (methodologist sees BOTH sides' Phase-2 args + ALL round-1
+   * rebuttals). Round-1 rebuttal entries should set
+   * `conclusionClaimIndex = -1` (they don't sit at a hinge sub-claim).
+   */
+  opponentByActor: {
+    a: ReadonlyMap<string, OpposingArgumentMeta>;
+    b: ReadonlyMap<string, OpposingArgumentMeta>;
+    methodologist: ReadonlyMap<string, OpposingArgumentMeta>;
+  };
+
+  /** Same shape as Phase 2 — used by the LLM judge. */
+  sources: EvidenceSourceLite[];
+
+  llm?: AnthropicClient;
+  cfg?: OrchestratorConfig;
+  logger?: RoundLogger;
+  judgeModel?: string;
+  judgeTimeoutMs?: number;
+}
+
+export async function runPhase3Round2SoftChecks(
+  opts: Phase3Round2SoftCheckOpts,
+): Promise<Phase3SoftCheckResult> {
+  const flags: ReviewFlag[] = [];
+  const judgeUsage = { calls: 0, inputTokens: 0, outputTokens: 0 };
+
+  const roles: SoftCheckRole[] = ["a", "b", "methodologist"];
+  const sourceByToken = opts.llm && opts.cfg
+    ? new Map(opts.sources.map((s) => [s.citationToken, s] as const))
+    : null;
+
+  for (const role of roles) {
+    const out = opts.outputs[role];
+    if (!out) continue;
+    const opponent = opts.opponentByActor[role];
+    flags.push(...checkAttackTargeting(role, out, opponent));
+    flags.push(...checkSchemeCqValidity(role, out, opponent));
+    flags.push(...checkRebuttalSchemeAppropriateness(role, out));
+
+    if (sourceByToken && opts.llm && opts.cfg) {
+      const judged = await judgeRebuttalEvidenceFidelity({
+        role,
+        out,
+        sourceByToken,
+        llm: opts.llm,
+        cfg: opts.cfg,
+        logger: opts.logger,
+        judgeModel: opts.judgeModel,
+        judgeTimeoutMs: opts.judgeTimeoutMs,
+      });
+      flags.push(...judged.flags);
+      judgeUsage.calls += judged.usage.calls;
+      judgeUsage.inputTokens += judged.usage.inputTokens;
+      judgeUsage.outputTokens += judged.usage.outputTokens;
+    }
+  }
+
+  return { flags, judgeUsage };
+}
+
+// ─────────────────────────────────────────────────────────────────
 // 1. attack_targeting (defensive)
 // ─────────────────────────────────────────────────────────────────
 
 function checkAttackTargeting(
-  role: "a" | "b",
+  role: SoftCheckRole,
   out: RebuttalOutput,
   opponent: ReadonlyMap<string, OpposingArgumentMeta>,
 ): ReviewFlag[] {
@@ -227,7 +328,7 @@ function checkAttackTargeting(
 // ─────────────────────────────────────────────────────────────────
 
 function checkSchemeCqValidity(
-  role: "a" | "b",
+  role: SoftCheckRole,
   out: RebuttalOutput,
   opponent: ReadonlyMap<string, OpposingArgumentMeta>,
 ): ReviewFlag[] {
@@ -355,7 +456,7 @@ const CAUSAL_LANG = /\b(cause|caused|causes|causing|causal|increase[ds]?|decreas
 const POWER_LANG = /\b(powered|sample size|n\s*=\s*\d|pre-?registered|95% (CI|confidence)|effect size|null finding|did not detect)\b/i;
 const EXPERT_ASSERTION_LANG = /\b(argues?|contends?|concludes?|holds?|maintains?|asserts?|recommends?|warns?)\b/i;
 
-function checkRebuttalSchemeAppropriateness(role: "a" | "b", out: RebuttalOutput): ReviewFlag[] {
+function checkRebuttalSchemeAppropriateness(role: SoftCheckRole, out: RebuttalOutput): ReviewFlag[] {
   const flags: ReviewFlag[] = [];
   for (let i = 0; i < out.rebuttals.length; i++) {
     const r = out.rebuttals[i];
@@ -416,7 +517,7 @@ Output ONLY a JSON object of shape:
 No prose before or after. premiseIndex is 0-based and matches the order in the input.`;
 
 interface JudgeOpts {
-  role: "a" | "b";
+  role: SoftCheckRole;
   out: RebuttalOutput;
   sourceByToken: Map<string, EvidenceSourceLite>;
   llm: AnthropicClient;
@@ -520,7 +621,7 @@ async function judgeRebuttalEvidenceFidelity(opts: JudgeOpts): Promise<JudgeBatc
 }
 
 function renderJudgePrompt(
-  role: "a" | "b",
+  role: SoftCheckRole,
   rebuttalIndex: number,
   r: RebuttalArgument,
   pairs: Array<{ premiseIndex: number; premiseText: string; citationToken: string; source: EvidenceSourceLite }>,

--- a/experiments/polarization-1/orchestrator/translators/defense-mint.ts
+++ b/experiments/polarization-1/orchestrator/translators/defense-mint.ts
@@ -211,6 +211,17 @@ export interface TranslateDefenseOpts {
    * carries `webCitations`. See materializeWebCitations() in argument-mint.
    */
   stackId?: string | null;
+
+  /**
+   * Iter-3 sub-round identifier. Defaults to "a" (sub-round-a / Iter-2
+   * behavior unchanged). When set to "b", the orphan-guard's
+   * narrow-variant cleanup branch is skipped so sub-round-a's narrow
+   * variants are preserved. The defense-edge cleanup branch is keyed
+   * by `opposingRebuttalArgIds` (sub-round-b passes round-2 attack
+   * ids), so it correctly only deletes any prior sub-round-b defense
+   * edges on resume and never touches sub-round-a edges.
+   */
+  subRound?: "a" | "b";
 }
 
 // ─────────────────────────────────────────────────────────────────
@@ -250,6 +261,7 @@ export async function translateDefenseOutput(opts: TranslateDefenseOpts): Promis
     opposingRebuttalArgIds: [...opts.opposingRebuttals.keys()],
     logger: opts.logger,
     advocate: opts.authorRole,
+    skipNarrowVariantCleanup: opts.subRound === "b",
   });
 
   // ─────────────────────────────────────────────────────────────────
@@ -607,6 +619,7 @@ async function orphanGuard(opts: {
   opposingRebuttalArgIds: string[];
   logger: RoundLogger;
   advocate: "advocate-a" | "advocate-b";
+  skipNarrowVariantCleanup?: boolean;
 }) {
   // (a) Defense Arguments: this bot's args with an outgoing edge whose
   // toArgumentId is one of the opposing rebuttals.
@@ -640,6 +653,15 @@ async function orphanGuard(opts: {
   // (b) Narrow-variant Arguments: this bot's args whose text starts
   // with the narrow-variant marker. These have no outgoing edges but
   // do have ASSERT moves attached. Cascade handles related rows.
+  // Skipped under sub-round-b so we don't wipe sub-round-a narrows.
+  if (opts.skipNarrowVariantCleanup) {
+    opts.logger.event("orphan_cleanup_skipped", {
+      step: "defense-mint",
+      advocate: opts.advocate,
+      reason: "sub-round-b: preserve sub-round-a narrow variants",
+    });
+    return;
+  }
   const droppedNarrows = await prisma.argument.deleteMany({
     where: {
       deliberationId: opts.deliberationId,

--- a/experiments/polarization-1/orchestrator/util/iter3-augment.ts
+++ b/experiments/polarization-1/orchestrator/util/iter3-augment.ts
@@ -1,0 +1,235 @@
+/**
+ * orchestrator/util/iter3-augment.ts
+ *
+ * Iter-3 helpers that read PHASE_3_ROUND2_PARTIAL.json and
+ * PHASE_4_SUBROUNDB_PARTIAL.json (when present) and emit:
+ *   1) An `appendedUserBlock` containing `## ROUND_2_ATTACKS` and
+ *      `## SUB_ROUND_B_RESPONSES` sections for tracker / synthesist.
+ *   2) Augmentation sets for `knownAttackIds` (round-2 rebuttal ids)
+ *      and `knownPhase4ResponseIds` (sub-round-b synthesized response ids).
+ *
+ * Gate: callers should only invoke when `cfg.iter3MultiRound` is true.
+ * If the partial files do not exist, returns empty augmentation.
+ */
+
+import { existsSync, readFileSync } from "fs";
+import path from "path";
+
+import type { Phase3Round2PartialFile } from "../phases/phase-3-round2";
+import type { Phase4SubRoundBPartialFile } from "../phases/phase-4-subround-b";
+
+export interface Iter3Augmentation {
+  /** Round-2 rebuttal Argument ids to merge into `knownAttackIds`. */
+  round2AttackIds: Set<string>;
+  /** Sub-round-b response synthesized ids to merge into `knownPhase4ResponseIds`. */
+  subRoundBResponseIds: Set<string>;
+  /** Block to append to user message (between EVIDENCE_CORPUS and YOUR_TASK). */
+  appendedUserBlock: string;
+  /** True iff at least one round-2 actor or sub-round-b defender was loaded. */
+  anyData: boolean;
+}
+
+const PHASE_3_ROUND2_PARTIAL_FILE = "PHASE_3_ROUND2_PARTIAL.json";
+const PHASE_4_SUBROUND_B_PARTIAL_FILE = "PHASE_4_SUBROUNDB_PARTIAL.json";
+
+export function loadIter3Augmentation(opts: {
+  runtimeDir: string;
+  deliberationId: string;
+}): Iter3Augmentation {
+  const round2 = readPartial<Phase3Round2PartialFile>(
+    path.join(opts.runtimeDir, PHASE_3_ROUND2_PARTIAL_FILE),
+    opts.deliberationId,
+  );
+  const subB = readPartial<Phase4SubRoundBPartialFile>(
+    path.join(opts.runtimeDir, PHASE_4_SUBROUND_B_PARTIAL_FILE),
+    opts.deliberationId,
+  );
+
+  const round2AttackIds = new Set<string>();
+  const subRoundBResponseIds = new Set<string>();
+  const sections: string[] = [];
+  let anyData = false;
+
+  if (round2) {
+    const block = renderRound2AttacksBlock(round2, round2AttackIds);
+    if (block.length > 0) {
+      sections.push(block);
+      anyData = true;
+    }
+  }
+  if (subB) {
+    const block = renderSubRoundBResponsesBlock(subB, subRoundBResponseIds);
+    if (block.length > 0) {
+      sections.push(block);
+      anyData = true;
+    }
+  }
+
+  return {
+    round2AttackIds,
+    subRoundBResponseIds,
+    appendedUserBlock: sections.join("\n\n"),
+    anyData,
+  };
+}
+
+function readPartial<T extends { deliberationId: string }>(
+  partialPath: string,
+  deliberationId: string,
+): T | null {
+  if (!existsSync(partialPath)) return null;
+  try {
+    const raw = JSON.parse(readFileSync(partialPath, "utf8")) as T;
+    if (raw.deliberationId !== deliberationId) return null;
+    return raw;
+  } catch {
+    return null;
+  }
+}
+
+function renderRound2AttacksBlock(
+  round2: Phase3Round2PartialFile,
+  outIds: Set<string>,
+): string {
+  const lines: string[] = [];
+  lines.push(`## ROUND_2_ATTACKS`);
+  lines.push(``);
+  lines.push(
+    `Iter-3 multi-round Phase 3 produced a SECOND round of attacks. Each ` +
+      `actor (Advocate A, Advocate B, Methodologist) below may have filed ` +
+      `(a) NEW direct attacks on opponent's Phase-2 args (\`targetKind=phase2-arg\`), ` +
+      `or (b) attacks-on-attacks targeting round-1 rebuttals filed against the ` +
+      `actor's own side (\`targetKind=round1-rebuttal\`). Treat these as part of ` +
+      `the full record when scoring per-argument standings.`,
+  );
+  lines.push(``);
+
+  let any = false;
+  const actors: Array<["a" | "b" | "methodologist", string]> = [
+    ["a", "Advocate A"],
+    ["b", "Advocate B"],
+    ["methodologist", "Methodologist"],
+  ];
+  for (const [slot, label] of actors) {
+    const rec = round2.actors[slot];
+    if (!rec || rec.outcome !== "ok" || !rec.mintResult || !rec.llmOutput) continue;
+    const inputs = rec.llmOutput.rebuttals as Array<any>;
+    const cqs = (rec.llmOutput as any).cqResponses as Array<any> | undefined;
+
+    let blockHeader = false;
+    for (const m of rec.mintResult.rebuttals) {
+      const orig = inputs[m.inputIndex];
+      if (!orig) continue;
+      const round = (orig as any).round ?? "1";
+      if (round !== "2") continue;
+      const targetKind = (orig as any).targetKind ?? "phase2-arg";
+      outIds.add(m.rebuttalArgumentId);
+      if (!blockHeader) {
+        lines.push(`### ${label} (round-2)`);
+        lines.push(``);
+        blockHeader = true;
+        any = true;
+      }
+      lines.push(
+        `ATTACK ${m.rebuttalArgumentId}  attackType=${m.attackType}  targetKind=${targetKind}  round=2`,
+      );
+      lines.push(
+        `  targets: ${targetKind === "round1-rebuttal" ? "ROUND_1_REBUTTAL" : "ARG"} ${m.targetArgumentId}  premise=${m.targetPremiseIndex ?? "null"}  cqKey=${m.cqKey ?? "null"}`,
+      );
+      lines.push(`  concludes: "${orig.conclusionText}"`);
+      lines.push(`  premises (0-indexed):`);
+      const premises = orig.premises as Array<{ text: string; citationToken?: string | null }>;
+      for (let i = 0; i < premises.length; i++) {
+        lines.push(
+          `    [${i}] "${premises[i].text}"  cite=${premises[i].citationToken ?? "null"}`,
+        );
+      }
+      lines.push(`  warrant: ${orig.warrant ? `"${orig.warrant}"` : "null"}`);
+      lines.push(`  scheme: ${m.schemeKey}`);
+      lines.push(``);
+    }
+    if (cqs) {
+      for (let i = 0; i < cqs.length; i++) {
+        const c = cqs[i];
+        if (c.action !== "raise") continue;
+        const targetKind = c.targetKind ?? "phase2-arg";
+        // Synthesized id mirrors the sub-round-b driver's format.
+        const cqResponseId = `cqraise-r2-${slot === "methodologist" ? "methodologist" : `advocate-${slot}`}:${c.targetArgumentId}:${c.cqKey}`;
+        outIds.add(cqResponseId);
+        if (!blockHeader) {
+          lines.push(`### ${label} (round-2)`);
+          lines.push(``);
+          blockHeader = true;
+          any = true;
+        }
+        lines.push(
+          `CQ_RAISE ${cqResponseId}  action=raise  targetKind=${targetKind}  round=2`,
+        );
+        lines.push(`  targets: ARG ${c.targetArgumentId}  cqKey=${c.cqKey}`);
+        lines.push(`  rationale: "${c.rationale ?? ""}"`);
+        lines.push(``);
+      }
+    }
+  }
+
+  if (!any) return "";
+  return lines.join("\n");
+}
+
+function renderSubRoundBResponsesBlock(
+  subB: Phase4SubRoundBPartialFile,
+  outIds: Set<string>,
+): string {
+  const lines: string[] = [];
+  lines.push(`## SUB_ROUND_B_RESPONSES`);
+  lines.push(``);
+  lines.push(
+    `Iter-3 multi-round Phase 4 produced a SECOND sub-round of defenses ` +
+      `responding to ROUND_2_ATTACKS above. Treat these alongside Phase-4 ` +
+      `sub-round-a responses when scoring per-argument standings.`,
+  );
+  lines.push(``);
+
+  let any = false;
+  for (const slot of ["a", "b"] as const) {
+    const rec = subB.advocates[slot];
+    if (!rec || rec.outcome !== "ok" || !rec.llmOutput) continue;
+    const letter = slot.toUpperCase() as "A" | "B";
+    const responses = (rec.llmOutput.responses ?? []) as Array<any>;
+    const cqAnswers = (rec.llmOutput.cqAnswers ?? []) as Array<any>;
+    if (responses.length === 0 && cqAnswers.length === 0) continue;
+    any = true;
+    lines.push(`### Advocate ${letter} (sub-round-b)`);
+    lines.push(``);
+    for (let i = 0; i < responses.length; i++) {
+      const r = responses[i];
+      const responseId = `phase4b-${letter}-r${i}`;
+      outIds.add(responseId);
+      lines.push(`RESPONSE ${responseId}  kind=${r.kind}  targets: ATTACK ${r.targetAttackId}`);
+      if (r.defense) {
+        lines.push(
+          `  defense: attackType=${r.defense.attackType}  scheme=${r.defense.schemeKey}  premises=${r.defense.premises.length}`,
+        );
+        lines.push(`  defense.concludes: "${r.defense.conclusionText}"`);
+      }
+      if (r.kind === "narrow" && r.narrowedConclusionText) {
+        lines.push(`  narrowedConclusionText: "${r.narrowedConclusionText}"`);
+      }
+      if (r.rationale) lines.push(`  rationale: "${r.rationale}"`);
+      lines.push(``);
+    }
+    for (let i = 0; i < cqAnswers.length; i++) {
+      const c = cqAnswers[i];
+      const cqAnswerId = `phase4b-${letter}-cq${i}`;
+      outIds.add(cqAnswerId);
+      lines.push(
+        `CQ_ANSWER ${cqAnswerId}  kind=${c.kind}  targets: CQ_RAISE ${c.targetCqRaiseId}`,
+      );
+      if (c.rationale) lines.push(`  rationale: "${c.rationale}"`);
+      lines.push(``);
+    }
+  }
+
+  if (!any) return "";
+  return lines.join("\n");
+}

--- a/experiments/polarization-1/prompts/10b-methodologist-round2-addendum.md
+++ b/experiments/polarization-1/prompts/10b-methodologist-round2-addendum.md
@@ -47,3 +47,85 @@ attack is itself methodologically sound, leave it alone; if it
 overreaches (e.g., draws causal inference from purely correlational
 evidence), file an attack-on-attack. Refuse with
 `NO_METHODOLOGICAL_FLAWS` rather than filling quota.
+
+## §10 (validation traps — read before emitting)
+
+These are the validation failures most likely to reject a round-2
+response. Each is an automatic hard-rejection.
+
+### 10.1 `targetAdvocateRole` MUST equal the author of `targetArgumentId`
+
+Whether a CQ or rebuttal targets a **Phase-2 argument** (`targetKind:
+"phase2-arg"`) or a **round-1 rebuttal** (`targetKind:
+"round1-rebuttal"`), the `targetAdvocateRole` field is bound *purely
+by authorship of the targeted item*:
+
+- `targetKind: "phase2-arg"` → set `targetAdvocateRole` to the
+  advocate who **authored that Phase-2 argument** (look it up under
+  `## OPPONENT_PHASE_2_A` vs `## OPPONENT_PHASE_2_B` headers, or
+  whichever per-side block the prompt uses).
+- `targetKind: "round1-rebuttal"` → set `targetAdvocateRole` to the
+  advocate **whose Phase-2 argument that round-1 rebuttal attacked**
+  (i.e., the side the round-2 attack-on-attack defends). Equivalently:
+  the side whose argument appears as the round-1 rebuttal's own
+  `targetArgumentId`.
+
+Do NOT set `targetAdvocateRole` to the side you are dialectically
+*sympathetic* to in this turn — the field tracks the *target*, not
+the *defender*. The orchestrator hard-rejects any item whose
+`targetAdvocateRole` disagrees with the resolved authorship binding.
+
+Concrete failure from a prior run (do NOT replicate):
+- Methodologist attacked Phase-2 argument `cmout8c6f...` (authored by
+  B) but emitted `targetAdvocateRole: "A"` → hard-rejected.
+  ✅ Correct: `targetAdvocateRole: "B"`.
+
+### 10.2 `cqKey` MUST come from the *target argument's own scheme*
+
+This rule applies in **three** places, all governed identically:
+1. `cqResponses[*].cqKey` (raising or waiving a CQ on the target).
+2. `rebuttals[*].cqKey` (the rebuttal's optional annotation linking it
+   to the CQ on the *target argument* it answers).
+3. Any other top-level field whose name ends in `cqKey`.
+
+In every case, the key is bound by the **target argument's scheme**
+(the argument whose `argumentId` appears in `targetArgumentId`), NOT
+by the rebuttal's own scheme. Look up the target's
+`schemeKey` in the prompt (printed inline as
+`ARG <argumentId>  scheme=<schemeKey>` or
+`REB <argumentId>  ... scheme=<schemeKey>`) and pick a `cqKey` from
+**that scheme's catalog**, shown immediately below as
+`critical-questions for scheme=<schemeKey>:`. Do NOT mix keys across
+schemes.
+
+The catalogs DO use different `?`-suffix conventions across schemes —
+some keys end in `?`, some do not. Copy the key **verbatim** from the
+catalog; never add or strip a trailing `?`.
+
+Concrete failures from a prior run (do NOT replicate):
+- ❌ `cqKey: "causal_mechanism?"` on a `cause_to_effect` arg (stray `?`).
+  ✅ Valid `cause_to_effect` keys: `causal_strength`,
+  `alternative_causes`, `intervening_factors`, `post_hoc`,
+  `causal_mechanism`.
+- ❌ `cqKey: "alternative_causes?"` on an
+  `inference_to_best_explanation` arg (wrong scheme entirely).
+  ✅ Valid `inference_to_best_explanation` keys:
+  `alternative_hypothesis?`, `explains_all_facts?`,
+  `explanatory_criteria?`, `evidence_artifact?`,
+  `conjunction_of_causes?`.
+
+### 10.3 `citationToken` MUST include the prefix
+
+Every non-null `citationToken` must match `^[a-z]+:[A-Za-z0-9._-]+$`.
+A bare cuid is hard-rejected. Copy the literal `<prefix>:<id>` shown
+in `EVIDENCE_CORPUS` (usually `src:` or `block:`); for web-discovered
+sources declare in `webCitations` and reference as `web:<slug>`.
+
+### 10.4 Every `web:<slug>` token used in a premise MUST be declared in `webCitations`
+
+If you cite a web-discovered source (token of the form `web:<slug>`)
+in ANY premise's `citationToken`, you MUST add a corresponding entry
+to the top-level `webCitations` array of this output, with full
+provenance: `token` (matching the citationToken exactly), `url`,
+`title`, `snippet`. A premise citing an undeclared `web:` token is
+automatically rejected.

--- a/experiments/polarization-1/prompts/4b-rebuttal-a-round2-addendum.md
+++ b/experiments/polarization-1/prompts/4b-rebuttal-a-round2-addendum.md
@@ -51,3 +51,48 @@ Round-2 attacks should advance the dialectic, not restate round 1.
 If you cannot produce at least one substantive new attack OR
 attack-on-attack, refuse with `NO_DEFENSIBLE_ATTACKS` rather than
 filling quota.
+
+## §10 (validation traps — read before emitting)
+
+These are the validation failures most likely to reject a round-2
+response. Each is an automatic hard-rejection — there is no partial
+credit.
+
+### 10.1 `cqKey` MUST come from the *target argument's own scheme*
+
+This rule applies in **three** places, all governed identically:
+1. `cqResponses[*].cqKey` (raising or waiving a CQ on the target).
+2. `rebuttals[*].cqKey` (the rebuttal's optional annotation linking it
+   to the CQ on the *target argument* it answers).
+3. Any other top-level field whose name ends in `cqKey`.
+
+In every case, the key is bound by the **target argument's scheme**
+(the argument whose `argumentId` appears in `targetArgumentId`), NOT
+by the rebuttal's own scheme. Look up the target's
+`schemeKey` in the prompt (printed inline as
+`ARG <argumentId>  scheme=<schemeKey>` or
+`REB <argumentId>  ... scheme=<schemeKey>`) and pick a `cqKey` from
+**that scheme's catalog**, shown immediately below as
+`critical-questions for scheme=<schemeKey>:`. Do NOT use a `cqKey`
+from a different scheme, even if the keys sound semantically related.
+
+The catalogs DO use different `?`-suffix conventions across schemes —
+some keys end in `?`, some do not. Copy the key **verbatim** from the
+catalog shown in the prompt; never add or strip a trailing `?`.
+
+### 10.2 `citationToken` MUST include the prefix
+
+Every non-null `citationToken` must match `^[a-z]+:[A-Za-z0-9._-]+$`.
+A bare cuid (e.g. `cmoup2j650`) is hard-rejected. Copy the literal
+`<prefix>:<id>` shown at the top of each `EVIDENCE_CORPUS` entry —
+usually `src:` or `block:`. For web-discovered sources, declare in
+`webCitations` and reference as `web:<slug>`.
+
+### 10.3 Every `web:<slug>` token used in a premise MUST be declared in `webCitations`
+
+If you cite a web-discovered source (token of the form `web:<slug>`)
+in ANY premise's `citationToken`, you MUST add a corresponding entry
+to the top-level `webCitations` array of this output, with full
+provenance: `token` (matching the citationToken exactly), `url`,
+`title`, `snippet`. A premise citing an undeclared `web:` token is
+automatically rejected.

--- a/experiments/polarization-1/prompts/5b-rebuttal-b-round2-addendum.md
+++ b/experiments/polarization-1/prompts/5b-rebuttal-b-round2-addendum.md
@@ -48,3 +48,76 @@ Round-2 attacks should advance the dialectic, not restate round 1.
 If you cannot produce at least one substantive new attack OR
 attack-on-attack, refuse with `NO_DEFENSIBLE_ATTACKS` rather than
 filling quota.
+
+## §10 (validation traps — read before emitting)
+
+These are the validation failures most likely to reject a round-2
+response. Each is an automatic hard-rejection — there is no partial
+credit.
+
+### 10.1 `cqKey` MUST come from the *target argument's own scheme*
+
+This rule applies in **three** places, all governed identically:
+1. `cqResponses[*].cqKey` (raising or waiving a CQ on the target).
+2. `rebuttals[*].cqKey` (the rebuttal's optional annotation linking it
+   to the CQ on the *target argument* it answers).
+3. Any other top-level field whose name ends in `cqKey`.
+
+In every case, the key is bound by the **target argument's scheme**
+(the argument whose `argumentId` appears in `targetArgumentId`), NOT
+by the rebuttal's own scheme. Look up the target's
+`schemeKey` in the prompt (printed inline as
+`ARG <argumentId>  scheme=<schemeKey>` or
+`REB <argumentId>  ... scheme=<schemeKey>`) and pick a `cqKey` from
+**that scheme's catalog**, shown immediately below as
+`critical-questions for scheme=<schemeKey>:`. Do NOT use a `cqKey`
+from a different scheme, even if the keys sound semantically related.
+
+The catalogs DO use different `?`-suffix conventions across schemes —
+some keys end in `?`, some do not. Copy the key **verbatim** from the
+catalog shown in the prompt; never add or strip a trailing `?`.
+
+Concrete failures from prior runs (do NOT replicate):
+- ❌ `cqResponses[*].cqKey: "causal_strength"` on a
+  `methodological_critique` arg.
+- ❌ `rebuttals[*].cqKey: "triangulation?"` on a rebuttal whose
+  TARGET is a `cause_to_effect` arg.
+  ✅ Valid `cause_to_effect` keys: `causal_strength`,
+  `alternative_causes`, `intervening_factors`, `post_hoc`,
+  `causal_mechanism` (no trailing `?`).
+- ❌ `cqKey: "causal_mechanism?"` on a `cause_to_effect` arg
+  (stray `?`).
+- ❌ `cqKey: "alternative_causes"` or `"causal_mechanism"` on an
+  `inference_to_best_explanation` arg (wrong scheme + missing `?`).
+  ✅ Valid `inference_to_best_explanation` keys (all end in `?`):
+  `alternative_hypothesis?`, `explains_all_facts?`,
+  `explanatory_criteria?`, `evidence_artifact?`,
+  `conjunction_of_causes?`.
+- ✅ Valid `methodological_critique` keys (all end in `?`):
+  `defect_present?`, `bias_direction_known?`, `robustness_check?`,
+  `triangulation?`, `magnitude_of_bias?`, `selective_critique?`.
+
+### 10.2 `citationToken` MUST include the prefix
+
+Every non-null `citationToken` must match `^[a-z]+:[A-Za-z0-9._-]+$`.
+A bare cuid (e.g. `cmoup2j650`) is hard-rejected. Copy the literal
+`<prefix>:<id>` shown at the top of each `EVIDENCE_CORPUS` entry —
+usually `src:` or `block:`. For web-discovered sources, declare in
+`webCitations` and reference as `web:<slug>`.
+
+### 10.3 Every `web:<slug>` token used in a premise MUST be declared in `webCitations`
+
+If you cite a web-discovered source (token of the form `web:<slug>`)
+in ANY premise's `citationToken`, you MUST add a corresponding entry
+to the top-level `webCitations` array of this output, with full
+provenance: `token` (matching the citationToken exactly), `url`,
+`title`, `snippet`. A premise citing an undeclared `web:` token is
+automatically rejected.
+
+Concrete failure from a prior run (do NOT replicate):
+- ❌ Used `citationToken: "web:allen-tucker-2025"` in five rebuttal
+  premises but never added a `web:allen-tucker-2025` entry to the
+  output's top-level `webCitations` array. → hard-rejected.
+  ✅ Either add a `webCitations` entry with full provenance, or use
+  the corresponding `src:<id>` token from `EVIDENCE_CORPUS` if the
+  source is already bound there.

--- a/experiments/polarization-1/prompts/8-tracker.md
+++ b/experiments/polarization-1/prompts/8-tracker.md
@@ -19,6 +19,8 @@ The framing document attached as `FRAMING.md` is the ground truth on what is in 
 
 For each Phase-2 argument from each advocate, judge whether — given the full record of attacks, defenses, concessions, narrows, and CQ outcomes — it currently STANDS, is WEAKENED, or has FALLEN; then synthesize a top-level verdict on the central claim.
 
+> **Multi-round note (Iter-3):** When the deliberation runs in multi-round mode you will see TWO rounds of Phase 3 (round-1 attacks against Phase-2 args; round-2 attacks against either Phase-2 args or round-1 rebuttals) under `## ROUND_2_ATTACKS`, and TWO sub-rounds of Phase 4 (sub-round-a defends round-1 attacks; sub-round-b defends round-2 attacks) under `## SUB_ROUND_B_RESPONSES`. Treat all rounds as part of the full record when scoring per-argument standings. When those sections are absent the deliberation ran single-round and you should ignore them.
+
 ---
 
 ## 2. Your scope (do this / do not do that)
@@ -127,6 +129,24 @@ A single user message of the following structure:
 ## EVIDENCE_CORPUS
 
 <the bound evidence corpus, item by item.>
+
+## ROUND_2_ATTACKS  (may be absent)
+
+<Iter-3 multi-round Phase 3 produced a SECOND round of attacks. Each
+   actor (Advocate A, Advocate B, Methodologist) filed (a) NEW direct
+   attacks on opponent's Phase-2 args (`targetKind=phase2-arg`), or
+   (b) attacks-on-attacks targeting round-1 rebuttals filed against
+   the actor's own side (`targetKind=round1-rebuttal`). Format mirrors
+   the Phase-3 attack blocks above with explicit `round=2` and
+   `targetKind` annotations. Treat these as part of the full record.
+   When this section is absent the deliberation ran single-round.>
+
+## SUB_ROUND_B_RESPONSES  (may be absent)
+
+<Iter-3 multi-round Phase 4 produced a SECOND sub-round of defenses
+   responding to ROUND_2_ATTACKS above. Format mirrors the Phase-4
+   response blocks. Score these alongside sub-round-a responses when
+   judging per-argument standings.>
 
 ## YOUR_TASK
 

--- a/experiments/polarization-1/prompts/9-synthesist.md
+++ b/experiments/polarization-1/prompts/9-synthesist.md
@@ -20,6 +20,8 @@ The framing document attached as `FRAMING.md` is the ground truth on what is in 
 
 Identify the cruxes, agreements, original contributions, and open questions that the dialectic exposed — and rate the deliberation's net epistemic value relative to a careful surface-level literature review on the same central claim.
 
+> **Multi-round note (Iter-3):** When the deliberation runs in multi-round mode you will see TWO rounds of Phase 3 (round-1 attacks against Phase-2 args; round-2 attacks against either Phase-2 args or round-1 rebuttals) under `## ROUND_2_ATTACKS`, and TWO sub-rounds of Phase 4 (sub-round-a defends round-1 attacks; sub-round-b defends round-2 attacks) under `## SUB_ROUND_B_RESPONSES`. Treat all rounds as part of the full record — round-2 exchanges that resolve a round-1 crux are first-class candidates for `agreements` (kind: revealed-by-dialectic) and for `originalContributions` attributable to "joint" or to the Methodologist. When those sections are absent the deliberation ran single-round and you should ignore them.
+
 ---
 
 ## 2. Your scope (do this / do not do that)
@@ -113,6 +115,26 @@ A single user message of the following structure:
 ## EVIDENCE_CORPUS
 
 <the bound evidence corpus AND web-discovered sources materialized during Phases 2-4, with provenance.>
+
+## ROUND_2_ATTACKS  (may be absent)
+
+<Iter-3 multi-round Phase 3 produced a SECOND round of attacks. Each
+   actor (Advocate A, Advocate B, Methodologist) filed (a) NEW direct
+   attacks on opponent's Phase-2 args (`targetKind=phase2-arg`), or
+   (b) attacks-on-attacks targeting round-1 rebuttals filed against
+   the actor's own side (`targetKind=round1-rebuttal`). Format mirrors
+   the Phase-3 attack blocks above with explicit `round=2` and
+   `targetKind` annotations. Round-2 exchanges that resolve a round-1
+   crux are first-class candidates for `agreements` and `originalContributions`.
+   When this section is absent the deliberation ran single-round.>
+
+## SUB_ROUND_B_RESPONSES  (may be absent)
+
+<Iter-3 multi-round Phase 4 produced a SECOND sub-round of defenses
+   responding to ROUND_2_ATTACKS above. Format mirrors the Phase-4
+   response blocks. Cite sub-round-b response ids as `phase4b-A-r0`,
+   `phase4b-B-cq2`, etc. when discussing what the second exchange
+   accomplished.>
 
 ## YOUR_TASK
 

--- a/experiments/polarization-1/tsconfig.iter3-check.json
+++ b/experiments/polarization-1/tsconfig.iter3-check.json
@@ -1,0 +1,15 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "incremental": false
+  },
+  "include": [
+    "orchestrator/**/*.ts",
+    "../../lib/prismaclient.ts",
+    "../../next-env.d.ts"
+  ],
+  "exclude": [
+    "../../node_modules",
+    "../../.next"
+  ]
+}


### PR DESCRIPTION
Introduce Iter-3 multi-round orchestration: round-2 for Phase 3 (attacks-on-attacks + new direct attacks) and sub-round-b for Phase 4. Key changes:

- New driver module: add phase-3-round2.ts to orchestrate round-2, fetch round-1 rebuttals, render addendum blocks, and write PHASE_3_ROUND2_PARTIAL.json.
- Finalizers: merge round-2 / sub-round-b mints into Phase 3/4 complete files (and add per-actor summaries) while keeping round-1/a partials intact; add types for round/sub-round summaries and wire audit inclusion of round-2/sub-round-b expected IDs.
- CLI: add --round flag parsing and validation (phase 3 accepts 1|2, phase 4 accepts a|b) and plumb roundFilter into the run flow to allow granular resume/gating.
- Agent changes: allow optional appended system/user prompt blocks (appendedSystemPrompt/appendedUserBlock) for advocate/defense/synthesist/tracker renderers so the Iter-3 addenda can be appended verbatim; propagate appended block through rendering.
- Schema/validation tweaks: normalize citationToken fields using .nullish().transform(... ?? null) across multiple agent schemas to accept missing fields from LLMs; add guidance and soft-check behavior for cqKey validation (coerce invalid keys to null rather than hard-reject) and improved validation followup messages.
- Exports and helpers: export/load helper functions (loadCqCatalog, buildSchemeMap, buildPremiseMap, buildConclusionMap) for reuse by round-2 driver; add small utility iter3-augment and TS config for iter3 checks.
- Misc: update prompts (round-2 addenda and tracker/synthesist prompts) and wire round-2 invocation from the main Phase 3 run when iter3MultiRound is enabled and round-1 actors succeeded. Failures in round-2/sub-round-b are recorded but do not poison round-1/a partials.

These changes are gated behind cfg.iter3MultiRound and the new --round flag; default behavior remains backward-compatible when the flag is off.