### PR TITLE
Rewrite README as Isonomia; tweak AI-epistemic UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,168 +1,469 @@
-# Mesh
+# Isonomia
 
-Mesh is an experimental social platform built with **Next.js** that lets users interact in real-time rooms. Each room hosts a collaborative canvas where posts are represented as nodes. Node types range from simple text posts to livestreams and AI-generated images.
+## Overview
 
-See [`Mesh_Roadmap.md`](Mesh_Roadmap.md) for the long term product plan.
-For the step‑by‑step rollout of the Prediction Market module, check
-[`PredictionMarket_Development_Playbook.md`](PredictionMarket_Development_Playbook.md).
+Isonomia is open-source infrastructure for community gathering and structured reasoning. It unifies a general-purpose social platform with a formal deliberation engine under a single data model, so that any conversation can be upgraded to a tracked deliberation through a single reversible action, and every resulting claim, argument, and deliberation is addressable, citable, challengeable, and durable.
 
-## Current Features
+The social layer is complete as a standalone platform: a chronological feed with eight post types, profiles and follows, persistent rooms and lounges, spatial canvas environments, sheaf-based layered messaging with drifts, proposals and polls, a long-form article system with anchored comments and rhetoric overlays, and shared document libraries. The reasoning layer sits beside it and implements four families of formalism: structured argumentation via ASPIC+ grounded extensions and the Walton taxonomy of schemes with auto-generated critical questions; interactive proof theory via Ludics designs, with a generative substrate of witnessing records, articulation lattices, and fossil retractions; typed dialogue protocols with commitment stores; and a category-theoretic evidence algebra over typed evidence arrows, with closed-monoid confidence folding and culprit-set belief revision. Evidence enters through a six-stage citation resolver (arXiv, Crossref, page metadata, OpenAlex, LLM extraction, Wayback) with four-tier confidence gating.
 
-Mesh already includes the following capabilities:
+The argument graph is exposed as a machine-citable epistemic primitive. Every permalink resolves to a content-hashed, dialectically attested structured argument with end-to-end provenance, served over content-negotiated HTTP (HTML, JSON-LD, AIF, social cards, oEmbed, iframe embeds) and over a bidirectional Model Context Protocol surface with read tools for arguments, counters, stances, and citations, and write tools that flag AI authorship honestly and gate logicality on human ratification. A public search surface fuses dense and sparse retrieval through reciprocal rank fusion, attaches the strongest known counter to every result by default, and reports empty states honestly rather than collapsing them.
 
-- **Real-time canvas** powered by React Flow with nodes for text, images, video, livestreams and AI-generated content.
-- **Presence synchronization** via Supabase channels so collaborators see each other's cursors and updates instantly.
-- **Firebase authentication middleware** protecting private content.
-- **Prisma data models** defining posts, edges, rooms and extended `UserAttributes` for interests like music or movies.
-- **Global and friends feed** built on Next.js pages alongside the real-time canvas.
-- **Livechat node** providing ephemeral conversations as described in `Livechat_Node_SRS.md`.
+Three further layers ride on this substrate. Living documents (theses, briefs, peer reviews) embed claims and arguments that read live from the graph, with inspectors, attack registers, auditable confidence cards, snapshots, and fork/merge. An institutional workflow layer carries deliberation outputs into authorized bodies through a verifiable institution registry, hash-chained pathway audit logs, recommendation packets, and facilitator cockpits with real-time equity surfaces. The Plexus network connects deliberation rooms as a graph-of-graphs across five typed meta-edges, with SHA-1 fingerprinted one-hop room functors and three confidence-gating modes (logical, social, hybrid).
 
-## Project layout
+Isonomia is free, self-hostable, and ad-free. There is no behavioral tracking, no algorithmic ranking, and no engagement metric. Data ownership, privacy, and provenance are enforced by architecture rather than by policy: the social graph is portable and exportable in open formats, and the reasoning graph is content-hashed and cryptographically auditable. The system is sustained by grants, institutional partnerships, and optional managed hosting. Its thesis is that the inferential structure connecting evidence to claims to conclusions deserves first-class infrastructure, and that such infrastructure can sit beneath an interface ordinary communities will actually use.
 
-```
-app/                Next.js route handlers and pages
-  (auth)/           Public auth routes (login, register, onboarding)
-  (root)/           Authenticated application routes
-  api/              Edge API routes (LiveKit tokens, geocoding, uploads)
-components/         React components grouped by feature (nodes, modals, ui)
-lib/                Server code: Prisma models, firebase config and actions
-constants/          Static values used across the app
-public/             Static assets (icons, fonts, sounds)
-```
+---
 
-`tsconfig.json` defines the `@/` alias that maps to the project root.
+## I. Architecture
 
-The app/(root)/(standard)/ folder contains the code for the standard linear infinite scroll twitter like feed which is connected to posts 
-created in the global rooms and by friends and rooms that are subscribed to.
+### The Two Layers
 
-The app/(root)/(realtime)/ folder contains the code for the reactflow canvas rooms.
+**The Social Layer (MESH)** provides the features of a general-purpose community platform: a chronological feed with multiple post types, direct and group messaging, persistent rooms and lounges, user profiles with friend and follow systems, shared document libraries, long-form article publishing, and spatial canvas environments. This layer is complete and functional as a standalone social platform. It requires no engagement with the reasoning layer.
 
-## Setup
+**The Reasoning Layer (Isonomia)** provides formal deliberation infrastructure: argumentation schemes with auto-generated critical questions, typed dialogue moves with protocol enforcement, commitment stores, evidence management with executable citations, Ludics game-theoretic evaluation, confidence scoring, and a cross-context transport network. This layer is accessible from any point in the social layer through a single upgrade action (a discussion can become a deliberation, a comment can become a claim, an annotation can become a proposition), and the transition is reversible.
 
-To avoid missing-bucket errors when uploading audio posts, create the `realtimepostaudio` bucket in Supabase:
+### The Spectrum
 
-1. Navigate to **Storage** → **Create a new bucket**.
-2. Name it `realtimepostaudio` and set it to **public** (or adjust policies).
-3. Ensure public read access and upload permissions are allowed.
-4. Under the bucket's **Policies** tab, add an **INSERT** policy that grants the
-   `anon` role upload access (for example, use condition `auth.role() = 'anon'`).
-   Without this policy uploads fail with "new row violates row-level security policy".
+Every feature on the platform exists at a position on a continuous spectrum from informal to formal:
 
-Apply the same steps to create a `realtime_post_images` bucket if it does not already exist.
-Create another public bucket named `stall-images` for SwapMeet thumbnails.
+**Conversation.** Feed posts and comments (informal) → threaded discussion with topics (structured) → deliberation with typed moves and commitment tracking (formal).
 
-## Development
+**Arguments.** Opinions stated in prose (informal) → claims with stated reasons (structured) → arguments instantiating recognized schemes with critical questions (formal).
 
-1. Install dependencies
+**Disagreement.** Replies and reactions (informal) → specific objections with stated grounds (structured) → formal challenges creating tracked obligations to respond (formal).
 
-   ```bash
-npm install
-```
+**Evidence.** Links and anecdotes (informal) → cited sources with annotations (structured) → executable citations with four anchor types, intent labeling, and DOI resolution (formal).
 
-2. Create `.env.local` with the required environment variables (Firebase, DeepSeek, database, etc.) and copy it to `.env` so Prisma can read them:
+**Persistence.** Feed that scrolls past (informal) → searchable archive (structured) → knowledge base with live deliberation blocks and stable citable references (formal).
 
-   ```bash
-   cp .env.local .env
-   ```
-3. Start the development server
+**Cross-context.** Cross-posting (informal) → shared references (structured) → transport functors with SHA-1 fingerprinted provenance and confidence gating (formal).
 
-   ```bash
-   npm run dev
-   ```
+The transition between any two adjacent points on the spectrum is a single user action. No transition requires specialized knowledge. No transition is irreversible. Communities move along the spectrum as their needs dictate, and the platform supports every position with a consistent interface.
 
-4. Apply Prisma schema changes
+### The Knowledge Production Pipeline
 
-   ```bash
-   npx prisma db push
-   ```
+When a community's work moves from informal to formal, the platform models the trajectory as a pipeline:
 
-5. Seed the database
+Informal discussion surfaces propositions, which are workshopped into claims and structured into arguments through formal schemes. Arguments are challenged through protocol-enforced dialogue moves; the moves accrue in commitment stores, which the Ludics engine analyzes for convergence and divergence. Those determinations feed confidence scores, which in turn gate the Plexus network: room functors transport arguments across rooms with fingerprinted provenance. At every stage, the reasoning is addressable, citable, challengeable, and durable.
 
-   ```bash
-   npm run seed    # populate the Supabase database with sample users and posts
-   ```
+Not every community will traverse the full pipeline. Most will operate at the early stages most of the time. The pipeline exists in its entirety so that the infrastructure is present when the community's reasoning reaches a point of complexity that warrants it.
 
-The app runs at [http://localhost:3000](http://localhost:3000).
+---
 
-### Database Migrations
+## II. The Social Layer
 
-For data migrations beyond schema changes, use scripts in `scripts/migrations/`:
+### Feed and Posts
 
-```bash
-# Example: Backfill AIF nodes for existing dialogue moves
-npx tsx scripts/migrations/add-dialogue-aif-links.ts --dry-run
+The main feed is chronological: content appears in the order it was posted by the people and communities the user follows. There is no algorithmic ranking, no engagement optimization, no promoted content, and no "suggested" posts from accounts the user did not choose to follow.
 
-# Run migration after confirming dry-run output
-npx tsx scripts/migrations/add-dialogue-aif-links.ts
-```
+The platform supports eight post types:
 
-**Migration Script Guidelines:**
-- Always run with `--dry-run` first to preview changes
-- Create database backup before running destructive migrations
-- Use transactions for batch operations (default: 50 records per batch)
-- Log progress to `logs/migrations/` directory
-- Include rollback logic for reversible migrations
+- **Text** — plain text posts.
+- **Image** — image uploads.
+- **Audio** — audio player embed.
+- **Gallery** — multi-image carousel.
+- **Article** — long-form writing.
+- **Library** — PDF stacks and collections.
+- **Thread** — threaded discussion.
+- **Document** — PDF/document embed.
 
-**Common Migration Commands:**
-```bash
-# Dry-run preview (no changes)
-npx tsx scripts/migrations/SCRIPT_NAME.ts --dry-run
+Post creation uses a composer UI with a type selector and dedicated creation modals for each type. Posts support upvotes/downvotes, comments, sharing, timestamping, and deletion.
 
-# Production run
-npx tsx scripts/migrations/SCRIPT_NAME.ts
+### Profiles and Social
 
-# Check migration logs
-tail -f logs/migrations/SCRIPT_NAME.log
-```
+User profiles with customizable display. Friend and follow systems. Notification pipeline for social actions, messages, challenges, and deliberation events. User discovery by interest, community membership, and group affiliation.
 
-### Scripts
+The social graph is owned by the user: exportable in open formats, portable, never sold or monetized. Discovery is through search and affiliation, not through algorithmic recommendation.
 
-- `npm run build` – build for production
-- `npm run start` – start a production build
-- `npm run lint` – run ESLint
+### Rooms and Lounges
 
-## Adding new node types
+Persistent spaces for communities, groups, projects, and organizations. Rooms are the primary organizational unit of the platform: each room has its own feed, discussions, shared library, member management, and (when the community is ready) its own deliberation space.
 
-Nodes are defined in `components/nodes` and typed in `lib/reactflow/types.ts`. To add a node type, create a new React component, extend the types, and register it in the React Flow store.
+**Lounges** are lighter-weight social spaces (open or invite-only) for casual gathering, conversation, and ambient connection.
 
-### Plug-ins
+**Spatial Canvas Rooms** allow freeform arrangement of content (posts, images, documents, links, embeds) in a two-dimensional navigable space. The canvas can be collaboratively edited and annotated. Canvas rooms serve as visual workspaces, mood boards, reference collections, and spatial brainstorming environments.
 
-Drop plug-ins into the `plugins/` folder. Each plug-in exports a `descriptor` with a `type`, the React component, and optional config. Restart the dev server with `npm run dev` and the new nodes become available.
+Rooms and lounges are governed by their members. The platform provides infrastructure; the community provides governance. Moderation controls are local to the room.
 
-## Deployment
+### Messaging
 
-### CRDT Prototype
-See [docs/realtime-crdt.md](docs/realtime-crdt.md) for notes on the experimental Yjs integration used for text nodes.
+Real-time messaging with direct messages, group conversations, and room-level chat.
 
-### Workflow API
-Versioned workflows can be queried via [docs/workflows.md](docs/workflows.md).
+**Message Layers.** The messaging system implements sheaf-based access control: each conversation has explicitly defined audience layers, each with its own sharing policy that determines what is visible to whom. The stratified communication that users already practice informally (what is public, what is group-only, what is private) is handled architecturally through defined layers rather than left to the uncertainty of informal norms.
+
+**Drifts.** Side conversations that branch from any anchor message, creating a threaded sub-conversation that preserves context from the parent message without disrupting the main flow.
+
+**Proposals.** Collaborative documents embedded in conversations, with approval workflows and merge mechanics. A group member drafts a proposal; others review, comment, suggest changes, and approve or request modifications. The proposal workflow integrates with the room's governance structure.
+
+**Polls.** Inline polls with two modes: multi-choice (select one or more options) and temperature check (gauge group sentiment on a spectrum). Polls can be embedded in any conversation.
+
+**Read Receipts and Acknowledgments.** Optional and transparent. Message forwarding with access-control validation: the platform checks whether the forwarding target has permission to see the forwarded content before allowing the forward.
+
+---
+
+## III. The Reasoning Layer
+
+### The Deliberation Engine
+
+The core formal system. When a discussion is upgraded to a deliberation, the following infrastructure becomes available:
+
+**Claims** are addressable objects with stable identifiers, version history, and authorship attribution. A claim can be in one of several statuses: proposed, accepted, challenged, defended, retracted, or resolved.
+
+**Arguments** instantiate formally recognized reasoning patterns. The platform implements over sixty argumentation schemes from the Walton taxonomy: Argument from Expert Opinion, Argument from Analogy, Argument from Sign, Argument from Cause to Effect, and so on. Each scheme has a defined structure (premises, conclusion, inference rule) and auto-generated critical questions that identify the specific points where the argument could fail.
+
+**Dialogue Moves** are typed speech acts governed by protocol: Assert, Challenge, Defend, Concede, Retract, Request Clarification, and others. Each move creates specific obligations and permissions for the moves that follow it. The protocol ensures that challenges cannot be silently ignored: an unanswered challenge is itself a recorded datum.
+
+**Commitment Stores** track what each participant has asserted, conceded, retracted, and is currently committed to. The store monitors consistency: if a participant's commitments contradict each other, the contradiction is flagged; if a commitment is retracted, the downstream arguments that depended on it are identified.
+
+**Argument Chains** organize arguments into sequential or branching structures. Chains can be rendered in multiple views: list (linear sequence), thread (branching tree), canvas (spatial graph), brief (legal-style structured document), and auto-generated essay (prose narrative derived from the argument structure).
+
+**The Deliberation Dictionary** allows key terms to be formally defined, contested, and versioned within a deliberation. When a dispute turns on the meaning of a term, the term is entered in the dictionary with its proposed definition; the definition itself then becomes available for challenge and refinement through the same dialogue protocol.
+
+**ASPIC+ Evaluation.** The platform computes grounded extensions (the maximal sets of mutually consistent arguments that can be simultaneously defended) using the ASPIC+ framework for structured argumentation. This provides a formal determination of which arguments survive challenge given the current state of the deliberation.
+
+**Ludics Evaluation.** The entire deliberation can be modeled as an interactive game between Proponent and Opponent designs under Girard's Ludics semantics. Strategic landscapes can be heat-mapped to identify decisive positions (where the game is determined), turning positions (where a single move changes the outcome), and bottleneck positions (where progress depends on resolving a specific sub-argument).
+
+### Stacks and Evidence Library
+
+Document management integrated with the deliberation engine.
+
+**Document Storage.** Upload, organize, and share PDFs, papers, reports, and other source materials. Documents are stored in Stacks: themed collections that can be shared across rooms or kept private.
+
+**Executable Citations.** Four anchor types for linking evidence to arguments: page-level, passage-level, figure-level, and section-level. Each citation is executable: clicking it navigates to the exact location in the source document. Citations carry intent labels: supports, challenges, provides context, provides evidence, qualifies, or extends.
+
+**Annotation and Promotion.** Source documents can be annotated in the library. Annotations are conversations: threaded discussions attached to specific passages. Any annotation can be promoted into the deliberation graph: a marginal note becomes a proposition, which can be workshopped into a claim, which can be structured into an argument.
+
+**Knowledge Graph.** Sources, claims, arguments, and deliberations are connected in a navigable knowledge graph. Cross-deliberation source discovery identifies cases where the same document has been cited in multiple contexts, enabling communities to find related reasoning.
+
+**Auto-Citation Engine.** Any URL or DOI pasted into the citation composer is resolved automatically into a verified bibliographic record, with no manual entry of title, authors, or year.
+
+The resolver runs a waterfall in priority order:
+
+1. **arXiv API** for preprints.
+2. **Crossref** for DOIs, detected directly in the URL or surfaced by page scraping.
+3. **Highwire / Dublin Core / OpenGraph metadata** for academic pages.
+4. **OpenAlex** enrichment for abstracts and Open Access PDFs.
+5. **GPT-4o-mini extraction** as a low-confidence fallback for pages with no structured metadata.
+6. **Internet Archive (Wayback)** as a last-ditch lookup for unreachable URLs.
+
+Successful resolutions are also enriched with a stable Wayback snapshot when one exists, so the cited evidence remains addressable even if the live URL rots.
+
+Each resolution carries an explicit confidence tier: **high** (Crossref or arXiv canonical record), **medium** (page metadata only), **low** (LLM-extracted; flagged in the UI for verification), or **none** (URL kept as-is, retried after 24h). AI-authored arguments with empirical schemes are gated on having at least one non-`none` citation.
+
+Bulk paste of up to 200 URLs into the New Library modal resolves in the background and hydrates citation chips as results arrive. Per-host rate limits, circuit breakers, polite-pool compliance for Crossref and OpenAlex, and a 30-day success / 24-hour failure cache keep the engine well-behaved against external services.
+
+### The Article System
+
+A full-featured publishing system integrated with the social and reasoning layers.
+
+**Editor.** Rich text editing powered by TipTap with custom nodes (image, pull-quote, callout, KaTeX math block, code, embed, deliberation block) and a slash-command menu for fast block insertion. An advanced toolbar exposes the full formatting surface; paste sanitization safely handles content from external sources; a 20,000-character limit is tracked live.
+
+**Templates.** Three article templates govern layout and reader chrome: **Standard** (clean minimal layout for most articles), **Feature** (magazine-style with hero image and large title), and **Interview** (Q&A format with speaker attribution).
+
+**Publishing Workflow.** Draft → Published with metadata generation, autosave, revision history with version comparison, and a full Articles dashboard supporting search, filter, trash, and CRUD. Hero-image upload with cropping. Articles can be published to user profiles, rooms, or the platform's public knowledge base; published articles surface in the platform feed and render through template-specific reader layouts with cards, preview modals, and social actions (like, save, share).
+
+**Anchored Comments.** Comment threads attach to specific passages in the article, with collision resolution when multiple comment threads target overlapping text ranges. A sidebar comment rail surfaces all threads in document order. Readers engage with the article at the level of the sentence rather than at the level of the page.
+
+**Rhetoric Analysis Overlays.** Visual overlays that surface the article's persuasive strategies (hedges, intensifiers, absolutes, analogies, metaphors), color-coded inline so readers and authors can see the rhetorical architecture beneath the prose alongside claim density, evidence distribution, and argument structure indicators.
+
+**Proposition Composer.** Annotations and comments can be promoted directly into the deliberation engine through a composition interface that guides the user from informal observation to structured claim. The deliberation panel embeds the full deliberation system inside the article reader.
+
+### The Discussion System
+
+The lightweight informal layer: forums, topic-based conversations, and loose exchanges. The discussion system is the most common entry point for community interaction and the starting point of the knowledge production pipeline.
+
+**Upgrade Paths.** Any discussion can be upgraded to a structured deliberation when the conversation warrants it. The upgrade preserves the discussion's content and participants while adding the formal infrastructure of the deliberation engine. The upgrade is a single action. It does not require the participants to have prior experience with the formal tools.
+
+### The Knowledge Base
+
+The durable, public-facing output of the reasoning process.
+
+**Publishable Pages.** Knowledge base pages combine prose narrative with live deliberation blocks: embedded views of argument graphs, claim statuses, confidence scores, and evidence summaries that reflect the current state of the underlying deliberation. The pages are stable and citable: each has a permanent URL and a versioned reference.
+
+**Live Deliberation Blocks.** Embedded components that render the current state of a deliberation within a knowledge base page. If the underlying deliberation is updated (new evidence, new challenges, revised confidence scores), the blocks update accordingly. The knowledge base is not a snapshot. It is a live view.
+
+### The Plexus Network
+
+The cross-context layer that connects deliberation rooms into a network.
+
+**Graph-of-Graphs.** The Plexus network visualizes the relationships between deliberation rooms as a meta-graph. Rooms are nodes. The connections between them are typed edges.
+
+**Five Meta-Edge Types:**
+
+1. **Shared Claims** — two rooms contain arguments about the same claim.
+2. **Shared Evidence** — two rooms cite the same source material.
+3. **Transported Arguments** — an argument from one room has been imported into another.
+4. **Cross-References** — a deliberation in one room explicitly references a determination in another.
+5. **Institutional Links** — rooms operated by the same organization or community are structurally connected.
+
+**Room Functors.** Arguments are transported between rooms through functors that preserve inferential structure. When an argument is imported, it carries its provenance (its origin room, its challenge history, its confidence score, its evidence links) with SHA-1 fingerprinted integrity. The receiving room can verify that the imported argument has not been altered in transit.
+
+**Confidence Gating.** Each room can set a confidence threshold for incoming arguments: only arguments that meet the threshold (based on their evaluation in the source room) are eligible for import. Three scoring modes:
+
+- **Logical** — based on the argument's formal structure (ASPIC+ grounded extension status).
+- **Social** — based on community assessment (upvotes, endorsements, expert ratings).
+- **Hybrid** — a weighted combination of logical and social scores.
+
+**Visualization.** The Plexus network can be viewed as a graph (node-link diagram), a board (kanban-style grouped by meta-edge type), or a matrix (adjacency matrix showing connection density between rooms).
+
+---
+
+## IV. Embeddable Argument Widgets and the AI-Epistemic Primitive
+
+Arguments and claims produced on the platform are exposed beyond the platform through a layered set of distribution surfaces. The same primitive that powers a Reddit unfurl also powers an LLM citation, a Google fact-check card, and a researcher's BibTeX entry.
+
+### Permalinks and Embeds
+
+**Permalink Pages.** Every claim and every argument resolves to a permanent URL that renders a standalone public page (no account required) showing the conclusion, premises, scheme, evidence list, confidence score, challenge history, and current standing. This is the public face of a structured argument.
+
+**Social Cards.** When an Isonomia link is shared on external platforms (Twitter, Reddit, Slack, Hacker News, Discord), it unfurls as a rich preview card showing the argument's structure: conclusion, premise count, evidence count, confidence score, scheme, and challenge status.
+
+**Iframe Embeds.** Any argument or claim can be embedded in an external website through a standard iframe tag. The embed renders as an interactive card that can be expanded, navigated, and (if the viewer has an account) challenged directly without leaving the host page.
+
+**oEmbed Discovery.** Standard oEmbed protocol support for automatic embed rendering by platforms and content management systems that consume oEmbed.
+
+**Structured Data.** Every permalink emits structured linked-data metadata so arguments are discoverable as fact-check cards in search engines and ingestible by any consumer of standards-grounded data.
+
+### Creation and Sharing
+
+**Share Modals.** Tabbed share surfaces (link, embed, markdown, plain text) with a live preview of the social card, accessible from the action row of every argument and claim.
+
+**Quick Argument Builder.** A lightweight composer for constructing a structured argument (claim, premises, evidence) and generating a shareable link in under sixty seconds. It is the on-ramp that turns a person with an argument into a person with a *structured* argument. A user's first quick argument automatically creates a personal deliberation, so every individually authored argument still lives inside the deliberation infrastructure with no setup overhead. The same write primitive is exposed to model-context-protocol agents as `propose_structured_argument`; an agent that omits `deliberationId` lands in the caller's personal deliberation just as a human user would, so the human-facing builder and the agent-facing tool are two surfaces of one substrate.
+
+**URL Unfurl.** A safe URL metadata extractor (title, favicon, site name) used by the builder to enrich evidence URLs.
+
+### Browser Extension
+
+A browser extension ships across Chrome, Firefox, and Safari:
+
+- **Context menu.** Select text on any webpage, right-click, and create an Isonomia argument pre-populated with the selection, page URL, and page title.
+- **Inline previews.** A content script detects Isonomia argument and claim links on Reddit, Twitter/X, and Hacker News and injects rich inline previews showing claim text, scheme, confidence, evidence count, and author.
+- **Popup composer.** A compact Quick Argument Builder embedded in the extension popup for one-click creation without leaving the page, plus a list of the user's recent arguments.
+
+### Deliberation-Scope Embeds
+
+The embed primitive lifts from a single argument to an entire deliberation: a state card and a contested-frontier lane suitable for embedding inside articles, briefs, or third-party sites, backed by the deliberation-scope readouts described below.
+
+### Public Argument Search and Discovery
+
+Isonomia exposes the public corpus as a crawlable, machine-citable search surface ("Google for arguments") reachable identically by humans, search engines, and language-model agents.
+
+**Consumer search page.** A server-rendered search page renders ranked results as substrate-first cards: a standing badge (tested-survived, tested-attacked, and so on), a scheme chip, a dialectical-fitness chip, a hybrid-retrieval chip, an attestation link, a deep link to counter-argument discovery, and a lexical-coverage indicator. The same URL serves humans and crawlers, with alternate links exposing JSON and JSON-LD representations of the same results. Empty states are reported honestly: no query intent, no results, an against-mode query with no counters on file, and API failure are surfaced as four distinct conditions rather than collapsed into a generic "nothing found."
+
+**Hybrid retrieval.** A single search endpoint is the source of truth, called by the page, by the model context protocol surface, and by external integrations alike. Hybrid mode fuses dense vector cosine similarity with sparse lexical recall through reciprocal rank fusion; lexical mode is deterministic substring matching; vector mode is purely semantic. Every result carries an auditable hybrid block exposing its dense and sparse ranks and distances, so the ranking is inspectable rather than opaque.
+
+**Quality filters.** Filters narrow results to dialectically tested, evidence-bearing arguments: tested-only, a minimum threshold of critical-question satisfaction, a minimum count of provenance-anchored evidence, and an ISO date range. The filters surface in the page UI as a collapsible quality-filters panel and as parameters in both the public API and the model context protocol tools.
+
+**Counter-citation discovery.** Each result can be enriched with the most-engaged structural contester to its conclusion: rebut and undercut edges, plus conflict applications, with self-counters excluded. When nothing is on file, the result is honestly null. The lookup is a bounded single-fanout across the top-K results (one edge query, one conflict-application query, one argument fetch, no N+1), so the consumer page opts in by default and every visible card displays either the strongest known counter or "none on file." There is no one-sided ranking.
+
+**Stance retrieval.** A claim-stances endpoint returns "for" and "against" arguments in a single call: the killer query for any debate UI. "For" arguments conclude to the claim; "against" arguments are structural contesters of it. Both lists carry the full search-result shape (and can carry the strongest-counter enrichment when requested), so any client that understands a search result already understands a stance result. A missing claim is reported as a 404 with an explicit error code; an empty side is reported as an empty list, not as absence. The claim page renders the dual-column dialectical view inline.
+
+**SEO surface.** A sitemap covers argument and claim permalinks together with canonical scheme search topics; a robots policy allows the public discovery surfaces while disallowing internal admin, cron, and authentication routes. Search-result preview cards generate live result counts together with sort and mode chips, so a social-platform unfurl shows the actual result count for the query rather than a generic placeholder.
+
+### The AI-Epistemic Primitive
+
+Layered on top of the embeddable surface is the **AI-Epistemic Primitive**: every permalink is treated as a machine-citable, dialectically attested, content-hashed epistemic artifact, exposed over content-negotiated HTTP and over a model context protocol. The primitive is organized around seven commitments.
+
+**Machine-citable structured arguments.** Every permalink resolves to a structured argument subgraph (claim, premises, scheme, evidence), not just prose. Content negotiation returns the same artifact as HTML, structured data, a formal argument graph, or a compact citation envelope, depending on what the requester asks for.
+
+**Verifiable provenance, end-to-end.** At the argument level, a content hash is computed over the canonical argument, and every artifact is reachable at an immutable, hash-anchored URL. At the evidence level, server-side fetch hashes, archive-snapshot URLs, fetch timestamps, and content types are recorded. Per-premise evidence is attested through the same pipeline as conclusion-level evidence: each premise's `EvidenceLink` rows carry their own fetch hash and archive snapshot, so per-source provenance maps cleanly onto per-premise standing rather than being collapsed onto the conclusion. At the premise level, counters surface unattested premises honestly rather than concealing them.
+
+**Dialectical honesty by construction.** Citations ship with their opposition attached. The strongest known objection is surfaced alongside the citation by default, and the public search surface exposes the symmetric flag so every search result carries either its strongest known counter or an honest null when none is on file. Standing is reported as a classified state (untested-default, untested-supported, tested-attacked, tested-undermined, tested-survived) rather than as an opaque float. Counterargument lookup, the search surface's against mode, and the strongest-counter helper all exclude same-conclusion self-counters by contract. Result rankings can be re-sorted by tested-and-survived (dialectical-fitness) status, and a claim-stances endpoint together with its matching model-context tool returns the dual for-and-against view in a single call. Authorship is honest at the row level: every argument minted by a model-context-protocol agent is flagged `authorKind: "AI"` with `aiProvenance` recording the originating tool (`propose_argument`, `propose_structured_argument`, `propose_warrant`), so consumers can distinguish AI-authored, human-authored, and ratified-AI material wherever the artifact is cited.
+
+**Standards-grounded interoperability.** The system speaks the established formats of the argumentation and web-data communities: the Argument Interchange Format, structured linked data, fact-check schema, and a model context protocol surface. There are no bespoke serializations.
+
+The model-context surface is bidirectional.
+
+*Read side.* It exposes deliberation-scope readouts, argument lookup, counterargument discovery, claim stances, and citation resolution itself (`resolve_citation` and `resolve_citations_bulk`), so an external agent can pre-mint verified `Source` records (with full waterfall provenance and Wayback fallback) before proposing arguments, rather than handing the platform unchecked URL strings.
+
+*Write side.* It exposes `propose_argument` (bare assertion), `propose_structured_argument` (explicit premises + scheme + per-premise evidence, with a four-code warning surface for inferred schemes, deduped premises, merged evidence, and missing required slots), `propose_warrant` (attach an inference-license warrant to an existing argument), and `list_schemes` (browse the Walton catalog before picking a scheme key).
+
+*Orientation.* Every session begins with a single `get_orientation` call that returns a versioned, hash-cached contract (`ORIENTATION_VERSION`) covering the ontology, write-tool selection rules, and the recipes for moving between read and write. An agent caches the platform's epistemic contract once and re-uses it across sessions rather than re-discovering it.
+
+**Shippable on existing infrastructure.** The primitive is built directly on the production argument graph, scheme catalog, and permalinks. There is no second source of truth and no migration: what users see is what citers cite.
+
+**Deliberation-scope readiness and honesty.** Above the per-argument primitive sits a deliberation-scope substrate that refuses to summarize prematurely:
+
+- A **fingerprint** capturing counts, depth, critical-question coverage, and the AI-versus-human extraction split.
+- A **contested frontier** surfacing unanswered undercuts, undermines, critical questions, and terminal leaves: the live edge of the deliberation.
+- A **missing-move report** with per-argument and rollup views, plus a **chain-exposure** projection identifying the weakest link in any inference chain.
+- A **synthetic readout** that emits an explicit honesty line and a refusal surface (with references to real graph elements) when the deliberation is too immature to summarize. The readout also emits `writingConstraints`, a pre-rendered compliance contract consumable by humans and agents alike: `mustInclude.honestyLine` (verbatim caveat keyed on the deliberation's content hash), `mustNotAssert[]` (conclusions the graph will not currently license), `shouldHedge[]` (per-argument hedge phrasings keyed to standing), and `framing.stage` (articulation, deliberation, or matured). Compliance is contract-as-data rather than free-form guidance.
+- **AI-engagement telemetry** that distinguishes genuine reasoning from articulation-only contribution.
+- **Cross-deliberation aggregation** with a consistent IN / OUT / contested / undecided rule.
+
+**Typed categorical algebra, deterministic and graph-derived.** A typed implementation of an evidential category of claims is exposed verbatim to language-model agents. The structure is straightforward: each claim has a typed evidence arrow, each derivation carries its assumption set, and a closed monoid (minimum, product, or Dempster-Shafer) folds confidence over the arrow. Culprit-set computation answers the canonical question, *what would I have to retract to reject this claim?*, with a deterministic ranking.
+
+Model-context tools give a language-model client graph-derived answers with no language model in the loop, and a contract test asserts bit-identical output across repeated invocations on the same fixture.
+
+Three contracts the surface honors:
+
+- **Strict logicality.** A derivation counts as logical only when every dependent assumption is accepted *and* the backing argument is human-authored (or AI- or hybrid-authored and subsequently ratified).
+- **AI-flagged warrants are non-logical until ratified.** A "propose warrant" action materializes an internal-hom warrant as an AI-authored argument together with a proposed assumption use; the resulting derivation never lifts to logical until a human ratifies the warrant text.
+- **One-hop cross-room transport.** Transport snapshots written by the transport-aggregator carry one-hop transport only, by contract: chained transport across three or more rooms is intentionally unsupported, so the aggregated band of *local*, *imported*, and *total* counts for any claim remains auditable to a single source room.
+
+**Substrate-level dialectical event stream.** Beneath the per-argument and per-deliberation surfaces sits a generative Ludics substrate that exposes the dialectical mechanics directly. Witnessing records bind dialogue acts to loci in a design; an articulation lattice exposes the cone structure of incarnations, with per-cone minima forming an antichain; a fossil record captures retractions with back-pointers to the loci they vacated; and a briefing-fingerprint API detects material change through five typed rules.
+
+Every binding act on the substrate (commit, reveal, contest, retract) is gated by a deliberation-scoped token (the scope is the deliberation itself; there is no tenant axis) and rate-limited on the compound key of deliberation, participant, and IP. The four axioms surface as four event types carried on a single envelope.
+
+The bus is the sole emit channel. External systems such as the embeddable widget, the model-context surface, third-party dashboards can use it to observe what a deliberation is doing in real time without polling the read model, and to do so against the same dialectical primitives the engine itself manipulates.
+
+Taken together, these surfaces let an external system — human or model — cite a unit rather than a webpage, prove what it cited and when, and surface the strongest known objection alongside the citation.
+
+---
+
+## V. Living Documents — Theses, Briefs, and Peer Review
+
+Isonomia treats long-form scholarly and policy outputs as **living documents** whose embedded claims, arguments, propositions, and citations remain bound to the live argument graph. The same infrastructure powers research theses, policy briefs, and academic peer reviews.
+
+### Living Thesis
+
+A thesis is a rich text document whose embedded claim, argument, proposition, and citation elements read live state from the deliberation graph rather than holding a frozen copy of it. Several capabilities sit on top of that live binding.
+
+**Live Binding.** Every embedded element (a claim cited in the introduction, an argument quoted in a footnote, a proposition lifted from a marginal annotation) reads its support count, attack count, evidence count, and current standing label from the deliberation in real time. The thesis updates as the underlying reasoning updates.
+
+**Inspector.** A single right-side drawer opens for any embedded element and shows its full lineage: where it came from, the evidence supporting it, the attacks against it, and the satisfied and unsatisfied critical questions associated with it.
+
+**Attack Register.** A sticky panel lists every attack on every thesis element, grouped by status (undefended, defended, conceded) and filterable and sortable by attack type: undercuts, undermines, rebuts. Authors and readers can see at a glance where the document is exposed and where it has held.
+
+**Confidence.** Per-prong and per-thesis confidence scores are computed from explicit, weighted inputs. A hover-card on every confidence badge discloses each input, its weight, and its contribution to the total: the score is auditable rather than opaque.
+
+**Snapshots.** A reader or a citer can capture a point-in-time freeze of the thesis. Snapshots render as stable views even as the underlying graph evolves, and any snapshot can be diffed against any other snapshot or against the current live state.
+
+**Traversals.** Deep links can target either an internal thesis element or a global claim identifier, resolving cleanly across documents. Every lineage row in the inspector is a clickable navigation, and "used in" backlinks expose where any element appears across other theses.
+
+**Hardening.** Read and write permissions are enforced at the element level; elements the viewer cannot see are redacted from backlinks and inspector views rather than disclosed by reference.
+
+### Living Peer Review
+
+The peer review system uses the same dialogue moves as deliberations and runs across three coordinated capabilities.
+
+**Review structure.** Configurable review templates define criteria sets and a multi-phase structure (for example, initial review, author response, revision). Reviews support blind and open modes and discriminate among target types: paper, preprint, thesis, and grant. Reviewer assignments carry roles, accept/decline workflows, and reviewer commitments scoped to specific issues with resolution tracking. Author responses flow as structured dialogue moves (concede, rebut, clarify, revise), each linked to the commitment it addresses. The review lifecycle advances through phases with editorial decisions (accept, revise, reject), progress and timeline visualization, and per-phase outcomes.
+
+**Argumentation-based reputation.** Scholarly reputation is derived from argumentation outcomes rather than from citation counts or journal prestige. Contribution tracking records distinct contribution types together with quality multipliers, verification status, and deliberation scope. Scholar statistics aggregate defense success rate, attack precision, consensus rate, and downstream citation count. Topic expertise runs on a graded scale from novice to authority, with per-topic scoring, expert discovery by topic area, and a reputation leaderboard. Reviewer recognition tracks completion and quality metrics, timeliness, blocking-concern resolution rate, and topic specializations.
+
+**Academic credit integration.** ORCID integration provides an OAuth connection flow, push of works to ORCID profiles, and auto-sync of eligible contributions. CV export emits structured data, BibTeX, LaTeX source, and CSV. Institutional reports aggregate faculty contribution breakdowns at department and institution level with impact metrics and period-over-period comparison.
+
+### Fork and Merge
+
+Deliberations and theses can be forked (creating a parallel version that explores an alternative line of argument) and merged when the parallel lines converge. The model is borrowed from version control and applied to reasoning itself.
+
+---
+
+## VI. Institutional Workflow Layer — Pathways and Facilitation
+
+Where the deliberation engine handles the *production* of structured reasoning, the institutional workflow layer handles its *transmission to, and reception by,* the bodies authorized to act on it. Two complementary subsystems live here.
+
+### Pathways
+
+Pathways move a deliberation's outputs into the formal record of an institution and track the institution's response.
+
+- **Institution Registry.** A verifiable directory of agencies, councils, NGOs, and their members. Institutions are first-class platform objects with member rosters and authority scopes; they appear on the Plexus network graph alongside rooms.
+- **Role Gating and Public Redaction.** Uniform admin, host, and facilitator gates, with public redaction rules so the audit log is publishable without leaking participant identities.
+- **Open Pathway.** A deliberation's recommendations are forwarded to a registered institution as a packet with a defined channel and target.
+- **Hash-Chained Audit Log.** Every pathway action is recorded as an event in a tamper-evident chain anchored at a draft-opened genesis event.
+- **Recommendation Packets.** Versioned, freezable bundles of claims, arguments, cards, and notes: the unit of submission to an institution.
+- **Submission Channels.** Packets can be sent in-platform, by email, by API, or as manually logged external submissions; the channel and its hints are recorded.
+- **Institutional Responses.** Institutions reply with per-item dispositions, with coverage tracking that surfaces which packet items remain unaddressed.
+- **Plexus Visualization.** Pathway connections render on the cross-context Plexus graph, so a deliberation's downstream institutional fate is visible at a glance.
+
+### Facilitation
+
+Facilitation provides the live operational surface for facilitators running structured deliberations, with audit trails for the work the facilitator does.
+
+- **Cockpit and Question Authoring.** A facilitator-only cockpit organizes the live session: the active facilitation question, the parent context, session status, and quick-action controls. Facilitation questions can be authored, scoped to specific arguments or claims, and rotated through the session.
+- **Equity Surface.** A real-time equity panel tracks who has spoken, who has not, and how participation distributes across constituencies. Facilitators can see when intervention is warranted before participation imbalances calcify.
+- **Timeline and Interventions.** A session timeline records every facilitator intervention as a typed, attributed event (redirect off-topic, surface minority view, reframe) as part of the audit log.
+- **Handoff.** A formal handoff flow when one facilitator passes control to another mid-session, preserving session state and acknowledging context transfer.
+- **Pending Banner and Report.** A pending-action banner surfaces queued moderator decisions; an end-of-session report compiles the timeline, equity metrics, and interventions for sharing with participants and institutional sponsors.
+- **Analytics and Canonical Export.** Aggregate analytics readouts and a canonical session export are available for inspection, archival, and external review.
+
+Facilitation is opt-in. Most rooms operate without it. It exists for the deliberations whose stakes warrant a trained facilitator and an auditable record of facilitator behavior.
+
+---
+
+## VII. Theoretical Foundations
+
+The platform's reasoning layer is grounded in formally studied frameworks:
+
+**Formal Argumentation Theory.** ASPIC+ (Prakken, 2010; Modgil & Prakken, 2018) provides the framework for structured argumentation with grounded extension computation. The Walton taxonomy (Walton, Reed & Macagno, 2008) provides over sixty argumentation schemes with associated critical questions. The Argument Interchange Format (AIF) (Chesñevar et al., 2006; Reed et al., 2010) provides the ontology for interoperable argument representation and JSON-LD export.
+
+**Interactive Proof Theory.** Ludics (Girard, 2001) models deliberation as a game between Proponent and Opponent strategies, with convergence and divergence computed through the interaction of designs. The Ludics layer provides game-theoretic evaluation independent of the ASPIC+ evaluation, offering a complementary perspective on which arguments are strategically decisive. Beneath that evaluation surface sits a generative substrate that exposes the dialectical primitives directly; witnessing records bound to loci, an articulation lattice with antichain minima, and a fossil record for retractions.
+
+**Evidence Theory.** Dempster-Shafer theory handles the combination and aggregation of evidence from multiple sources with varying degrees of reliability, producing belief functions that represent the state of evidential support more precisely than binary true/false or simple probability.
+
+**Category-Theoretic Models.** Ambler's compositional semantics of evidence (evidential categories, SLat-enriched categories with symmetric monoidal structure) provides the mathematical foundation for the evidence algebra and for the Plexus transport mechanism. Morphisms are evidence arrows. The tensor product (⊗) conjoins evidence. The join operation (∨) aggregates within hom-sets. Selected maps (simple ∧ entire) provide the cartesian subcategory where projection and pairing laws hold exactly: the mathematically safe fragment for operations like "duplicate premise" and "project reason." A typed evidence-arrow implementation carries per-derivation assumption sets, drives a strict logicality predicate, and exposes belief-revision (culprit-set) computation and a closed monoid registry to both the in-app pipeline and the model-context protocol surface.
+
+**Formal Dialogue Systems.** The dialogue protocol draws on the tradition of formal dialogue games (Hamblin, 1970; Walton & Krabbe, 1995), implementing typed speech acts with defined obligations and permissions.
+
+These foundations are fully implemented and operational. They are also fully invisible to any user who does not seek them out. The platform's formal complexity is the basis of its interface simplicity: it is precisely the systems that enforce argumentative rigor behind the interface that allow the interface itself to present structured reasoning through clear, guided forms, without requiring the user to learn the underlying theory.
+
+---
+
+## VIII. Technical Stack
+
+- **Framework:** Next.js
+- **Database:** Prisma ORM with Supabase (PostgreSQL)
+- **Real-time:** Supabase broadcast for messaging, presence, and live updates
+- **State Management:** Zustand
+- **Rich Text:** TipTap with custom nodes (MathBlock, MathInline, deliberation embeds)
+- **Graph Visualization:** D3, React Flow with Dagre layout
+- **Mathematical Typesetting:** KaTeX
+- **Design Language:** Consistent, restrained, and legible across all subsystems. The social layer uses warmer tones and softer transitions. The reasoning layer uses cream backgrounds and gold accents with institutional clarity. Both share a unified typography and component system.
+
+---
+
+## IX. Data Ownership and Privacy
+
+- All data is owned by the user and the community that produced it.
+- Data is exportable at any time in open formats (JSON, AIF, BibTeX, Markdown, PDF).
+- The platform collects only what users post. No behavioral tracking, no engagement analytics, no shadow profiles, no data broker relationships.
+- Users can contribute anonymously. The platform supports pseudonymous and anonymous participation with configurable attribution policies per room.
+- The platform is self-hostable. Organizations that require full control over their data can deploy the platform on their own infrastructure using the open-source codebase.
+- The architecture is designed with the understanding that many of the communities the platform serves have historical and ongoing reasons to distrust data collection. The privacy commitments are enforced by architecture, not by policy.
+
+---
+
+## X. Distribution and Governance
+
+**Open Source.** The entire codebase is public. Contributions are welcome. The platform's architecture, including the formal argumentation engine, is available for inspection, audit, and extension by any party.
+
+**Sustainability Model.** The platform is free for all users. Sustainability is pursued through grants (NEH, NSF, foundation funding), institutional partnerships (universities, policy organizations, civic institutions), and optional hosted enterprise services for organizations that require managed infrastructure with SLA guarantees.
+
+---
+
+## XI. Applications
+
+**Community organizations** use the social layer for ongoing community engagement (forums, rooms, messaging, shared documents) and the reasoning layer when participatory input needs structure: planning processes, budget deliberations, program evaluations, needs assessments. The platform preserves the reasoning behind community decisions, not just the decisions themselves.
+
+**Research teams and reading groups** use the social layer for discussion and shared libraries. When a research question crystallizes or an interpretive disagreement becomes substantive, the reasoning layer provides infrastructure for structured synthesis. Evidence is linked to claims at the source level. The synthesis is collaborative, living, and navigable as a graph.
+
+**Student organizations and governance bodies** use the social layer for coordination and the reasoning layer for decisions that affect constituents. The reasoning persists after the officers graduate.
+
+**Open-source projects** use the social layer for community building and the reasoning layer for architectural decisions and RFCs. Technical reasoning is structured, challenged, and preserved beyond the contributor who made it.
+
+**Civic media and public interest journalism** embed argument maps into articles, providing readers with navigable representations of public debates that update as the debate evolves.
+
+**Policy organizations and regulated industries** use the reasoning layer for structured analysis with auditable reasoning chains. The audit trail is generated by the process, not reconstructed after the fact.
+
+**Academic publication and peer review** uses the Living Peer Review system for public, structured, credited review processes that improve on the opacity and inefficiency of traditional anonymous review.
+
+**Individuals and informal communities** use the social layer as a social platform (posting, sharing, discussing, connecting) with the knowledge that the reasoning layer is available when they need it and invisible when they don't.
+
+---
+
+## XII. The Proposition
+
+Social platforms circulate content. The circulation is optimized for engagement: the architecture selects for what produces reaction and selects against what requires sustained attention. The result is discourse in which reasoning — the inferential structure that connects evidence to claims to conclusions — is structurally unsupported. The reasoning still happens. The platforms simply do not preserve it.
+
+Isonomia is designed from first principles to support the full range of what communities do when they gather: from casual conversation to formal deliberation, from sharing a photograph to defending a thesis, from the ambient connection of a feed to the tracked obligation of a challenge-response protocol.
+
+The social layer provides the space. The reasoning layer provides the structure. The spectrum between them is continuous. The community moves along the spectrum as its needs dictate. The platform holds everything the community produces — the posts and the proofs, the comments and the commitments, the shared links and the shared reasoning — in a single architecture where nothing is lost.
+
+Every claim has a stable identifier. Every argument follows a recognized scheme. Every challenge creates an obligation. Every piece of evidence links to its source. Every determination is provisional, subject to better evidence and stronger argument. Every community owns its data. The code is open. The infrastructure is public.
+
+The feed is chronological. The deliberation is formal. The space between them is yours.
 
 
-## Faster setup in Codex
-See `Codex_Environment_Guide.md` for tips on caching dependencies and using a Docker image so the development server starts quickly.
+*Isonomia is free, open-source, and community funded.*
 
-### Embedding Service
-See services/embedding/README.md for setup.
-
-### Discovery Candidates API
-`GET /api/v2/discovery/candidates?k=50` returns the top‑K users with similar
-taste. Authentication via Supabase session is required. Results are cached in
-Redis for `CANDIDATE_CACHE_TTL` seconds.
-
-## Portfolio Builder shortcuts
-
-- Cmd/Ctrl+Z = Undo
-- Cmd/Ctrl+Shift+Z or Ctrl+Y = Redo
-- Draft autosaves locally every 0.8 s; clear via "New / Clear" in menu
-
-## Roadmap Highlights
-
-The documents in this repo outline the path toward a public launch. Key themes include:
-
-- **Foundation & Refinement** – multi‑factor auth, role‑based room permissions and a hardened middleware layer.
-- **Social Discovery Engine** – expanded user attributes and a recommendation API combining embeddings with collaborative filtering.
-- **Advanced Node Workflows** – instruction nodes, a state machine builder and plug‑in architecture for custom node types.
-- **Real-Time Collaboration Enhancements** – presence labels, ephemeral chat and CRDT conflict resolution.
-- **Production Hardening** – CI pipelines, performance monitoring and security reviews.
-
-See `Mesh_Roadmap.md`, `SocialDiscoverEngine_V2_SRS.md`, `Flowstate_v2_SRS.md` and other SRS files for full details.
+*MESH · Isonomia*

--- a/app/test/ai-epistemic/page.tsx
+++ b/app/test/ai-epistemic/page.tsx
@@ -56,6 +56,7 @@ import {
   Waypoints,
   Workflow,
   type LucideIcon,
+  Triangle,
 } from "lucide-react";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { TooltipProvider } from "@/components/ui/tooltip";
@@ -88,6 +89,8 @@ interface PillarCard {
   body: string;
   status: "shipped" | "partial" | "planned";
   evidence: string[];
+  color: string;
+  iconColor: string;
 }
 
 const PILLARS: PillarCard[] = [
@@ -97,8 +100,10 @@ const PILLARS: PillarCard[] = [
     label: "Pillar 1",
     title: "Machine-citable structured arguments",
     body:
-      "Every permalink resolves to a structured AIF subgraph (claim, premises, scheme, evidence) — not just prose. LLMs cite a unit, not a webpage.",
+      "Every permalink resolves to a structured AIF subgraph — claim, premises, scheme, evidence — not just prose. LLMs cite a unit, not a webpage.",
     status: "shipped",
+    color: "from-sky-500/10 to-blue-500/15",
+    iconColor: "text-sky-600",
     evidence: [
       "Content negotiation: /a/{id} returns HTML, JSON-LD, AIF, or attestation",
       "?format=jsonld emits AIF + Schema.org composite",
@@ -111,8 +116,10 @@ const PILLARS: PillarCard[] = [
     label: "Pillar 2",
     title: "Verifiable provenance, end-to-end",
     body:
-      "Argument-level: sha256 over the canonical AIF subgraph plus an immutable @hash permalink. Evidence-level: server-side fetch hash + archive.org snapshot. Premise-level: counters surface unattested premises honestly.",
+      "Three layers of evidence: a sha256 over the canonical AIF subgraph; a server-side fetch hash plus archive.org snapshot per source; and a counter that surfaces unattested premises honestly.",
     status: "shipped",
+    color: "from-violet-500/10 to-purple-500/15",
+    iconColor: "text-violet-600",
     evidence: [
       "Argument contentHash = sha256 over canonical(claim, premises, scheme, evidence)",
       "Immutable URL: /a/{shortCode}@{hash}",
@@ -126,8 +133,10 @@ const PILLARS: PillarCard[] = [
     label: "Pillar 3",
     title: "Dialectical honesty by construction",
     body:
-      "The citation primitive ships with its opposition attached. Counter-arguments are surfaced inline, standing scores are classified (not raw floats), and an empty result is honestly empty rather than a false positive.",
+      "The citation ships with its opposition attached. Counter-arguments are inline, standing scores are classified (not raw floats), and empty results are honestly empty.",
     status: "shipped",
+    color: "from-rose-500/10 to-pink-500/15",
+    iconColor: "text-rose-600",
     evidence: [
       "cite_argument.strongestObjection (default: on)",
       "standingState: untested-default | tested-attacked | tested-survived | …",
@@ -141,23 +150,27 @@ const PILLARS: PillarCard[] = [
     label: "Pillar 4",
     title: "Standards-grounded interoperability",
     body:
-      "AIF + JSON-LD + Schema.org + MCP. No bespoke formats. Any client that speaks one of these can consume Isonomia today.",
+      "AIF, JSON-LD, Schema.org, MCP. No bespoke formats — any client that speaks one of these can consume Isonomia today.",
     status: "shipped",
+    color: "from-emerald-500/10 to-teal-500/15",
+    iconColor: "text-emerald-600",
     evidence: [
       "AIF context with aif:/as:/cq: prefixes",
       "Schema.org composite: Claim + ScholarlyArticle + ClaimReview",
       "MCP server (6 tools, stdio)",
-      "OpenAPI 3.1 spec + Scalar docs at /api/v3/docs (B.3)",
+      "OpenAPI 3.1 spec + Scalar docs at /api/v3/docs",
     ],
   },
   {
     id: "shippable",
-    icon: Sparkles,
+    icon: Triangle,
     label: "Pillar 5",
     title: "Shippable on existing infrastructure",
     body:
-      "Built on production Isonomia: existing argument graph, existing scheme catalog, existing permalinks. No migration, no second source of truth.",
+      "Built on production Isonomia: same argument graph, same scheme catalog, same permalinks. No migration, no second source of truth.",
     status: "shipped",
+    color: "from-amber-500/10 to-orange-500/15",
+    iconColor: "text-amber-600",
     evidence: [
       "54/54 attestation verifier passing",
       "37/37 MCP verifier passing",
@@ -169,17 +182,19 @@ const PILLARS: PillarCard[] = [
     id: "deliberation-honesty",
     icon: Eye,
     label: "Pillar 6",
-    title: "Deliberation-scope readiness & honesty (Pt. 4)",
+    title: "Deliberation-scope readiness & honesty",
     body:
-      "Above the per-argument primitive sits a deliberation-scope substrate: a structural fingerprint, a contested frontier, a missing-moves audit, chain-fragility projections, and a deterministic synthetic readout that refuses to summarise prematurely. Citing a deliberation, not just an argument, comes with the same honesty contract.",
+      "Above the per-argument primitive sits a deliberation-scope substrate: a structural fingerprint, a contested frontier, a missing-moves audit, chain-fragility projections, and a deterministic readout that refuses to summarise prematurely.",
     status: "shipped",
+    color: "from-indigo-500/10 to-violet-500/15",
+    iconColor: "text-indigo-600",
     evidence: [
-      "DeliberationFingerprint (counts, depth, CQ coverage, AI-vs-human extraction split)",
-      "ContestedFrontier (unanswered undercuts/undermines/CQs, terminal leaves)",
+      "DeliberationFingerprint: counts, depth, CQ coverage, AI-vs-human split",
+      "ContestedFrontier: unanswered undercuts / undermines / CQs, terminal leaves",
       "MissingMoveReport (per-argument + rollup) + ChainExposure (weakestLink)",
-      "SyntheticReadout with deterministic honestyLine + refusalSurface (real graph node ids)",
-      "Cross-deliberation aggregation rule (consistent\u2011IN / OUT / contested / undecided)",
-      "AI-engagement telemetry \u2192 truthful articulationOnly chip",
+      "SyntheticReadout: deterministic honestyLine + refusalSurface (real node ids)",
+      "Cross-deliberation aggregation: consistent-IN / OUT / contested / undecided",
+      "AiDraftEngagement telemetry \u2192 articulationOnly chip",
       "DeliberationFingerprintCache (contentHash-keyed) + 30s SWR dedupe",
     ],
   },
@@ -270,8 +285,23 @@ const TRACKS: { letter: string; name: string; rows: TrackRow[] }[] = [
       { id: "G.6", label: "G.6", title: "Fossil record (get_fossil_record) + briefing-fingerprint API (5 material-change rules)", status: "shipped" },
       { id: "G.7", label: "G.7", title: "Scorecard v1.5: coverage-exposure dimension + manifest extensions (openExposurePoints, coverageRatio, fossilCount)", status: "shipped" },
       { id: "G.8", label: "G.8", title: "Staging migration + stratum-labeling benchmark (< 500ms p95 target)", status: "planned" },
-      { id: "G.9", label: "G.9", title: "Fossil retraction lifecycle (argument / locus deletion → fossilize)", status: "planned" },
+      { id: "G.9", label: "G.9", title: "Fossil retraction lifecycle (argument / locus deletion → fossilize + witness rescission)", status: "shipped" },
       { id: "G.10", label: "G.10", title: "AI synthesis workflow: compute_articulation_join → bind_participant_to_design end-to-end", status: "planned" },
+    ],
+  },
+  {
+    letter: "H",
+    name: "Ludics generative substrate (Phase 2 — production)",
+    rows: [
+      { id: "H.1", label: "H.1", title: "Inc(B) antichain decomposition + ∨_⊥⊥ Reading A (per-cone synthesis)", status: "shipped" },
+      { id: "H.2", label: "H.2", title: "R1–R5 fingerprint material-change rules (R1 new fossil · R2 stratum delta · R3 minimum-shift · R4 join-eligible · R5 antichain widen)", status: "shipped" },
+      { id: "H.3", label: "H.3", title: "OQ-JSL proof pass (Inc(B) antichain invariant verified across the suite)", status: "shipped" },
+      { id: "H.4", label: "H.4", title: "Redis-only fingerprint cache (WS-1 / B12) — Postgres truth, Upstash read-through, horizontal-scale convergence", status: "shipped" },
+      { id: "H.5", label: "H.5", title: "Compound rate-limit (WS-2 / B11) — (deliberationId, participantId, IP) keyed; bind / propose / retract", status: "shipped" },
+      { id: "H.6", label: "H.6", title: "Scoped session tokens (WS-3 / B6) — deliberation-bound JWT via jose; scope mismatch → 403", status: "shipped" },
+      { id: "H.7", label: "H.7", title: "Announcement bus A1–A4 — witness_committed / design_revealed / witness_contested / witness_rescinded (BullMQ; idempotent on (eventType,subjectId,occurredAt); replayable from Postgres)", status: "shipped" },
+      { id: "H.8", label: "H.8", title: "v2.5 cutover — bus is sole emit channel (no console.info dual-emit); LUDICS_LEGACY_BEARER + ludics legacy bearer branch removed", status: "shipped" },
+      { id: "H.9", label: "H.9", title: "Upstash p99 latency dashboard + ElastiCache migration trigger threshold", status: "planned", note: "ops task — outside code-side sprint" },
     ],
   },
 ];
@@ -320,6 +350,29 @@ const EXAMPLE_ATTESTATION = {
     standingScore: 0.62,
   },
   author: { username: "panand", name: "Dr. Priya Anand" },
+};
+
+const EXAMPLE_ANNOUNCEMENT = {
+  eventType: "witness_rescinded",
+  version: 1,
+  scopeId: "delib_7c1a4f0e",
+  actorParticipantId: "participant_panand",
+  subjectId: "wr_9f1b3a2c",
+  occurredAt: "2026-05-24T18:42:11.083Z",
+  payload: {
+    ludicMoveId: "lm_bx7kqm",
+    fossilizedAt: "2026-05-24T18:42:11.080Z",
+    retractLayer: "witness",
+    retractReason: "Premise p2 revised; original commitment no longer load-bearing.",
+  },
+};
+
+const EXAMPLE_SCOPED_JWT_CLAIMS = {
+  iss: "mesh-ludics",
+  sub: "participant_panand",
+  scope: { deliberationId: "delib_7c1a4f0e" },
+  iat: 1748112000,
+  exp: 1748115600,
 };
 
 const EXAMPLE_CITE = {
@@ -408,7 +461,7 @@ function PillarsSection() {
   return (
     <section>
       <div className="mb-4">
-        <h2 className="text-xl font-semibold text-slate-800">The five pillars</h2>
+        <h2 className="text-xl font-semibold text-slate-800">The six pillars</h2>
         <p className="text-sm text-slate-500 mt-0.5">
           What an Isonomia permalink means when an LLM cites it.
         </p>
@@ -417,34 +470,35 @@ function PillarsSection() {
         {PILLARS.map((p) => {
           const Icon = p.icon;
           return (
-            <div
-              key={p.id}
-              className="rounded-xl border border-slate-200 bg-white p-5 hover:shadow-sm transition-shadow"
-            >
-              <div className="flex items-start justify-between gap-2 mb-3">
-                <div className="p-2 rounded-lg bg-gradient-to-br from-indigo-50 to-violet-50 text-indigo-600 border border-indigo-100">
-                  <Icon className="w-5 h-5" />
+            <div key={p.id} className="cardv2 h-full flex flex-col">
+              <div className="p-5 pb-3">
+                <div className="flex items-start justify-between gap-3">
+                  <div className="flex items-center gap-3 min-w-0">
+                    <div className={`p-2 rounded-xl bg-gradient-to-br ${p.color} ${p.iconColor} shrink-0`}>
+                      <Icon className="w-4 h-4" />
+                    </div>
+                    <div className="min-w-0">
+                      <span className="text-[10px] font-bold text-slate-400 font-mono">{p.label}</span>
+                      <p className="font-semibold text-slate-900 text-[14px] leading-tight">{p.title}</p>
+                    </div>
+                  </div>
+                  <StatusPill status={p.status} />
                 </div>
-                <StatusPill status={p.status} />
+                <p className="text-xs text-slate-500 mt-3 leading-snug">{p.body}</p>
               </div>
-              <p className="text-[10px] uppercase tracking-wider font-semibold text-slate-400">
-                {p.label}
-              </p>
-              <h3 className="text-base font-semibold text-slate-800 mt-0.5 leading-snug">
-                {p.title}
-              </h3>
-              <p className="text-sm text-slate-600 mt-2 leading-relaxed">{p.body}</p>
-              <ul className="mt-3 space-y-1.5">
-                {p.evidence.map((e) => (
-                  <li
-                    key={e}
-                    className="flex items-start gap-1.5 text-[12px] text-slate-500"
-                  >
-                    <ArrowRight className="w-3 h-3 mt-1 text-slate-400 shrink-0" />
-                    <span>{e}</span>
-                  </li>
-                ))}
-              </ul>
+              <div className="px-5 pb-5 flex-1">
+                <ul className="space-y-1.5">
+                  {p.evidence.map((e) => (
+                    <li
+                      key={e}
+                      className="flex items-start gap-2 text-[12.5px] text-slate-600 leading-snug"
+                    >
+                      <div className="w-1 h-1 rounded-full bg-sky-400/70 flex-shrink-0 mt-[5px]" />
+                      {e}
+                    </li>
+                  ))}
+                </ul>
+              </div>
             </div>
           );
         })}
@@ -459,8 +513,7 @@ function TracksSection() {
       <div className="mb-4">
         <h2 className="text-xl font-semibold text-slate-800">Roadmap tracks</h2>
         <p className="text-sm text-slate-500 mt-0.5">
-          Five capability tracks, ordered by leverage. Each is independently
-          shippable.
+          Eight capability tracks, ordered by leverage. Each is independently shippable.
         </p>
       </div>
       <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
@@ -538,10 +591,9 @@ function PermalinkExplainer() {
           <Hash className="w-4 h-4 text-slate-500" /> Content addressing
         </p>
         <p className="text-sm text-slate-600 leading-relaxed">
-          Every argument's canonical AIF subgraph is hashed (sha256, sorted-keys
-          JSON). The hash and the version number ride alongside the permalink in
-          response headers and an immutable URL form, so a citation can pin to
-          the exact state of the argument at retrieval time.
+          Each argument&apos;s canonical AIF subgraph is sha256-hashed (sorted-keys JSON).
+          The hash and version ride alongside the permalink in response headers and an
+          immutable URL form, so a citation can pin to the exact state at retrieval time.
         </p>
         <CodeBlock language="http">
 {`HTTP/1.1 200 OK
@@ -570,7 +622,7 @@ function AttestationExplainer() {
         </p>
         <p className="text-sm text-slate-600 leading-relaxed">
           What an LLM should embed when it cites Isonomia. Verifiable, dated,
-          and dialectically scored — the unit a careful reasoner would want.
+          and dialectically scored.
         </p>
       </div>
       <CodeBlock>{JSON.stringify(EXAMPLE_ATTESTATION, null, 2)}</CodeBlock>
@@ -604,7 +656,7 @@ function AttestationExplainer() {
             CQ counters, inbound attacks/supports,{" "}
             <span className="font-mono">testedness</span> bucket, and a{" "}
             <span className="font-mono">standingScore</span> that is{" "}
-            <em>null</em> when there's no signal — never a misleading 1.0.
+            <em>null</em> when there&apos;s no signal — never a misleading 1.0.
           </p>
         </div>
         <div className="rounded-md border border-slate-200 bg-slate-50/60 p-3">
@@ -632,14 +684,13 @@ function CounterCitationExplainer() {
           </div>
           <div>
             <p className="text-sm font-semibold text-rose-800">
-              No other citation system in the world does this
+              No other citation system ships its opposition
             </p>
             <p className="text-sm text-rose-700 mt-1 leading-relaxed">
-              When an LLM calls{" "}
-              <span className="font-mono">cite_argument</span>, the citation
-              block arrives with the strongest known counter-argument
-              <em> already attached</em>. There is no path to citing an
-              Isonomia argument that hides what attacks it.
+              When an LLM calls <span className="font-mono">cite_argument</span>,
+              the citation block arrives with the strongest known counter-argument
+              <em> already attached</em>. There is no path to citing an Isonomia
+              argument that hides what attacks it.
             </p>
           </div>
         </div>
@@ -651,7 +702,7 @@ function CounterCitationExplainer() {
         </p>
         <p className="text-sm text-slate-600 leading-relaxed mb-3">
           A naive consumer reading <span className="font-mono">standingScore: 1.0</span>{" "}
-          might infer "this argument has survived everything." That can be
+          might infer &quot;this argument has survived everything.&quot; That can be
           misleading: a scheme requiring zero critical questions, with no
           inbound traffic, would also produce 1.0. So we classify:
         </p>
@@ -896,12 +947,12 @@ function McpExplainer() {
       </div>
       <div className="rounded-xl border border-amber-200 bg-amber-50/30 p-5">
         <p className="text-sm font-semibold text-amber-900 mb-3 flex items-center gap-2">
-          <Eye className="w-4 h-4 text-amber-700" /> Deliberation primitive — 7 new tools (Pt. 4)
+          <Eye className="w-4 h-4 text-amber-700" /> Deliberation primitive — 7 new tools
         </p>
         <p className="text-sm text-amber-800/90 leading-relaxed mb-4">
           The deliberation-scope substrate is exposed over the same MCP
-          surface. These tools let an LLM ask <em>"is this debate ready to
-          summarise?"</em> before it tries to.
+          surface. These tools let an LLM ask <em>&quot;is this debate ready to
+          summarise?&quot;</em> before it tries to.
         </p>
         <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
           {[
@@ -946,7 +997,7 @@ function McpExplainer() {
       </div>
       <div className="rounded-xl border border-violet-200 bg-violet-50/30 p-5">
         <p className="text-sm font-semibold text-violet-900 mb-3 flex items-center gap-2">
-          <Workflow className="w-4 h-4 text-violet-700" /> Ludics substrate — 14 new tools (Phase 1)
+          <Workflow className="w-4 h-4 text-violet-700" /> Ludics substrate — 14 new tools
         </p>
         <p className="text-sm text-violet-800/90 leading-relaxed mb-4">
           The generative substrate exposes the dialectical structure beneath deliberations: incarnation lattices, witnessing records, fossil transcripts, and a briefing-fingerprint for agent staleness detection. These tools give LLMs the algebraic layer of the argument graph, not just the graph surface.
@@ -1020,12 +1071,147 @@ function McpExplainer() {
   );
 }
 
+function LudicsSubstrateTab() {
+  return (
+    <div className="space-y-4">
+      <div className="rounded-xl border border-violet-200 bg-violet-50/40 p-5">
+        <div className="flex items-start gap-3">
+          <div className="p-1.5 rounded-lg bg-violet-100 text-violet-700 shrink-0">
+            <Radio className="w-4 h-4" />
+          </div>
+          <div>
+            <p className="text-sm font-semibold text-violet-900">
+              Substrate v2.5 — typed, scoped, replayable
+            </p>
+            <p className="text-sm text-violet-800/90 mt-1 leading-relaxed">
+              Phase 1 shipped the read model: witnessing, fossils, articulation
+              lattice. Phase 2 hardened the perimeter and made the substrate
+              observable from outside. Every binding act on the substrate now
+              (a) writes through a deliberation-scoped JWT, (b) is rate-limited
+              on a compound key, and (c) emits a typed announcement that is
+              persisted in Postgres and dispatched at-least-once via BullMQ.
+              v2.5 retired the last <span className="font-mono">console.info</span>{" "}
+              dual-emit and the legacy shared bearer; the bus is now the sole channel.
+            </p>
+          </div>
+        </div>
+      </div>
+
+      <div className="rounded-xl border border-slate-200 bg-white p-5">
+        <p className="text-sm font-semibold text-slate-700 mb-3 flex items-center gap-2">
+          <Radio className="w-4 h-4 text-slate-500" /> Announcement envelope (A1–A4)
+        </p>
+        <p className="text-sm text-slate-600 leading-relaxed mb-3">
+          Four event types map onto Ludics&apos; four axioms — A1 commit, A2 reveal,
+          A3 contest, A4 retract — and ride a single Zod-validated envelope.
+          Idempotency key is the triple{" "}
+          <span className="font-mono">(eventType, subjectId, occurredAt)</span>;
+          subscribers must dedupe.
+        </p>
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-2 mb-3">
+          {[
+            { type: "witness_committed", axiom: "A1", note: "new WitnessRecord persisted at a locus" },
+            { type: "design_revealed", axiom: "A2", note: "first published synthesis (same-cone-join)" },
+            { type: "witness_contested", axiom: "A3", note: "counter-witness bound to the same locus" },
+            { type: "witness_rescinded", axiom: "A4", note: "witness retracted → fossil emitted" },
+          ].map((e) => (
+            <div key={e.type} className="rounded-md border border-violet-200/70 bg-violet-50/40 p-2.5">
+              <p className="text-[10px] uppercase font-semibold tracking-wide text-violet-700">{e.axiom}</p>
+              <p className="text-[12px] font-mono font-semibold text-slate-800 mt-0.5">{e.type}</p>
+              <p className="text-[11px] text-slate-600 leading-snug mt-0.5">{e.note}</p>
+            </div>
+          ))}
+        </div>
+        <CodeBlock>{JSON.stringify(EXAMPLE_ANNOUNCEMENT, null, 2)}</CodeBlock>
+      </div>
+
+      <div className="rounded-xl border border-slate-200 bg-white p-5">
+        <p className="text-sm font-semibold text-slate-700 mb-3 flex items-center gap-2">
+          <Lock className="w-4 h-4 text-slate-500" /> Scoped session token (JWT claims)
+        </p>
+        <p className="text-sm text-slate-600 leading-relaxed mb-3">
+          Every write to the substrate (bind / propose / retract) verifies a
+          short-lived JWT signed with{" "}
+          <span className="font-mono">LUDICS_JWT_SIGNING_KEY</span>. The token&apos;s{" "}
+          <span className="font-mono">scope.deliberationId</span> must match
+          the request body — a mismatch returns{" "}
+          <span className="font-mono">403 SCOPE_MISMATCH</span>, an expired token returns{" "}
+          <span className="font-mono">401 EXPIRED_TOKEN</span>. There is no tenant
+          axis in this repo (WS-0 audit), so the scope unit is the
+          deliberation itself.
+        </p>
+        <CodeBlock>{JSON.stringify(EXAMPLE_SCOPED_JWT_CLAIMS, null, 2)}</CodeBlock>
+        <p className="text-[11px] text-slate-500 mt-3">
+          Mint locally via{" "}
+          <span className="font-mono">
+            npx tsx scripts/mintMcpToken.ts --deliberation &lt;id&gt; --participant &lt;id&gt; --ttl 3600
+          </span>.
+        </p>
+      </div>
+
+      <div className="rounded-xl border border-slate-200 bg-white p-5">
+        <p className="text-sm font-semibold text-slate-700 mb-3 flex items-center gap-2">
+          <ShieldCheck className="w-4 h-4 text-slate-500" /> Production-readiness invariants (§6.6 suite)
+        </p>
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+          {[
+            { hdr: "Fingerprint cache (WS-1)", body: "Postgres truth + Upstash read-through; cold-miss writes Redis; recordFingerprint invalidates; two PrismaClient instances converge." },
+            { hdr: "Compound rate-limit (WS-2)", body: "(deliberationId, participantId) + (deliberationId, IP) buckets; cross-deliberation isolation; Retry-After header set on 429." },
+            { hdr: "Scoped JWT (WS-3)", body: "Valid token + matching scope → 200; wrong deliberationId → 403; expired → 401; unparseable bearer → 401 INVALID_TOKEN." },
+            { hdr: "Announcement bus (A1–A4)", body: "Envelope shape · idempotency on (eventType,subjectId,occurredAt) · replay-from-Postgres · dispatcher retries · DLQ on terminal failure." },
+          ].map((row) => (
+            <div key={row.hdr} className="rounded-md border border-slate-200 bg-slate-50/60 p-3">
+              <p className="text-[11px] uppercase font-semibold text-slate-500 tracking-wide mb-1">{row.hdr}</p>
+              <p className="text-[12px] text-slate-600 leading-snug">{row.body}</p>
+            </div>
+          ))}
+        </div>
+        <p className="text-[11px] text-slate-500 mt-3 font-mono">
+          npx jest __tests__/invariants __tests__/eval · 22 suites · 390 tests + 1 todo at v2.5 cutover
+        </p>
+      </div>
+
+      <div className="rounded-xl border border-emerald-200 bg-emerald-50/30 p-5">
+        <p className="text-sm font-semibold text-emerald-900 mb-2 flex items-center gap-2">
+          <CheckCircle2 className="w-4 h-4 text-emerald-700" /> v2.5 cutover — sole-channel emit
+        </p>
+        <ul className="text-[12px] text-emerald-900/90 leading-relaxed space-y-1 list-disc pl-5">
+          <li>
+            Removed the{" "}
+            <span className="font-mono">console.info({"{ event: \"witness_rescinded\", … }"})</span>{" "}
+            dual-emit from <span className="font-mono">app/api/v3/ludics/retract-witness/route.ts</span> —
+            the bus is the only channel.
+          </li>
+          <li>
+            Dropped <span className="font-mono">LUDICS_LEGACY_BEARER</span> and the legacy{" "}
+            <span className="font-mono">MCP_API_TOKEN</span> branch in{" "}
+            <span className="font-mono">server/ludics/auth.ts</span>. Resolution is now
+            (1) Bearer → scoped JWT, (2) Session cookie.
+          </li>
+          <li>
+            JWT-failure catch re-throws the precise{" "}
+            <span className="font-mono">LudicsAuthError</span> code
+            (<span className="font-mono">SCOPE_MISMATCH</span> /{" "}
+            <span className="font-mono">EXPIRED_TOKEN</span> /{" "}
+            <span className="font-mono">INVALID_TOKEN</span>) instead of silently collapsing.
+          </li>
+          <li>
+            The <span className="font-mono">MCP_API_TOKEN</span> env var itself is preserved —
+            it is still consumed by <span className="font-mono">lib/citation/mcpAuth.ts</span>{" "}
+            and the isonomia MCP OpenAPI surface (non-ludics).
+          </li>
+        </ul>
+      </div>
+    </div>
+  );
+}
+
 function FlowExplainer() {
   const steps = [
     {
       n: 1,
       title: "User asks an LLM about a contested issue",
-      body: '"Is social media driving the teen mental health crisis?"',
+      body: '"Are GLP-1 medications safe for long-term use?" → LLM identifies key claims and formulates a search query',
       icon: HelpCircle,
     },
     {
@@ -1227,82 +1413,101 @@ function DeliberationReadoutTab() {
   );
 }
 
+const ROUTES = [
+  { method: "GET", path: "/a/{shortCode}", description: "Content-negotiated permalink (HTML / JSON-LD / AIF / attestation)", tag: "Page" },
+  { method: "GET", path: "/a/{shortCode}@{hash}", description: "Immutable, content-addressed permalink", tag: "Page" },
+  { method: "GET", path: "/api/v3/search/arguments", description: "Hybrid retrieval; ?sort=dialectical_fitness re-rank", tag: "API" },
+  { method: "GET", path: "/api/v3/arguments/{shortCode}/attestation", description: "Compact citation envelope (the LLM unit)", tag: "API" },
+  { method: "GET", path: "/api/v3/deliberations/{id}/synthetic-readout", description: "Deterministic readout + refusalSurface (real node ids)", tag: "API" },
+  { method: "GET", path: "/api/v3/deliberations/{id}/fingerprint", description: "Structural fingerprint (counts, depth, CQ coverage)", tag: "API" },
+  { method: "GET", path: "/api/v3/ludics/fossil-record", description: "Retraction history with locus back-pointers", tag: "API" },
+  { method: "GET", path: "/api/v3/docs", description: "OpenAPI 3.1 spec (Scalar UI)", tag: "API" },
+  { method: "MCP", path: "cite_argument", description: "Citation block + strongest objection + provenance counters", tag: "MCP" },
+  { method: "MCP", path: "get_synthetic_readout", description: "Editorial primitive: deterministic honestyLine + refusalSurface", tag: "MCP" },
+  { method: "MCP", path: "summarize_debate", description: "Refusal-aware narrative; refuses with cited blockers when not ready", tag: "MCP" },
+  { method: "MCP", path: "bind_participant_to_design", description: "Write seam: scoped JWT + rate-limit + announcement bus (A1)", tag: "MCP" },
+];
+
 export default function AIEpistemicInfrastructurePage() {
   const [tab, setTab] = useState("permalink");
   return (
     <TooltipProvider>
-      <div className="min-h-screen bg-gradient-to-b from-slate-50 to-white">
-        <div className="max-w-6xl mx-auto px-6 py-10 space-y-10">
-          {/* Header */}
-          <div className="space-y-4">
-            <div className="flex items-center gap-3 flex-wrap">
-              <span className="inline-flex items-center gap-1.5 px-3 py-1 rounded-full bg-gradient-to-r from-indigo-500/10 to-violet-500/10 text-indigo-700 border border-indigo-500/20 text-xs font-semibold">
-                <Cpu className="w-3.5 h-3.5" />
+      <div
+        className="min-h-screen"
+        style={{
+          background:
+            "linear-gradient(145deg, #f5faff 0%, #eef5ff 25%, #faf6ff 60%, #fff6f8 100%)",
+        }}
+      >
+        {/* Sticky header */}
+        <div
+          className="border-b border-slate-900/[0.07] bg-white/85 backdrop-blur-xl sticky top-0 z-40 px-6 py-4"
+          style={{
+            boxShadow:
+              "0 1px 3px rgba(99,102,241,0.06), 0 4px 16px -8px rgba(99,102,241,0.08)",
+          }}
+        >
+          <div className="max-w-6xl mx-auto flex items-center justify-between">
+            <div>
+              <h1 className="text-2xl font-bold text-slate-900 flex items-center gap-2">
+                <div className="p-1.5 rounded-lg bg-gradient-to-br from-indigo-500 to-violet-600">
+                  <Cpu className="w-5 h-5 text-white" />
+                </div>
                 AI-Epistemic Infrastructure
-              </span>
-              <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-[11px] font-medium bg-emerald-50 border border-emerald-200/80 text-emerald-700">
-                Tracks A–F + G.1–7 shipped
-              </span>
-              <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-[11px] font-medium bg-amber-50 border border-amber-200/80 text-amber-700">
-                Pt. 4 deliberation readout live
-              </span>
-              <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-[11px] font-medium bg-indigo-50 border border-indigo-200/80 text-indigo-700">
-                Four-week pitch deliverable
-              </span>
+              </h1>
+              <p className="text-sm text-slate-500 mt-1 ml-12">
+                The argument primitive for AI citation
+              </p>
             </div>
-            <h1 className="text-3xl font-bold text-slate-900 tracking-tight">
-              The argument primitive for AI citation
-            </h1>
-            <p className="text-base text-slate-600 max-w-3xl leading-relaxed">
-              Every Isonomia permalink is an addressable, structured,
-              verifiable, machine-citable epistemic artifact. It carries a
-              canonical claim, attested evidence with provenance, a typed
-              inference (scheme + critical questions), the dialectical context
-              that has tested it, and a cryptographically stable identifier.
-              LLMs need exactly this shape of unit when they cite.
-            </p>
-            <div className="flex items-center gap-2 flex-wrap">
-              {[
-                { label: "Content-negotiated permalinks", color: "bg-indigo-100 text-indigo-700" },
-                { label: "AIF + JSON-LD + Schema.org", color: "bg-violet-100 text-violet-700" },
-                { label: "sha256 content addressing", color: "bg-fuchsia-100 text-fuchsia-700" },
-                { label: "archive.org evidence snapshots", color: "bg-amber-100 text-amber-700" },
-                { label: "MCP server (~40 tools)", color: "bg-teal-100 text-teal-700" },
-                { label: "Counter-citation by default", color: "bg-rose-100 text-rose-700" },
-                { label: "Honest-empty failure mode", color: "bg-emerald-100 text-emerald-700" },
-                { label: "Dialectical-fitness re-rank", color: "bg-yellow-100 text-yellow-700" },
-                { label: "Synthetic readout (deterministic)", color: "bg-amber-100 text-amber-800" },
-                { label: "Cross-deliberation aggregation", color: "bg-sky-100 text-sky-700" },
-                { label: "AI-engagement telemetry", color: "bg-violet-100 text-violet-800" },
-              ].map((chip) => (
-                <span
-                  key={chip.label}
-                  className={`text-xs font-medium px-2.5 py-1 rounded-full ${chip.color}`}
-                >
-                  {chip.label}
-                </span>
-              ))}
-            </div>
+            
           </div>
+        </div>
 
-          {/* Vision callout */}
-          <div className="rounded-xl border border-indigo-200 bg-indigo-50/50 p-5">
-            <div className="flex items-start gap-3">
-              <div className="p-1.5 rounded-lg bg-indigo-100 text-indigo-600 shrink-0">
-                <Target className="w-4 h-4" />
+        <div className="max-w-6xl mx-auto px-6 py-8 space-y-8">
+          {/* Strategic context banner */}
+          <div className="rounded-xl bg-gradient-to-r from-indigo-50 via-violet-50 to-pink-50 border border-indigo-100/80 p-5">
+            <div className="flex items-start gap-4">
+              <div className="p-2.5 rounded-xl bg-gradient-to-br from-indigo-500 to-violet-600 text-white shrink-0">
+                <Target className="w-5 h-5" />
               </div>
               <div>
-                <p className="font-semibold text-indigo-800 text-sm">Thesis</p>
-                <p className="text-sm text-indigo-700 mt-1 leading-relaxed">
-                  Citations today cite <em>prose</em>. URLs point at webpages
-                  whose state can drift, whose evidence isn't hashed, whose
-                  reasoning isn't typed, and whose opposition isn't surfaced.
-                  Isonomia citations cite <em>adjudicated reasoning</em>: a
-                  structured argument graph with provenance, dialectical
-                  status, and the strongest known counter attached. This is
-                  what scalable-oversight and retrieval-augmented systems need
-                  — and it's standards-grounded, shippable today.
+                <h2 className="text-base font-semibold text-slate-900 mb-1">
+                  What an Isonomia citation contains
+                </h2>
+                <p className="text-sm text-slate-600 leading-relaxed">
+                  A standard web citation resolves to an HTML page: the
+                  underlying claim, evidence, and counter-arguments are not
+                  addressable, hashed, or typed. An Isonomia permalink
+                  resolves to an AIF subgraph that includes the claim, its
+                  premises and inference scheme, sha256-addressed evidence,
+                  a dialectical standing value, and the highest-ranked known
+                  counter-argument. The same resource is served over
+                  content-negotiated HTTP and MCP, and returns an explicit
+                  &quot;not yet&quot; state when no signal is available.
                 </p>
+                <div className="flex flex-wrap gap-2 mt-3">
+                  {[
+                    { label: "Content-negotiated permalinks", color: "bg-indigo-100 text-indigo-700" },
+                    { label: "AIF + JSON-LD + Schema.org", color: "bg-violet-100 text-violet-700" },
+                    { label: "sha256 content addressing", color: "bg-fuchsia-100 text-fuchsia-700" },
+                    { label: "archive.org snapshots", color: "bg-amber-100 text-amber-700" },
+                    { label: "MCP (~40 tools)", color: "bg-teal-100 text-teal-700" },
+                    { label: "Counter-citation by default", color: "bg-rose-100 text-rose-700" },
+                    { label: "Honest-empty failure mode", color: "bg-emerald-100 text-emerald-700" },
+                    { label: "Dialectical-fitness re-rank", color: "bg-yellow-100 text-yellow-700" },
+                    { label: "Deterministic synthetic readout", color: "bg-amber-100 text-amber-800" },
+                    { label: "Cross-deliberation aggregation", color: "bg-sky-100 text-sky-700" },
+                    { label: "Ludics bus (A1–A4)", color: "bg-violet-100 text-violet-700" },
+                    { label: "Deliberation-scoped JWT", color: "bg-pink-100 text-pink-700" },
+                  ].map((chip) => (
+                    <span
+                      key={chip.label}
+                      className={`text-xs font-medium px-2.5 py-1 rounded-full ${chip.color}`}
+                    >
+                      {chip.label}
+                    </span>
+                  ))}
+                </div>
               </div>
             </div>
           </div>
@@ -1314,11 +1519,10 @@ export default function AIEpistemicInfrastructurePage() {
           <section>
             <div className="mb-4">
               <h2 className="text-xl font-semibold text-slate-800">
-                End-to-end flow
+                Example Flow
               </h2>
               <p className="text-sm text-slate-500 mt-0.5">
-                What happens when a user asks an LLM about a contested issue
-                with the Isonomia MCP server installed.
+                What an LLM does when a user asks about a contested issue with the Isonomia MCP server installed.
               </p>
             </div>
             <FlowExplainer />
@@ -1332,8 +1536,7 @@ export default function AIEpistemicInfrastructurePage() {
             <div className="mb-4">
               <h2 className="text-xl font-semibold text-slate-800">Deep dive</h2>
               <p className="text-sm text-slate-500 mt-0.5">
-                The actual shapes — permalink contracts, attestation envelope,
-                counter-citation reflex, and the MCP surface.
+                Shapes and contracts: permalink, attestation, counter-citation, MCP, deliberation, substrate.
               </p>
             </div>
             <Tabs value={tab} onValueChange={setTab} className="space-y-4">
@@ -1356,7 +1559,11 @@ export default function AIEpistemicInfrastructurePage() {
                 </TabsTrigger>
                 <TabsTrigger value="deliberation" className="gap-1.5">
                   <Eye className="w-4 h-4" />
-                  Deliberation (Pt. 4)
+                  Deliberation
+                </TabsTrigger>
+                <TabsTrigger value="substrate" className="gap-1.5">
+                  <Radio className="w-4 h-4" />
+                  Ludics substrate
                 </TabsTrigger>
                 <TabsTrigger value="live" className="gap-1.5">
                   <Activity className="w-4 h-4" />
@@ -1377,6 +1584,9 @@ export default function AIEpistemicInfrastructurePage() {
               </TabsContent>
               <TabsContent value="deliberation">
                 <DeliberationReadoutTab />
+              </TabsContent>
+              <TabsContent value="substrate">
+                <LudicsSubstrateTab />
               </TabsContent>
               <TabsContent value="live">
                 <LiveVerification />
@@ -1419,29 +1629,68 @@ export default function AIEpistemicInfrastructurePage() {
             </div>
           </section>
 
+          {/* Routes & MCP tools */}
+          <section>
+            <div className="mb-4">
+              <h2 className="text-xl font-semibold text-slate-800">Routes &amp; MCP tools</h2>
+              <p className="text-sm text-slate-500 mt-0.5">
+                The full surface, identical for humans, crawlers, and language-model agents.
+              </p>
+            </div>
+            <div className="rounded-xl border border-slate-200 bg-white overflow-hidden divide-y">
+              {ROUTES.map((r, i) => (
+                <div key={i} className="flex items-center gap-3 px-5 py-3">
+                  <span
+                    className={`text-[10px] font-bold px-1.5 py-0.5 rounded shrink-0 font-mono ${
+                      r.tag === "Page"
+                        ? "bg-emerald-100 text-emerald-700"
+                        : r.tag === "API"
+                        ? "bg-sky-100 text-sky-700"
+                        : "bg-violet-100 text-violet-700"
+                    }`}
+                  >
+                    {r.method}
+                  </span>
+                  <code className="font-mono text-xs text-slate-700 flex-1 truncate">{r.path}</code>
+                  <span className="text-xs text-slate-400 hidden md:block truncate max-w-[55%] text-right">
+                    {r.description}
+                  </span>
+                </div>
+              ))}
+            </div>
+          </section>
+
           {/* Footer */}
-          <div className="text-center text-[12px] text-slate-400 pb-4">
-            <p className="flex items-center justify-center gap-1.5 flex-wrap">
+          <footer className="py-6 border-t border-slate-900/[0.06] flex items-center justify-between text-xs text-slate-400 flex-wrap gap-3">
+            <span className="font-medium text-slate-500 inline-flex items-center gap-1.5">
               <Activity className="w-3 h-3" />
               Live verifiers: 54/54 attestation · 37/37 MCP
-              <span className="mx-2">·</span>
+            </span>
+            <div className="flex items-center gap-3 flex-wrap">
+              <a
+                href="/test/argument-search-discovery"
+                className="text-indigo-500 hover:underline inline-flex items-center gap-1"
+              >
+                Search &amp; Discovery <ExternalLink className="w-3 h-3" />
+              </a>
+              <span className="text-slate-300">·</span>
               <a
                 href="/test/living-thesis"
-                className="text-indigo-500 hover:text-indigo-700 inline-flex items-center gap-1"
+                className="text-indigo-500 hover:underline inline-flex items-center gap-1"
               >
-                Living Thesis demo
-                <ExternalLink className="w-3 h-3" />
+                Living Thesis <ExternalLink className="w-3 h-3" />
               </a>
-              <span className="mx-2">·</span>
+              <span className="text-slate-300">·</span>
               <a
                 href="/test/embeddable-widget-pt4"
-                className="text-amber-600 hover:text-amber-800 inline-flex items-center gap-1"
+                className="text-amber-600 hover:underline inline-flex items-center gap-1"
               >
-                Embeddable widget (Pt. 4)
-                <ExternalLink className="w-3 h-3" />
+                Embeddable widget (Pt. 4) <ExternalLink className="w-3 h-3" />
               </a>
-            </p>
-          </div>
+              <span className="text-slate-300">·</span>
+              <span>May 2026</span>
+            </div>
+          </footer>
         </div>
       </div>
     </TooltipProvider>

--- a/docs/isonomia-overview-general.md
+++ b/docs/isonomia-overview-general.md
@@ -1,10 +1,16 @@
 # Isonomia
 
-## Complete Platform Overview
+## Overview
 
-Isonomia is a social platform with a formal reasoning layer. The social layer (forums, feed, messaging, rooms, articles, shared libraries, user profiles) provides the space where communities gather. The reasoning layer, a deliberation engine implementing formal argumentation theory, interactive proof theory, and evidence aggregation, provides the infrastructure that preserves what the gathering produces. The two layers share a single data model and a continuous spectrum of formality: any conversation can become a structured deliberation, and any deliberation exists within a social context.
+Isonomia is open-source infrastructure for community gathering and structured reasoning. It unifies a general-purpose social platform with a formal deliberation engine under a single data model, so that any conversation can be upgraded to a tracked deliberation through a single reversible action, and every resulting claim, argument, and deliberation is addressable, citable, challengeable, and durable.
 
-The platform is open-source, self-hostable, and designed as public infrastructure. There is no advertising, no algorithmic feed optimization, no data harvesting, and no engagement metrics. The data belongs to the community that produces it. The code is public. The architecture enforces these commitments at the protocol level rather than the policy level.
+The social layer is complete as a standalone platform: a chronological feed with eight post types, profiles and follows, persistent rooms and lounges, spatial canvas environments, sheaf-based layered messaging with drifts, proposals and polls, a long-form article system with anchored comments and rhetoric overlays, and shared document libraries. The reasoning layer sits beside it and implements four families of formalism: structured argumentation via ASPIC+ grounded extensions and the Walton taxonomy of schemes with auto-generated critical questions; interactive proof theory via Ludics designs, with a generative substrate of witnessing records, articulation lattices, and fossil retractions; typed dialogue protocols with commitment stores; and a category-theoretic evidence algebra over typed evidence arrows, with closed-monoid confidence folding and culprit-set belief revision. Evidence enters through a six-stage citation resolver (arXiv, Crossref, page metadata, OpenAlex, LLM extraction, Wayback) with four-tier confidence gating.
+
+The argument graph is exposed as a machine-citable epistemic primitive. Every permalink resolves to a content-hashed, dialectically attested structured argument with end-to-end provenance, served over content-negotiated HTTP (HTML, JSON-LD, AIF, social cards, oEmbed, iframe embeds) and over a bidirectional Model Context Protocol surface with read tools for arguments, counters, stances, and citations, and write tools that flag AI authorship honestly and gate logicality on human ratification. A public search surface fuses dense and sparse retrieval through reciprocal rank fusion, attaches the strongest known counter to every result by default, and reports empty states honestly rather than collapsing them.
+
+Three further layers ride on this substrate. Living documents (theses, briefs, peer reviews) embed claims and arguments that read live from the graph, with inspectors, attack registers, auditable confidence cards, snapshots, and fork/merge. An institutional workflow layer carries deliberation outputs into authorized bodies through a verifiable institution registry, hash-chained pathway audit logs, recommendation packets, and facilitator cockpits with real-time equity surfaces. The Plexus network connects deliberation rooms as a graph-of-graphs across five typed meta-edges, with SHA-1 fingerprinted one-hop room functors and three confidence-gating modes (logical, social, hybrid).
+
+Isonomia is free, self-hostable, and ad-free. There is no behavioral tracking, no algorithmic ranking, and no engagement metric. Data ownership, privacy, and provenance are enforced by architecture rather than by policy: the social graph is portable and exportable in open formats, and the reasoning graph is content-hashed and cryptographically auditable. The system is sustained by grants, institutional partnerships, and optional managed hosting. Its thesis is that the inferential structure connecting evidence to claims to conclusions deserves first-class infrastructure, and that such infrastructure can sit beneath an interface ordinary communities will actually use.
 
 ---
 
@@ -15,8 +21,6 @@ The platform is open-source, self-hostable, and designed as public infrastructur
 **The Social Layer (MESH)** provides the features of a general-purpose community platform: a chronological feed with multiple post types, direct and group messaging, persistent rooms and lounges, user profiles with friend and follow systems, shared document libraries, long-form article publishing, and spatial canvas environments. This layer is complete and functional as a standalone social platform. It requires no engagement with the reasoning layer.
 
 **The Reasoning Layer (Isonomia)** provides formal deliberation infrastructure: argumentation schemes with auto-generated critical questions, typed dialogue moves with protocol enforcement, commitment stores, evidence management with executable citations, Ludics game-theoretic evaluation, confidence scoring, and a cross-context transport network. This layer is accessible from any point in the social layer through a single upgrade action (a discussion can become a deliberation, a comment can become a claim, an annotation can become a proposition), and the transition is reversible.
-
-The two layers are coordinate, not hierarchical: not a simplified version and an advanced version of one thing, but two modes of the same platform addressing two moments in a community's life, the moment of gathering and the moment of deciding. Most communities spend most of their time gathering. The reasoning layer exists for those moments when the gathering needs structure.
 
 ### The Spectrum
 
@@ -297,7 +301,13 @@ Three contracts the surface honors:
 - **AI-flagged warrants are non-logical until ratified.** A "propose warrant" action materializes an internal-hom warrant as an AI-authored argument together with a proposed assumption use; the resulting derivation never lifts to logical until a human ratifies the warrant text.
 - **One-hop cross-room transport.** Transport snapshots written by the transport-aggregator carry one-hop transport only, by contract: chained transport across three or more rooms is intentionally unsupported, so the aggregated band of *local*, *imported*, and *total* counts for any claim remains auditable to a single source room.
 
-Taken together, these surfaces let an external system — human or model — cite a unit rather than a webpage, prove what it cited and when, and surface the strongest known objection alongside the citation. An empty result is honestly empty rather than a false positive.
+**Substrate-level dialectical event stream.** Beneath the per-argument and per-deliberation surfaces sits a generative Ludics substrate that exposes the dialectical mechanics directly. Witnessing records bind dialogue acts to loci in a design; an articulation lattice exposes the cone structure of incarnations, with per-cone minima forming an antichain; a fossil record captures retractions with back-pointers to the loci they vacated; and a briefing-fingerprint API detects material change through five typed rules.
+
+Every binding act on the substrate (commit, reveal, contest, retract) is gated by a deliberation-scoped token (the scope is the deliberation itself; there is no tenant axis) and rate-limited on the compound key of deliberation, participant, and IP. The four axioms surface as four event types carried on a single envelope.
+
+The bus is the sole emit channel. External systems such as the embeddable widget, the model-context surface, third-party dashboards can use it to observe what a deliberation is doing in real time without polling the read model, and to do so against the same dialectical primitives the engine itself manipulates.
+
+Taken together, these surfaces let an external system — human or model — cite a unit rather than a webpage, prove what it cited and when, and surface the strongest known objection alongside the citation.
 
 ---
 
@@ -377,7 +387,7 @@ The platform's reasoning layer is grounded in formally studied frameworks:
 
 **Formal Argumentation Theory.** ASPIC+ (Prakken, 2010; Modgil & Prakken, 2018) provides the framework for structured argumentation with grounded extension computation. The Walton taxonomy (Walton, Reed & Macagno, 2008) provides over sixty argumentation schemes with associated critical questions. The Argument Interchange Format (AIF) (Chesñevar et al., 2006; Reed et al., 2010) provides the ontology for interoperable argument representation and JSON-LD export.
 
-**Interactive Proof Theory.** Ludics (Girard, 2001) models deliberation as a game between Proponent and Opponent strategies. Convergence and divergence are computed through the interaction of designs. The Ludics layer provides game-theoretic evaluation that is independent of the ASPIC+ evaluation, offering a complementary perspective on which arguments are strategically decisive.
+**Interactive Proof Theory.** Ludics (Girard, 2001) models deliberation as a game between Proponent and Opponent strategies, with convergence and divergence computed through the interaction of designs. The Ludics layer provides game-theoretic evaluation independent of the ASPIC+ evaluation, offering a complementary perspective on which arguments are strategically decisive. Beneath that evaluation surface sits a generative substrate that exposes the dialectical primitives directly; witnessing records bound to loci, an articulation lattice with antichain minima, and a fossil record for retractions.
 
 **Evidence Theory.** Dempster-Shafer theory handles the combination and aggregation of evidence from multiple sources with varying degrees of reliability, producing belief functions that represent the state of evidential support more precisely than binary true/false or simple probability.
 

--- a/docs/isonomia-overview.md
+++ b/docs/isonomia-overview.md
@@ -1,0 +1,465 @@
+# Isonomia
+
+## Complete Platform Overview
+
+Isonomia is a social platform with a formal reasoning layer. The social layer (forums, feed, messaging, rooms, articles, shared libraries, user profiles) provides the space where communities gather. The reasoning layer, a deliberation engine implementing formal argumentation theory, interactive proof theory, and evidence aggregation, provides the infrastructure that preserves what the gathering produces. The two layers share a single data model and a continuous spectrum of formality: any conversation can become a structured deliberation, and any deliberation exists within a social context.
+
+The platform is open-source, self-hostable, and designed as public infrastructure. There is no advertising, no algorithmic feed optimization, no data harvesting, and no engagement metrics. The data belongs to the community that produces it. The code is public. The architecture enforces these commitments at the protocol level rather than the policy level.
+
+---
+
+## I. Architecture
+
+### The Two Layers
+
+**The Social Layer (MESH)** provides the features of a general-purpose community platform: a chronological feed with multiple post types, direct and group messaging, persistent rooms and lounges, user profiles with friend and follow systems, shared document libraries, long-form article publishing, and spatial canvas environments. This layer is complete and functional as a standalone social platform. It requires no engagement with the reasoning layer.
+
+**The Reasoning Layer (Isonomia)** provides formal deliberation infrastructure: argumentation schemes with auto-generated critical questions, typed dialogue moves with protocol enforcement, commitment stores, evidence management with executable citations, Ludics game-theoretic evaluation, confidence scoring, and a cross-context transport network. This layer is accessible from any point in the social layer through a single upgrade action (a discussion can become a deliberation, a comment can become a claim, an annotation can become a proposition), and the transition is reversible.
+
+The two layers are coordinate, not hierarchical: not a simplified version and an advanced version of one thing, but two modes of the same platform addressing two moments in a community's life, the moment of gathering and the moment of deciding. Most communities spend most of their time gathering. The reasoning layer exists for those moments when the gathering needs structure.
+
+### The Spectrum
+
+Every feature on the platform exists at a position on a continuous spectrum from informal to formal:
+
+**Conversation.** Feed posts and comments (informal) → threaded discussion with topics (structured) → deliberation with typed moves and commitment tracking (formal).
+
+**Arguments.** Opinions stated in prose (informal) → claims with stated reasons (structured) → arguments instantiating recognized schemes with critical questions (formal).
+
+**Disagreement.** Replies and reactions (informal) → specific objections with stated grounds (structured) → formal challenges creating tracked obligations to respond (formal).
+
+**Evidence.** Links and anecdotes (informal) → cited sources with annotations (structured) → executable citations with four anchor types, intent labeling, and DOI resolution (formal).
+
+**Persistence.** Feed that scrolls past (informal) → searchable archive (structured) → knowledge base with live deliberation blocks and stable citable references (formal).
+
+**Cross-context.** Cross-posting (informal) → shared references (structured) → transport functors with SHA-1 fingerprinted provenance and confidence gating (formal).
+
+The transition between any two adjacent points on the spectrum is a single user action. No transition requires specialized knowledge. No transition is irreversible. Communities move along the spectrum as their needs dictate, and the platform supports every position with a consistent interface.
+
+### The Knowledge Production Pipeline
+
+When a community's work moves from informal to formal, the platform models the trajectory as a pipeline:
+
+Informal discussion surfaces propositions, which are workshopped into claims and structured into arguments through formal schemes. Arguments are challenged through protocol-enforced dialogue moves; the moves accrue in commitment stores, which the Ludics engine analyzes for convergence and divergence. Those determinations feed confidence scores, which in turn gate the Plexus network: room functors transport arguments across rooms with fingerprinted provenance. At every stage, the reasoning is addressable, citable, challengeable, and durable.
+
+Not every community will traverse the full pipeline. Most will operate at the early stages most of the time. The pipeline exists in its entirety so that the infrastructure is present when the community's reasoning reaches a point of complexity that warrants it.
+
+---
+
+## II. The Social Layer
+
+### Feed and Posts
+
+The main feed is chronological: content appears in the order it was posted by the people and communities the user follows. There is no algorithmic ranking, no engagement optimization, no promoted content, and no "suggested" posts from accounts the user did not choose to follow.
+
+The platform supports eight post types:
+
+- **Text** — plain text posts.
+- **Image** — image uploads.
+- **Audio** — audio player embed.
+- **Gallery** — multi-image carousel.
+- **Article** — long-form writing.
+- **Library** — PDF stacks and collections.
+- **Thread** — threaded discussion.
+- **Document** — PDF/document embed.
+
+Post creation uses a composer UI with a type selector and dedicated creation modals for each type. Posts support upvotes/downvotes, comments, sharing, timestamping, and deletion.
+
+### Profiles and Social
+
+User profiles with customizable display. Friend and follow systems. Notification pipeline for social actions, messages, challenges, and deliberation events. User discovery by interest, community membership, and group affiliation.
+
+The social graph is owned by the user: exportable in open formats, portable, never sold or monetized. Discovery is through search and affiliation, not through algorithmic recommendation.
+
+### Rooms and Lounges
+
+Persistent spaces for communities, groups, projects, and organizations. Rooms are the primary organizational unit of the platform: each room has its own feed, discussions, shared library, member management, and (when the community is ready) its own deliberation space.
+
+**Lounges** are lighter-weight social spaces (open or invite-only) for casual gathering, conversation, and ambient connection.
+
+**Spatial Canvas Rooms** allow freeform arrangement of content (posts, images, documents, links, embeds) in a two-dimensional navigable space. The canvas can be collaboratively edited and annotated. Canvas rooms serve as visual workspaces, mood boards, reference collections, and spatial brainstorming environments.
+
+Rooms and lounges are governed by their members. The platform provides infrastructure; the community provides governance. Moderation controls are local to the room.
+
+### Messaging
+
+Real-time messaging with direct messages, group conversations, and room-level chat.
+
+**Message Layers.** The messaging system implements sheaf-based access control: each conversation has explicitly defined audience layers, each with its own sharing policy that determines what is visible to whom. The stratified communication that users already practice informally (what is public, what is group-only, what is private) is handled architecturally through defined layers rather than left to the uncertainty of informal norms.
+
+**Drifts.** Side conversations that branch from any anchor message, creating a threaded sub-conversation that preserves context from the parent message without disrupting the main flow.
+
+**Proposals.** Collaborative documents embedded in conversations, with approval workflows and merge mechanics. A group member drafts a proposal; others review, comment, suggest changes, and approve or request modifications. The proposal workflow integrates with the room's governance structure.
+
+**Polls.** Inline polls with two modes: multi-choice (select one or more options) and temperature check (gauge group sentiment on a spectrum). Polls can be embedded in any conversation.
+
+**Read Receipts and Acknowledgments.** Optional and transparent. Message forwarding with access-control validation: the platform checks whether the forwarding target has permission to see the forwarded content before allowing the forward.
+
+---
+
+## III. The Reasoning Layer
+
+### The Deliberation Engine
+
+The core formal system. When a discussion is upgraded to a deliberation, the following infrastructure becomes available:
+
+**Claims** are addressable objects with stable identifiers, version history, and authorship attribution. A claim can be in one of several statuses: proposed, accepted, challenged, defended, retracted, or resolved.
+
+**Arguments** instantiate formally recognized reasoning patterns. The platform implements over sixty argumentation schemes from the Walton taxonomy: Argument from Expert Opinion, Argument from Analogy, Argument from Sign, Argument from Cause to Effect, and so on. Each scheme has a defined structure (premises, conclusion, inference rule) and auto-generated critical questions that identify the specific points where the argument could fail.
+
+**Dialogue Moves** are typed speech acts governed by protocol: Assert, Challenge, Defend, Concede, Retract, Request Clarification, and others. Each move creates specific obligations and permissions for the moves that follow it. The protocol ensures that challenges cannot be silently ignored: an unanswered challenge is itself a recorded datum.
+
+**Commitment Stores** track what each participant has asserted, conceded, retracted, and is currently committed to. The store monitors consistency: if a participant's commitments contradict each other, the contradiction is flagged; if a commitment is retracted, the downstream arguments that depended on it are identified.
+
+**Argument Chains** organize arguments into sequential or branching structures. Chains can be rendered in multiple views: list (linear sequence), thread (branching tree), canvas (spatial graph), brief (legal-style structured document), and auto-generated essay (prose narrative derived from the argument structure).
+
+**The Deliberation Dictionary** allows key terms to be formally defined, contested, and versioned within a deliberation. When a dispute turns on the meaning of a term, the term is entered in the dictionary with its proposed definition; the definition itself then becomes available for challenge and refinement through the same dialogue protocol.
+
+**ASPIC+ Evaluation.** The platform computes grounded extensions (the maximal sets of mutually consistent arguments that can be simultaneously defended) using the ASPIC+ framework for structured argumentation. This provides a formal determination of which arguments survive challenge given the current state of the deliberation.
+
+**Ludics Evaluation.** The entire deliberation can be modeled as an interactive game between Proponent and Opponent designs under Girard's Ludics semantics. Strategic landscapes can be heat-mapped to identify decisive positions (where the game is determined), turning positions (where a single move changes the outcome), and bottleneck positions (where progress depends on resolving a specific sub-argument).
+
+### Stacks and Evidence Library
+
+Document management integrated with the deliberation engine.
+
+**Document Storage.** Upload, organize, and share PDFs, papers, reports, and other source materials. Documents are stored in Stacks: themed collections that can be shared across rooms or kept private.
+
+**Executable Citations.** Four anchor types for linking evidence to arguments: page-level, passage-level, figure-level, and section-level. Each citation is executable: clicking it navigates to the exact location in the source document. Citations carry intent labels: supports, challenges, provides context, provides evidence, qualifies, or extends.
+
+**Annotation and Promotion.** Source documents can be annotated in the library. Annotations are conversations: threaded discussions attached to specific passages. Any annotation can be promoted into the deliberation graph: a marginal note becomes a proposition, which can be workshopped into a claim, which can be structured into an argument.
+
+**Knowledge Graph.** Sources, claims, arguments, and deliberations are connected in a navigable knowledge graph. Cross-deliberation source discovery identifies cases where the same document has been cited in multiple contexts, enabling communities to find related reasoning.
+
+**Auto-Citation Engine.** Any URL or DOI pasted into the citation composer is resolved automatically into a verified bibliographic record, with no manual entry of title, authors, or year.
+
+The resolver runs a waterfall in priority order:
+
+1. **arXiv API** for preprints.
+2. **Crossref** for DOIs, detected directly in the URL or surfaced by page scraping.
+3. **Highwire / Dublin Core / OpenGraph metadata** for academic pages.
+4. **OpenAlex** enrichment for abstracts and Open Access PDFs.
+5. **GPT-4o-mini extraction** as a low-confidence fallback for pages with no structured metadata.
+6. **Internet Archive (Wayback)** as a last-ditch lookup for unreachable URLs.
+
+Successful resolutions are also enriched with a stable Wayback snapshot when one exists, so the cited evidence remains addressable even if the live URL rots.
+
+Each resolution carries an explicit confidence tier: **high** (Crossref or arXiv canonical record), **medium** (page metadata only), **low** (LLM-extracted; flagged in the UI for verification), or **none** (URL kept as-is, retried after 24h). AI-authored arguments with empirical schemes are gated on having at least one non-`none` citation.
+
+Bulk paste of up to 200 URLs into the New Library modal resolves in the background and hydrates citation chips as results arrive. Per-host rate limits, circuit breakers, polite-pool compliance for Crossref and OpenAlex, and a 30-day success / 24-hour failure cache keep the engine well-behaved against external services.
+
+### The Article System
+
+A full-featured publishing system integrated with the social and reasoning layers.
+
+**Editor.** Rich text editing powered by TipTap with custom nodes (image, pull-quote, callout, KaTeX math block, code, embed, deliberation block) and a slash-command menu for fast block insertion. An advanced toolbar exposes the full formatting surface; paste sanitization safely handles content from external sources; a 20,000-character limit is tracked live.
+
+**Templates.** Three article templates govern layout and reader chrome: **Standard** (clean minimal layout for most articles), **Feature** (magazine-style with hero image and large title), and **Interview** (Q&A format with speaker attribution).
+
+**Publishing Workflow.** Draft → Published with metadata generation, autosave, revision history with version comparison, and a full Articles dashboard supporting search, filter, trash, and CRUD. Hero-image upload with cropping. Articles can be published to user profiles, rooms, or the platform's public knowledge base; published articles surface in the platform feed and render through template-specific reader layouts with cards, preview modals, and social actions (like, save, share).
+
+**Anchored Comments.** Comment threads attach to specific passages in the article, with collision resolution when multiple comment threads target overlapping text ranges. A sidebar comment rail surfaces all threads in document order. Readers engage with the article at the level of the sentence rather than at the level of the page.
+
+**Rhetoric Analysis Overlays.** Visual overlays that surface the article's persuasive strategies (hedges, intensifiers, absolutes, analogies, metaphors), color-coded inline so readers and authors can see the rhetorical architecture beneath the prose alongside claim density, evidence distribution, and argument structure indicators.
+
+**Proposition Composer.** Annotations and comments can be promoted directly into the deliberation engine through a composition interface that guides the user from informal observation to structured claim. The deliberation panel embeds the full deliberation system inside the article reader.
+
+### The Discussion System
+
+The lightweight informal layer: forums, topic-based conversations, and loose exchanges. The discussion system is the most common entry point for community interaction and the starting point of the knowledge production pipeline.
+
+**Upgrade Paths.** Any discussion can be upgraded to a structured deliberation when the conversation warrants it. The upgrade preserves the discussion's content and participants while adding the formal infrastructure of the deliberation engine. The upgrade is a single action. It does not require the participants to have prior experience with the formal tools.
+
+### The Knowledge Base
+
+The durable, public-facing output of the reasoning process.
+
+**Publishable Pages.** Knowledge base pages combine prose narrative with live deliberation blocks: embedded views of argument graphs, claim statuses, confidence scores, and evidence summaries that reflect the current state of the underlying deliberation. The pages are stable and citable: each has a permanent URL and a versioned reference.
+
+**Live Deliberation Blocks.** Embedded components that render the current state of a deliberation within a knowledge base page. If the underlying deliberation is updated (new evidence, new challenges, revised confidence scores), the blocks update accordingly. The knowledge base is not a snapshot. It is a live view.
+
+### The Plexus Network
+
+The cross-context layer that connects deliberation rooms into a network.
+
+**Graph-of-Graphs.** The Plexus network visualizes the relationships between deliberation rooms as a meta-graph. Rooms are nodes. The connections between them are typed edges.
+
+**Five Meta-Edge Types:**
+
+1. **Shared Claims** — two rooms contain arguments about the same claim.
+2. **Shared Evidence** — two rooms cite the same source material.
+3. **Transported Arguments** — an argument from one room has been imported into another.
+4. **Cross-References** — a deliberation in one room explicitly references a determination in another.
+5. **Institutional Links** — rooms operated by the same organization or community are structurally connected.
+
+**Room Functors.** Arguments are transported between rooms through functors that preserve inferential structure. When an argument is imported, it carries its provenance (its origin room, its challenge history, its confidence score, its evidence links) with SHA-1 fingerprinted integrity. The receiving room can verify that the imported argument has not been altered in transit.
+
+**Confidence Gating.** Each room can set a confidence threshold for incoming arguments: only arguments that meet the threshold (based on their evaluation in the source room) are eligible for import. Three scoring modes:
+
+- **Logical** — based on the argument's formal structure (ASPIC+ grounded extension status).
+- **Social** — based on community assessment (upvotes, endorsements, expert ratings).
+- **Hybrid** — a weighted combination of logical and social scores.
+
+**Visualization.** The Plexus network can be viewed as a graph (node-link diagram), a board (kanban-style grouped by meta-edge type), or a matrix (adjacency matrix showing connection density between rooms).
+
+---
+
+## IV. Embeddable Argument Widgets and the AI-Epistemic Primitive
+
+Arguments and claims produced on the platform are exposed beyond the platform through a layered set of distribution surfaces. The same primitive that powers a Reddit unfurl also powers an LLM citation, a Google fact-check card, and a researcher's BibTeX entry.
+
+### Permalinks and Embeds
+
+**Permalink Pages.** Every claim and every argument resolves to a permanent URL that renders a standalone public page (no account required) showing the conclusion, premises, scheme, evidence list, confidence score, challenge history, and current standing. This is the public face of a structured argument.
+
+**Social Cards.** When an Isonomia link is shared on external platforms (Twitter, Reddit, Slack, Hacker News, Discord), it unfurls as a rich preview card showing the argument's structure: conclusion, premise count, evidence count, confidence score, scheme, and challenge status.
+
+**Iframe Embeds.** Any argument or claim can be embedded in an external website through a standard iframe tag. The embed renders as an interactive card that can be expanded, navigated, and (if the viewer has an account) challenged directly without leaving the host page.
+
+**oEmbed Discovery.** Standard oEmbed protocol support for automatic embed rendering by platforms and content management systems that consume oEmbed.
+
+**Structured Data.** Every permalink emits structured linked-data metadata so arguments are discoverable as fact-check cards in search engines and ingestible by any consumer of standards-grounded data.
+
+### Creation and Sharing
+
+**Share Modals.** Tabbed share surfaces (link, embed, markdown, plain text) with a live preview of the social card, accessible from the action row of every argument and claim.
+
+**Quick Argument Builder.** A lightweight composer for constructing a structured argument (claim, premises, evidence) and generating a shareable link in under sixty seconds. It is the on-ramp that turns a person with an argument into a person with a *structured* argument. A user's first quick argument automatically creates a personal deliberation, so every individually authored argument still lives inside the deliberation infrastructure with no setup overhead. The same write primitive is exposed to model-context-protocol agents as `propose_structured_argument`; an agent that omits `deliberationId` lands in the caller's personal deliberation just as a human user would, so the human-facing builder and the agent-facing tool are two surfaces of one substrate.
+
+**URL Unfurl.** A safe URL metadata extractor (title, favicon, site name) used by the builder to enrich evidence URLs.
+
+### Browser Extension
+
+A browser extension ships across Chrome, Firefox, and Safari:
+
+- **Context menu.** Select text on any webpage, right-click, and create an Isonomia argument pre-populated with the selection, page URL, and page title.
+- **Inline previews.** A content script detects Isonomia argument and claim links on Reddit, Twitter/X, and Hacker News and injects rich inline previews showing claim text, scheme, confidence, evidence count, and author.
+- **Popup composer.** A compact Quick Argument Builder embedded in the extension popup for one-click creation without leaving the page, plus a list of the user's recent arguments.
+
+### Deliberation-Scope Embeds
+
+The embed primitive lifts from a single argument to an entire deliberation: a state card and a contested-frontier lane suitable for embedding inside articles, briefs, or third-party sites, backed by the deliberation-scope readouts described below.
+
+### Public Argument Search and Discovery
+
+Isonomia exposes the public corpus as a crawlable, machine-citable search surface ("Google for arguments") reachable identically by humans, search engines, and language-model agents.
+
+**Consumer search page.** A server-rendered search page renders ranked results as substrate-first cards: a standing badge (tested-survived, tested-attacked, and so on), a scheme chip, a dialectical-fitness chip, a hybrid-retrieval chip, an attestation link, a deep link to counter-argument discovery, and a lexical-coverage indicator. The same URL serves humans and crawlers, with alternate links exposing JSON and JSON-LD representations of the same results. Empty states are reported honestly: no query intent, no results, an against-mode query with no counters on file, and API failure are surfaced as four distinct conditions rather than collapsed into a generic "nothing found."
+
+**Hybrid retrieval.** A single search endpoint is the source of truth, called by the page, by the model context protocol surface, and by external integrations alike. Hybrid mode fuses dense vector cosine similarity with sparse lexical recall through reciprocal rank fusion; lexical mode is deterministic substring matching; vector mode is purely semantic. Every result carries an auditable hybrid block exposing its dense and sparse ranks and distances, so the ranking is inspectable rather than opaque.
+
+**Quality filters.** Filters narrow results to dialectically tested, evidence-bearing arguments: tested-only, a minimum threshold of critical-question satisfaction, a minimum count of provenance-anchored evidence, and an ISO date range. The filters surface in the page UI as a collapsible quality-filters panel and as parameters in both the public API and the model context protocol tools.
+
+**Counter-citation discovery.** Each result can be enriched with the most-engaged structural contester to its conclusion: rebut and undercut edges, plus conflict applications, with self-counters excluded. When nothing is on file, the result is honestly null. The lookup is a bounded single-fanout across the top-K results (one edge query, one conflict-application query, one argument fetch, no N+1), so the consumer page opts in by default and every visible card displays either the strongest known counter or "none on file." There is no one-sided ranking.
+
+**Stance retrieval.** A claim-stances endpoint returns "for" and "against" arguments in a single call: the killer query for any debate UI. "For" arguments conclude to the claim; "against" arguments are structural contesters of it. Both lists carry the full search-result shape (and can carry the strongest-counter enrichment when requested), so any client that understands a search result already understands a stance result. A missing claim is reported as a 404 with an explicit error code; an empty side is reported as an empty list, not as absence. The claim page renders the dual-column dialectical view inline.
+
+**SEO surface.** A sitemap covers argument and claim permalinks together with canonical scheme search topics; a robots policy allows the public discovery surfaces while disallowing internal admin, cron, and authentication routes. Search-result preview cards generate live result counts together with sort and mode chips, so a social-platform unfurl shows the actual result count for the query rather than a generic placeholder.
+
+### The AI-Epistemic Primitive
+
+Layered on top of the embeddable surface is the **AI-Epistemic Primitive**: every permalink is treated as a machine-citable, dialectically attested, content-hashed epistemic artifact, exposed over content-negotiated HTTP and over a model context protocol. The primitive is organized around seven commitments.
+
+**Machine-citable structured arguments.** Every permalink resolves to a structured argument subgraph (claim, premises, scheme, evidence), not just prose. Content negotiation returns the same artifact as HTML, structured data, a formal argument graph, or a compact citation envelope, depending on what the requester asks for.
+
+**Verifiable provenance, end-to-end.** At the argument level, a content hash is computed over the canonical argument, and every artifact is reachable at an immutable, hash-anchored URL. At the evidence level, server-side fetch hashes, archive-snapshot URLs, fetch timestamps, and content types are recorded. Per-premise evidence is attested through the same pipeline as conclusion-level evidence: each premise's `EvidenceLink` rows carry their own fetch hash and archive snapshot, so per-source provenance maps cleanly onto per-premise standing rather than being collapsed onto the conclusion. At the premise level, counters surface unattested premises honestly rather than concealing them.
+
+**Dialectical honesty by construction.** Citations ship with their opposition attached. The strongest known objection is surfaced alongside the citation by default, and the public search surface exposes the symmetric flag so every search result carries either its strongest known counter or an honest null when none is on file. Standing is reported as a classified state (untested-default, untested-supported, tested-attacked, tested-undermined, tested-survived) rather than as an opaque float. Counterargument lookup, the search surface's against mode, and the strongest-counter helper all exclude same-conclusion self-counters by contract. Result rankings can be re-sorted by tested-and-survived (dialectical-fitness) status, and a claim-stances endpoint together with its matching model-context tool returns the dual for-and-against view in a single call. Authorship is honest at the row level: every argument minted by a model-context-protocol agent is flagged `authorKind: "AI"` with `aiProvenance` recording the originating tool (`propose_argument`, `propose_structured_argument`, `propose_warrant`), so consumers can distinguish AI-authored, human-authored, and ratified-AI material wherever the artifact is cited.
+
+**Standards-grounded interoperability.** The system speaks the established formats of the argumentation and web-data communities: the Argument Interchange Format, structured linked data, fact-check schema, and a model context protocol surface. There are no bespoke serializations.
+
+The model-context surface is bidirectional.
+
+*Read side.* It exposes deliberation-scope readouts, argument lookup, counterargument discovery, claim stances, and citation resolution itself (`resolve_citation` and `resolve_citations_bulk`), so an external agent can pre-mint verified `Source` records (with full waterfall provenance and Wayback fallback) before proposing arguments, rather than handing the platform unchecked URL strings.
+
+*Write side.* It exposes `propose_argument` (bare assertion), `propose_structured_argument` (explicit premises + scheme + per-premise evidence, with a four-code warning surface for inferred schemes, deduped premises, merged evidence, and missing required slots), `propose_warrant` (attach an inference-license warrant to an existing argument), and `list_schemes` (browse the Walton catalog before picking a scheme key).
+
+*Orientation.* Every session begins with a single `get_orientation` call that returns a versioned, hash-cached contract (`ORIENTATION_VERSION`) covering the ontology, write-tool selection rules, and the recipes for moving between read and write. An agent caches the platform's epistemic contract once and re-uses it across sessions rather than re-discovering it.
+
+**Shippable on existing infrastructure.** The primitive is built directly on the production argument graph, scheme catalog, and permalinks. There is no second source of truth and no migration: what users see is what citers cite.
+
+**Deliberation-scope readiness and honesty.** Above the per-argument primitive sits a deliberation-scope substrate that refuses to summarize prematurely:
+
+- A **fingerprint** capturing counts, depth, critical-question coverage, and the AI-versus-human extraction split.
+- A **contested frontier** surfacing unanswered undercuts, undermines, critical questions, and terminal leaves: the live edge of the deliberation.
+- A **missing-move report** with per-argument and rollup views, plus a **chain-exposure** projection identifying the weakest link in any inference chain.
+- A **synthetic readout** that emits an explicit honesty line and a refusal surface (with references to real graph elements) when the deliberation is too immature to summarize. The readout also emits `writingConstraints`, a pre-rendered compliance contract consumable by humans and agents alike: `mustInclude.honestyLine` (verbatim caveat keyed on the deliberation's content hash), `mustNotAssert[]` (conclusions the graph will not currently license), `shouldHedge[]` (per-argument hedge phrasings keyed to standing), and `framing.stage` (articulation, deliberation, or matured). Compliance is contract-as-data rather than free-form guidance.
+- **AI-engagement telemetry** that distinguishes genuine reasoning from articulation-only contribution.
+- **Cross-deliberation aggregation** with a consistent IN / OUT / contested / undecided rule.
+
+**Typed categorical algebra, deterministic and graph-derived.** A typed implementation of an evidential category of claims is exposed verbatim to language-model agents. The structure is straightforward: each claim has a typed evidence arrow, each derivation carries its assumption set, and a closed monoid (minimum, product, or Dempster-Shafer) folds confidence over the arrow. Culprit-set computation answers the canonical question, *what would I have to retract to reject this claim?*, with a deterministic ranking.
+
+Model-context tools give a language-model client graph-derived answers with no language model in the loop, and a contract test asserts bit-identical output across repeated invocations on the same fixture.
+
+Three contracts the surface honors:
+
+- **Strict logicality.** A derivation counts as logical only when every dependent assumption is accepted *and* the backing argument is human-authored (or AI- or hybrid-authored and subsequently ratified).
+- **AI-flagged warrants are non-logical until ratified.** A "propose warrant" action materializes an internal-hom warrant as an AI-authored argument together with a proposed assumption use; the resulting derivation never lifts to logical until a human ratifies the warrant text.
+- **One-hop cross-room transport.** Transport snapshots written by the transport-aggregator carry one-hop transport only, by contract: chained transport across three or more rooms is intentionally unsupported, so the aggregated band of *local*, *imported*, and *total* counts for any claim remains auditable to a single source room.
+
+**Substrate-level dialectical event stream.** Beneath the per-argument and per-deliberation surfaces sits a generative Ludics substrate that exposes the dialectical mechanics directly. Witnessing records bind dialogue acts to loci in a design; an articulation lattice exposes the cone structure of incarnations, with per-cone minima forming an antichain; a fossil record captures retractions with back-pointers to the loci they vacated; and a briefing-fingerprint API detects material change through five typed rules.
+
+Every binding act on the substrate (commit, reveal, contest, retract) is gated by a deliberation-scoped token (the scope is the deliberation itself; there is no tenant axis) and rate-limited on the compound key of deliberation, participant, and IP. The four axioms surface as four event types carried on a single envelope.
+
+The bus is the sole emit channel. External systems such as the embeddable widget, the model-context surface, third-party dashboards can use it to observe what a deliberation is doing in real time without polling the read model, and to do so against the same dialectical primitives the engine itself manipulates.
+
+Taken together, these surfaces let an external system — human or model — cite a unit rather than a webpage, prove what it cited and when, and surface the strongest known objection alongside the citation.
+
+---
+
+## V. Living Documents — Theses, Briefs, and Peer Review
+
+Isonomia treats long-form scholarly and policy outputs as **living documents** whose embedded claims, arguments, propositions, and citations remain bound to the live argument graph. The same infrastructure powers research theses, policy briefs, and academic peer reviews.
+
+### Living Thesis
+
+A thesis is a rich text document whose embedded claim, argument, proposition, and citation elements read live state from the deliberation graph rather than holding a frozen copy of it. Several capabilities sit on top of that live binding.
+
+**Live Binding.** Every embedded element (a claim cited in the introduction, an argument quoted in a footnote, a proposition lifted from a marginal annotation) reads its support count, attack count, evidence count, and current standing label from the deliberation in real time. The thesis updates as the underlying reasoning updates.
+
+**Inspector.** A single right-side drawer opens for any embedded element and shows its full lineage: where it came from, the evidence supporting it, the attacks against it, and the satisfied and unsatisfied critical questions associated with it.
+
+**Attack Register.** A sticky panel lists every attack on every thesis element, grouped by status (undefended, defended, conceded) and filterable and sortable by attack type: undercuts, undermines, rebuts. Authors and readers can see at a glance where the document is exposed and where it has held.
+
+**Confidence.** Per-prong and per-thesis confidence scores are computed from explicit, weighted inputs. A hover-card on every confidence badge discloses each input, its weight, and its contribution to the total: the score is auditable rather than opaque.
+
+**Snapshots.** A reader or a citer can capture a point-in-time freeze of the thesis. Snapshots render as stable views even as the underlying graph evolves, and any snapshot can be diffed against any other snapshot or against the current live state.
+
+**Traversals.** Deep links can target either an internal thesis element or a global claim identifier, resolving cleanly across documents. Every lineage row in the inspector is a clickable navigation, and "used in" backlinks expose where any element appears across other theses.
+
+**Hardening.** Read and write permissions are enforced at the element level; elements the viewer cannot see are redacted from backlinks and inspector views rather than disclosed by reference.
+
+### Living Peer Review
+
+The peer review system uses the same dialogue moves as deliberations and runs across three coordinated capabilities.
+
+**Review structure.** Configurable review templates define criteria sets and a multi-phase structure (for example, initial review, author response, revision). Reviews support blind and open modes and discriminate among target types: paper, preprint, thesis, and grant. Reviewer assignments carry roles, accept/decline workflows, and reviewer commitments scoped to specific issues with resolution tracking. Author responses flow as structured dialogue moves (concede, rebut, clarify, revise), each linked to the commitment it addresses. The review lifecycle advances through phases with editorial decisions (accept, revise, reject), progress and timeline visualization, and per-phase outcomes.
+
+**Argumentation-based reputation.** Scholarly reputation is derived from argumentation outcomes rather than from citation counts or journal prestige. Contribution tracking records distinct contribution types together with quality multipliers, verification status, and deliberation scope. Scholar statistics aggregate defense success rate, attack precision, consensus rate, and downstream citation count. Topic expertise runs on a graded scale from novice to authority, with per-topic scoring, expert discovery by topic area, and a reputation leaderboard. Reviewer recognition tracks completion and quality metrics, timeliness, blocking-concern resolution rate, and topic specializations.
+
+**Academic credit integration.** ORCID integration provides an OAuth connection flow, push of works to ORCID profiles, and auto-sync of eligible contributions. CV export emits structured data, BibTeX, LaTeX source, and CSV. Institutional reports aggregate faculty contribution breakdowns at department and institution level with impact metrics and period-over-period comparison.
+
+### Fork and Merge
+
+Deliberations and theses can be forked (creating a parallel version that explores an alternative line of argument) and merged when the parallel lines converge. The model is borrowed from version control and applied to reasoning itself.
+
+---
+
+## VI. Institutional Workflow Layer — Pathways and Facilitation
+
+Where the deliberation engine handles the *production* of structured reasoning, the institutional workflow layer handles its *transmission to, and reception by,* the bodies authorized to act on it. Two complementary subsystems live here.
+
+### Pathways
+
+Pathways move a deliberation's outputs into the formal record of an institution and track the institution's response.
+
+- **Institution Registry.** A verifiable directory of agencies, councils, NGOs, and their members. Institutions are first-class platform objects with member rosters and authority scopes; they appear on the Plexus network graph alongside rooms.
+- **Role Gating and Public Redaction.** Uniform admin, host, and facilitator gates, with public redaction rules so the audit log is publishable without leaking participant identities.
+- **Open Pathway.** A deliberation's recommendations are forwarded to a registered institution as a packet with a defined channel and target.
+- **Hash-Chained Audit Log.** Every pathway action is recorded as an event in a tamper-evident chain anchored at a draft-opened genesis event.
+- **Recommendation Packets.** Versioned, freezable bundles of claims, arguments, cards, and notes: the unit of submission to an institution.
+- **Submission Channels.** Packets can be sent in-platform, by email, by API, or as manually logged external submissions; the channel and its hints are recorded.
+- **Institutional Responses.** Institutions reply with per-item dispositions, with coverage tracking that surfaces which packet items remain unaddressed.
+- **Plexus Visualization.** Pathway connections render on the cross-context Plexus graph, so a deliberation's downstream institutional fate is visible at a glance.
+
+### Facilitation
+
+Facilitation provides the live operational surface for facilitators running structured deliberations, with audit trails for the work the facilitator does.
+
+- **Cockpit and Question Authoring.** A facilitator-only cockpit organizes the live session: the active facilitation question, the parent context, session status, and quick-action controls. Facilitation questions can be authored, scoped to specific arguments or claims, and rotated through the session.
+- **Equity Surface.** A real-time equity panel tracks who has spoken, who has not, and how participation distributes across constituencies. Facilitators can see when intervention is warranted before participation imbalances calcify.
+- **Timeline and Interventions.** A session timeline records every facilitator intervention as a typed, attributed event (redirect off-topic, surface minority view, reframe) as part of the audit log.
+- **Handoff.** A formal handoff flow when one facilitator passes control to another mid-session, preserving session state and acknowledging context transfer.
+- **Pending Banner and Report.** A pending-action banner surfaces queued moderator decisions; an end-of-session report compiles the timeline, equity metrics, and interventions for sharing with participants and institutional sponsors.
+- **Analytics and Canonical Export.** Aggregate analytics readouts and a canonical session export are available for inspection, archival, and external review.
+
+Facilitation is opt-in. Most rooms operate without it. It exists for the deliberations whose stakes warrant a trained facilitator and an auditable record of facilitator behavior.
+
+---
+
+## VII. Theoretical Foundations
+
+The platform's reasoning layer is grounded in formally studied frameworks:
+
+**Formal Argumentation Theory.** ASPIC+ (Prakken, 2010; Modgil & Prakken, 2018) provides the framework for structured argumentation with grounded extension computation. The Walton taxonomy (Walton, Reed & Macagno, 2008) provides over sixty argumentation schemes with associated critical questions. The Argument Interchange Format (AIF) (Chesñevar et al., 2006; Reed et al., 2010) provides the ontology for interoperable argument representation and JSON-LD export.
+
+**Interactive Proof Theory.** Ludics (Girard, 2001) models deliberation as a game between Proponent and Opponent strategies, with convergence and divergence computed through the interaction of designs. The Ludics layer provides game-theoretic evaluation independent of the ASPIC+ evaluation, offering a complementary perspective on which arguments are strategically decisive. Beneath that evaluation surface sits a generative substrate that exposes the dialectical primitives directly; witnessing records bound to loci, an articulation lattice with antichain minima, and a fossil record for retractions.
+
+**Evidence Theory.** Dempster-Shafer theory handles the combination and aggregation of evidence from multiple sources with varying degrees of reliability, producing belief functions that represent the state of evidential support more precisely than binary true/false or simple probability.
+
+**Category-Theoretic Models.** Ambler's compositional semantics of evidence (evidential categories, SLat-enriched categories with symmetric monoidal structure) provides the mathematical foundation for the evidence algebra and for the Plexus transport mechanism. Morphisms are evidence arrows. The tensor product (⊗) conjoins evidence. The join operation (∨) aggregates within hom-sets. Selected maps (simple ∧ entire) provide the cartesian subcategory where projection and pairing laws hold exactly: the mathematically safe fragment for operations like "duplicate premise" and "project reason." A typed evidence-arrow implementation carries per-derivation assumption sets, drives a strict logicality predicate, and exposes belief-revision (culprit-set) computation and a closed monoid registry to both the in-app pipeline and the model-context protocol surface.
+
+**Formal Dialogue Systems.** The dialogue protocol draws on the tradition of formal dialogue games (Hamblin, 1970; Walton & Krabbe, 1995), implementing typed speech acts with defined obligations and permissions.
+
+These foundations are fully implemented and operational. They are also fully invisible to any user who does not seek them out. The platform's formal complexity is the basis of its interface simplicity: it is precisely the systems that enforce argumentative rigor behind the interface that allow the interface itself to present structured reasoning through clear, guided forms, without requiring the user to learn the underlying theory.
+
+---
+
+## VIII. Technical Stack
+
+- **Framework:** Next.js
+- **Database:** Prisma ORM with Supabase (PostgreSQL)
+- **Real-time:** Supabase broadcast for messaging, presence, and live updates
+- **State Management:** Zustand
+- **Rich Text:** TipTap with custom nodes (MathBlock, MathInline, deliberation embeds)
+- **Graph Visualization:** D3, React Flow with Dagre layout
+- **Mathematical Typesetting:** KaTeX
+- **Design Language:** Consistent, restrained, and legible across all subsystems. The social layer uses warmer tones and softer transitions. The reasoning layer uses cream backgrounds and gold accents with institutional clarity. Both share a unified typography and component system.
+
+---
+
+## IX. Data Ownership and Privacy
+
+- All data is owned by the user and the community that produced it.
+- Data is exportable at any time in open formats (JSON, AIF, BibTeX, Markdown, PDF).
+- The platform collects only what users post. No behavioral tracking, no engagement analytics, no shadow profiles, no data broker relationships.
+- Users can contribute anonymously. The platform supports pseudonymous and anonymous participation with configurable attribution policies per room.
+- The platform is self-hostable. Organizations that require full control over their data can deploy the platform on their own infrastructure using the open-source codebase.
+- The architecture is designed with the understanding that many of the communities the platform serves have historical and ongoing reasons to distrust data collection. The privacy commitments are enforced by architecture, not by policy.
+
+---
+
+## X. Distribution and Governance
+
+**Open Source.** The entire codebase is public. Contributions are welcome. The platform's architecture, including the formal argumentation engine, is available for inspection, audit, and extension by any party.
+
+**Sustainability Model.** The platform is free for all users. Sustainability is pursued through grants (NEH, NSF, foundation funding), institutional partnerships (universities, policy organizations, civic institutions), and optional hosted enterprise services for organizations that require managed infrastructure with SLA guarantees.
+
+---
+
+## XI. Applications
+
+**Community organizations** use the social layer for ongoing community engagement (forums, rooms, messaging, shared documents) and the reasoning layer when participatory input needs structure: planning processes, budget deliberations, program evaluations, needs assessments. The platform preserves the reasoning behind community decisions, not just the decisions themselves.
+
+**Research teams and reading groups** use the social layer for discussion and shared libraries. When a research question crystallizes or an interpretive disagreement becomes substantive, the reasoning layer provides infrastructure for structured synthesis. Evidence is linked to claims at the source level. The synthesis is collaborative, living, and navigable as a graph.
+
+**Student organizations and governance bodies** use the social layer for coordination and the reasoning layer for decisions that affect constituents. The reasoning persists after the officers graduate.
+
+**Open-source projects** use the social layer for community building and the reasoning layer for architectural decisions and RFCs. Technical reasoning is structured, challenged, and preserved beyond the contributor who made it.
+
+**Civic media and public interest journalism** embed argument maps into articles, providing readers with navigable representations of public debates that update as the debate evolves.
+
+**Policy organizations and regulated industries** use the reasoning layer for structured analysis with auditable reasoning chains. The audit trail is generated by the process, not reconstructed after the fact.
+
+**Academic publication and peer review** uses the Living Peer Review system for public, structured, credited review processes that improve on the opacity and inefficiency of traditional anonymous review.
+
+**Individuals and informal communities** use the social layer as a social platform (posting, sharing, discussing, connecting) with the knowledge that the reasoning layer is available when they need it and invisible when they don't.
+
+---
+
+## XII. The Proposition
+
+Social platforms circulate content. The circulation is optimized for engagement: the architecture selects for what produces reaction and selects against what requires sustained attention. The result is discourse in which reasoning — the inferential structure that connects evidence to claims to conclusions — is structurally unsupported. The reasoning still happens. The platforms simply do not preserve it.
+
+Isonomia is designed from first principles to support the full range of what communities do when they gather: from casual conversation to formal deliberation, from sharing a photograph to defending a thesis, from the ambient connection of a feed to the tracked obligation of a challenge-response protocol.
+
+The social layer provides the space. The reasoning layer provides the structure. The spectrum between them is continuous. The community moves along the spectrum as its needs dictate. The platform holds everything the community produces — the posts and the proofs, the comments and the commitments, the shared links and the shared reasoning — in a single architecture where nothing is lost.
+
+Every claim has a stable identifier. Every argument follows a recognized scheme. Every challenge creates an obligation. Every piece of evidence links to its source. Every determination is provisional, subject to better evidence and stronger argument. Every community owns its data. The code is open. The infrastructure is public.
+
+The feed is chronological. The deliberation is formal. The space between them is yours.
+
+
+*Isonomia is free, open-source, and community funded.*
+
+*MESH · Isonomia*


### PR DESCRIPTION
Massive overhaul of README: project renamed from Mesh to Isonomia and replaced with a comprehensive product and architecture doc describing the social and reasoning layers, knowledge pipeline, deliberation engine, evidence/citation resolver, Plexus network, living documents, institutional workflows, theoretical foundations, stack, privacy, distribution, and applications. Updated public-facing narrative, sections, and examples to reflect Isonomia's goals and features.

UI/code changes: updated app/test/ai-epistemic/page.tsx to add Triangle import, extend PillarCard with color and iconColor, adjust pillar copy and status values, assign gradient/color and iconColor values to pillars, replace the shippable pillar icon, and tweak several evidence/track entries (including G.9 status and an added H track entry). Also modified docs/isonomia-overview*.md files (content adjustments).